### PR TITLE
feat: implement tag listing and tag filter pages (#8)

### DIFF
--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,96 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '@layouts/BaseLayout.astro';
+import PostCard from '@components/PostCard.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => {
+    return import.meta.env.PROD ? !data.draft : true;
+  });
+
+  // Get all unique tags
+  const tags = new Set<string>();
+  posts.forEach((post) => {
+    post.data.tags.forEach((tag) => tags.add(tag));
+  });
+
+  return [...tags].map((tag) => ({
+    params: { tag },
+    props: {
+      tag,
+      posts: posts
+        .filter((post) => post.data.tags.includes(tag))
+        .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()),
+    },
+  }));
+}
+
+interface Props {
+  tag: string;
+  posts: Awaited<ReturnType<typeof getCollection<'blog'>>>;
+}
+
+const { tag, posts } = Astro.props;
+---
+
+<BaseLayout
+  title={`Posts tagged "${tag}" | gvns.ca`}
+  description={`All blog posts tagged with ${tag}.`}
+>
+  <main id="main-content" class="tag-page">
+    <header>
+      <a href="/blog/tags" class="back-link">&larr; All tags</a>
+      <h1>Posts tagged: <span class="tag-name">{tag}</span></h1>
+      <p class="count">{posts.length} post{posts.length !== 1 ? 's' : ''}</p>
+    </header>
+
+    <div class="post-list">
+      {posts.map((post) => (
+        <PostCard post={post} />
+      ))}
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .tag-page {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+
+  header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    color: var(--color-link);
+    text-decoration: none;
+    margin-bottom: 1rem;
+    transition: color var(--transition-fast);
+  }
+
+  .back-link:hover {
+    color: var(--color-link-hover);
+  }
+
+  h1 {
+    font-size: 1.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .tag-name {
+    color: var(--pink);
+  }
+
+  .count {
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+  }
+
+  .post-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+</style>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,0 +1,106 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '@layouts/BaseLayout.astro';
+
+const posts = await getCollection('blog', ({ data }) => {
+  return import.meta.env.PROD ? !data.draft : true;
+});
+
+// Count posts per tag
+const tagCounts = new Map<string, number>();
+posts.forEach((post) => {
+  post.data.tags.forEach((tag) => {
+    tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+  });
+});
+
+// Sort tags alphabetically
+const sortedTags = [...tagCounts.entries()].sort((a, b) =>
+  a[0].localeCompare(b[0])
+);
+---
+
+<BaseLayout
+  title="Tags | gvns.ca"
+  description="Browse all blog post tags."
+>
+  <main id="main-content" class="tags-page">
+    <h1>Tags</h1>
+    <p class="intro">Browse posts by topic.</p>
+
+    {sortedTags.length > 0 ? (
+      <ul class="tag-list">
+        {sortedTags.map(([tag, count]) => (
+          <li>
+            <a href={`/blog/tags/${tag}`} class="tag-link">
+              <span class="tag-name">{tag}</span>
+              <span class="tag-count">({count})</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p class="no-tags">No tags yet.</p>
+    )}
+  </main>
+</BaseLayout>
+
+<style>
+  .tags-page {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .intro {
+    color: var(--color-text-secondary);
+    margin-bottom: 2rem;
+  }
+
+  .tag-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .tag-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-bg-secondary);
+    border-radius: 6px;
+    text-decoration: none;
+    transition: background-color var(--transition-fast);
+  }
+
+  .tag-link:hover {
+    background: var(--color-bg-elevated);
+  }
+
+  .tag-link:focus-visible {
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: 2px;
+  }
+
+  .tag-name {
+    color: var(--pink);
+    font-weight: 500;
+  }
+
+  .tag-count {
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+  }
+
+  .no-tags {
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Add tag index page at `/blog/tags`
- Add dynamic tag filter pages at `/blog/tags/[tag]`

## Files Changed

- `src/pages/blog/tags/index.astro` - All tags listing
- `src/pages/blog/tags/[tag].astro` - Posts filtered by tag

## Features

### Tag Index
- Lists all used tags with post counts
- Alphabetically sorted
- Hover effects on tag links

### Tag Filter
- Shows posts with specific tag
- Sorted by date (newest first)
- Uses PostCard component
- Navigation back to all tags

## Verification

- [x] Build passes with tag pages generated
- [x] Tags sorted alphabetically
- [x] Posts sorted by date on filter page

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)