### PR TITLE
feat: set up Content Collections with blog schema (#3)

### DIFF
--- a/src/content/blog/2024/12/hello-world.md
+++ b/src/content/blog/2024/12/hello-world.md
@@ -1,0 +1,22 @@
+---
+title: "Hello, World!"
+description: "Welcome to gvns.ca — a personal blog about homelab, BJJ, and productivity."
+pubDate: 2024-12-09
+tags: ["meta"]
+---
+
+Welcome to my corner of the internet.
+
+This is a test post to verify the content collection setup is working correctly. In the future, this space will be home to:
+
+- **Homelab adventures** — self-hosting, Docker, networking
+- **BJJ journeys** — training logs, technique notes, competition prep
+- **Productivity systems** — ADHD strategies, PKM workflows, tools that actually work
+
+Stay tuned for real content. For now, the plumbing is being tested.
+
+## What's Next
+
+I'm building this site with Astro 5, Svelte 5 islands, and Tailwind CSS 4. The Dracula colour scheme keeps things easy on the eyes during late-night coding sessions.
+
+More posts coming soon.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,17 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  type: 'content',
+  schema: ({ image }) =>
+    z.object({
+      title: z.string().max(100),
+      description: z.string().max(200),
+      pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      tags: z.array(z.string()).min(1).max(4),
+      draft: z.boolean().default(false),
+      heroImage: image().optional(),
+    }),
+});
+
+export const collections = { blog };


### PR DESCRIPTION
## Summary

- Add Astro Content Collections configuration for the blog
- Create Zod schema with required fields (title, description, pubDate, tags)
- Add optional fields (updatedDate, draft, heroImage)
- Include sample "Hello, World!" post for testing

## Files Changed

- `src/content/config.ts` - Content collection schema
- `src/content/blog/2024/12/hello-world.md` - Sample blog post

## Verification

- [x] Build passes (`npm run build`)
- [x] TypeScript types generated in `.astro/content.d.ts`
- [x] Content synced successfully

## Notes

- Series fields (`series`, `seriesOrder`) excluded per issue spec (deferred)
- Schema validates 1-4 tags, max 100 char title, max 200 char description

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched blog functionality with an initial post covering upcoming topics and technical stack details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->