### PR TITLE
feat: create PostLayout and individual blog post pages (#7)

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -12,11 +12,16 @@ interface Props {
 const { post, showReadingTime = true } = Astro.props;
 const { title, description, pubDate, tags } = post.data;
 const readingTime = getReadingTime(post.body);
+
+// Extract just the filename from the full slug path
+// e.g., "2024/12/hello-world" -> "hello-world"
+const slugParts = post.slug.split('/');
+const filename = slugParts[slugParts.length - 1];
 ---
 
 <article class="post-card">
   <h3 class="post-title">
-    <a href={`/blog/${post.slug}`}>{title}</a>
+    <a href={`/blog/${filename}`}>{title}</a>
   </h3>
   <div class="post-meta">
     <time datetime={pubDate.toISOString()}>{formatDate(pubDate)}</time>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,0 +1,182 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import BaseLayout from './BaseLayout.astro';
+import TagList from '@components/TagList.astro';
+import { formatDate } from '@utils/date';
+import { getReadingTime } from '@utils/reading-time';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+const { title, description, pubDate, updatedDate, tags } = post.data;
+const readingTime = getReadingTime(post.body);
+---
+
+<BaseLayout title={`${title} | gvns.ca`} description={description}>
+  <article class="post">
+    <header class="post-header">
+      <h1>{title}</h1>
+      <div class="post-meta">
+        <time datetime={pubDate.toISOString()}>
+          {formatDate(pubDate)}
+        </time>
+        {updatedDate && (
+          <span class="updated">
+            (Updated: <time datetime={updatedDate.toISOString()}>{formatDate(updatedDate)}</time>)
+          </span>
+        )}
+        <span class="reading-time">{readingTime} min read</span>
+      </div>
+      <TagList tags={tags} />
+    </header>
+
+    <div class="prose">
+      <slot />
+    </div>
+
+    <footer class="post-footer">
+      <a href="/blog">&larr; Back to blog</a>
+    </footer>
+  </article>
+</BaseLayout>
+
+<style>
+  .post {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+
+  .post-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--current-line);
+  }
+
+  .post-header h1 {
+    font-size: 2.25rem;
+    line-height: 1.2;
+    margin-bottom: 0.75rem;
+  }
+
+  .post-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 1rem;
+  }
+
+  .reading-time::before {
+    content: "·";
+    margin-right: 1rem;
+  }
+
+  .updated {
+    font-style: italic;
+  }
+
+  .post-footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--current-line);
+  }
+
+  .post-footer a {
+    color: var(--color-link);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .post-footer a:hover {
+    color: var(--color-link-hover);
+  }
+
+  /* Prose styling for markdown content */
+  .prose {
+    line-height: 1.7;
+  }
+
+  .prose :global(h2) {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  .prose :global(h3) {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .prose :global(p) {
+    margin-bottom: 1.25rem;
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-bottom: 1.25rem;
+    padding-left: 1.5rem;
+  }
+
+  .prose :global(li) {
+    margin-bottom: 0.5rem;
+  }
+
+  .prose :global(blockquote) {
+    border-left: 3px solid var(--purple);
+    padding-left: 1rem;
+    margin: 1.5rem 0;
+    font-style: italic;
+    color: var(--color-text-secondary);
+  }
+
+  .prose :global(a) {
+    color: var(--color-link);
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-underline-offset: 2px;
+    transition: text-decoration-color var(--transition-fast);
+  }
+
+  .prose :global(a:hover) {
+    text-decoration-color: var(--color-link);
+  }
+
+  .prose :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--current-line);
+    padding: 0.125em 0.375em;
+    border-radius: 4px;
+  }
+
+  .prose :global(pre) {
+    background: var(--current-line);
+    padding: 1rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  .prose :global(pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.875rem;
+    line-height: 1.7;
+  }
+
+  .prose :global(strong) {
+    font-weight: 600;
+  }
+
+  .prose :global(hr) {
+    border: none;
+    border-top: 1px solid var(--current-line);
+    margin: 2rem 0;
+  }
+</style>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,29 @@
+---
+import { getCollection, render } from 'astro:content';
+import PostLayout from '@layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => {
+    return import.meta.env.PROD ? !data.draft : true;
+  });
+
+  return posts.map((post) => {
+    // Extract just the filename from the full slug path
+    // e.g., "2024/12/hello-world" -> "hello-world"
+    const slugParts = post.slug.split('/');
+    const filename = slugParts[slugParts.length - 1];
+
+    return {
+      params: { slug: filename },
+      props: { post },
+    };
+  });
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<PostLayout post={post}>
+  <Content />
+</PostLayout>


### PR DESCRIPTION
## Summary

- Add `PostLayout.astro` for individual blog posts
- Add `[slug].astro` dynamic route for post rendering
- Update `PostCard.astro` to use filename-only URLs

## Files Changed

- `src/layouts/PostLayout.astro` - Blog post layout with metadata and prose styling
- `src/pages/blog/[slug].astro` - Dynamic route for individual posts
- `src/components/PostCard.astro` - Updated URL generation

## Features

### PostLayout
- Title, dates, tags, reading time in header
- Prose styling for markdown content (headings, lists, code, blockquotes)
- Back to blog navigation in footer

### URL Generation
- Posts use filename as slug, not folder path
- `src/content/blog/2024/12/hello-world.md` → `/blog/hello-world`
- Draft filtering in production

## Verification

- [x] Build passes with post pages generated
- [x] Prose styling applied to markdown
- [x] URLs derived from filename only

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)