### PR TITLE
feat: create PageLayout and About page (#9)

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,0 +1,86 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<BaseLayout title={`${title} | gvns.ca`} description={description || title}>
+  <article class="page">
+    <header class="page-header">
+      <h1>{title}</h1>
+    </header>
+    <div class="prose">
+      <slot />
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .page {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+
+  .page-header {
+    margin-bottom: 2rem;
+  }
+
+  .page-header h1 {
+    font-size: 2.25rem;
+    line-height: 1.2;
+  }
+
+  /* Prose styling for page content */
+  .prose {
+    line-height: 1.7;
+  }
+
+  .prose :global(h2) {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  .prose :global(h3) {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .prose :global(p) {
+    margin-bottom: 1.25rem;
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-bottom: 1.25rem;
+    padding-left: 1.5rem;
+  }
+
+  .prose :global(li) {
+    margin-bottom: 0.5rem;
+  }
+
+  .prose :global(a) {
+    color: var(--color-link);
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-underline-offset: 2px;
+    transition: text-decoration-color var(--transition-fast);
+  }
+
+  .prose :global(a:hover) {
+    text-decoration-color: var(--color-link);
+  }
+
+  .prose :global(strong) {
+    font-weight: 600;
+  }
+</style>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,0 +1,42 @@
+---
+import PageLayout from '@layouts/PageLayout.astro';
+---
+
+<PageLayout
+  title="About"
+  description="Web developer on Vancouver Island. Writing about homelab, web development, BJJ, and whatever catches my attention."
+>
+  <p>
+    Hi, I'm Gareth — a web developer based on Vancouver Island, Canada.
+  </p>
+
+  <p>
+    I build things for the web by day, and tinker with homelabs and self-hosting
+    by night. When I'm not at a keyboard, you'll find me on the mats training
+    Brazilian Jiu-Jitsu.
+  </p>
+
+  <h2>What I Write About</h2>
+
+  <ul>
+    <li><strong>Homelab &amp; Self-Hosting</strong> — Docker, Linux, networking, automation</li>
+    <li><strong>Web Development</strong> — Mostly frontend, sometimes fullstack</li>
+    <li><strong>BJJ</strong> — Training logs, technique notes, competition prep</li>
+    <li><strong>Productivity</strong> — ADHD strategies, PKM workflows, tools that work</li>
+  </ul>
+
+  <h2>Elsewhere</h2>
+
+  <ul>
+    <li><a href="https://github.com/ggfevans">GitHub</a> — Code and projects</li>
+  </ul>
+
+  <h2>About This Site</h2>
+
+  <p>
+    Built with <a href="https://astro.build">Astro</a>, styled with
+    <a href="https://tailwindcss.com">Tailwind CSS</a> using the
+    <a href="https://draculatheme.com">Dracula</a> colour palette. Self-hosted
+    on a Linode Nanode with analytics via <a href="https://umami.is">Umami</a>.
+  </p>
+</PageLayout>


### PR DESCRIPTION
## Summary

- Add `PageLayout.astro` for static pages
- Add About page at `/about`

## Files Changed

- `src/layouts/PageLayout.astro` - Static page layout
- `src/pages/about/index.astro` - About page

## Verification

- [x] Build passes with About page generated
- [x] Uses prose styling

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)