### PR TITLE
feat: implement blog listing page at /blog (#6)

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,59 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '@layouts/BaseLayout.astro';
+import PostCard from '@components/PostCard.astro';
+
+const posts = (await getCollection('blog'))
+  .filter((post) => import.meta.env.PROD ? !post.data.draft : true)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<BaseLayout
+  title="Blog | gvns.ca"
+  description="Thoughts on homelab, web development, BJJ, and productivity."
+>
+  <main id="main-content" class="blog-listing">
+    <h1>Blog</h1>
+    <p class="intro">
+      Thoughts on homelab, web development, BJJ, and productivity.
+    </p>
+
+    {posts.length > 0 ? (
+      <div class="post-list">
+        {posts.map((post) => (
+          <PostCard post={post} />
+        ))}
+      </div>
+    ) : (
+      <p class="no-posts">No posts yet. Check back soon!</p>
+    )}
+  </main>
+</BaseLayout>
+
+<style>
+  .blog-listing {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .intro {
+    color: var(--color-text-secondary);
+    margin-bottom: 2rem;
+  }
+
+  .post-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .no-posts {
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Add blog index page at `/blog`
- Lists all published posts sorted by date (newest first)
- Uses PostCard component for each entry

## Files Changed

- `src/pages/blog/index.astro` - Blog listing page

## Features

- Filters draft posts in production
- Shows "No posts yet" message when collection is empty
- Proper page title and meta description

## Verification

- [x] Build passes with `/blog/index.html` generated
- [x] Uses PostCard component
- [x] Draft filtering works

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated blog index page displaying all published blog posts sorted by publication date in descending order for easy discovery of recent content
  * Posts are presented in a clean, card-based list format for improved readability
  * Includes an informative message when no posts are available

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->