### PR TITLE
fix: add skip link target to PageLayout and PostLayout (#27)

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,14 +10,14 @@ const { title, description } = Astro.props;
 ---
 
 <BaseLayout title={`${title} | gvns.ca`} description={description || title}>
-  <article class="page">
+  <main id="main-content" class="page">
     <header class="page-header">
       <h1>{title}</h1>
     </header>
     <div class="prose">
       <slot />
     </div>
-  </article>
+  </main>
 </BaseLayout>
 
 <style>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -15,7 +15,8 @@ const readingTime = getReadingTime(post.body);
 ---
 
 <BaseLayout title={`${title} | gvns.ca`} description={description}>
-  <article class="post">
+  <main id="main-content">
+    <article class="post">
     <header class="post-header">
       <h1>{title}</h1>
       <div class="post-meta">
@@ -39,7 +40,8 @@ const readingTime = getReadingTime(post.body);
     <footer class="post-footer">
       <a href="/blog">&larr; Back to blog</a>
     </footer>
-  </article>
+    </article>
+  </main>
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
## Summary

- Added `id="main-content"` landmark to PageLayout and PostLayout
- Skip link now works on About, Projects, and all blog post pages

## Changes

- `src/layouts/PageLayout.astro`: Changed `<article>` to `<main id="main-content">`
- `src/layouts/PostLayout.astro`: Wrapped `<article>` in `<main id="main-content">`

## Verification

- [x] Build passes
- [x] Skip link targets exist on all page types
- [x] Semantic HTML preserved (article inside main for posts)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated HTML structure in page layouts to enhance semantic markup organisation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->