### PR TITLE
fix: add aria-current to active navigation links (#28)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,16 +16,20 @@ const currentPath = Astro.url.pathname;
     <a href="/" class="logo">gvns.ca</a>
     <div class="nav-right">
       <ul class="nav-links">
-        {navItems.map(({ href, label }) => (
-          <li>
-            <a
-              href={href}
-              class:list={['nav-link', { active: currentPath === href || (href !== '/' && currentPath.startsWith(href)) }]}
-            >
-              {label}
-            </a>
-          </li>
-        ))}
+        {navItems.map(({ href, label }) => {
+          const isActive = currentPath === href || (href !== '/' && currentPath.startsWith(href));
+          return (
+            <li>
+              <a
+                href={href}
+                class:list={['nav-link', { active: isActive }]}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {label}
+              </a>
+            </li>
+          );
+        })}
       </ul>
       <ThemeToggle client:load />
     </div>


### PR DESCRIPTION
## Summary

- Added `aria-current="page"` to active navigation links
- Screen readers now announce the current page in navigation

## Changes

- `src/components/Header.astro`: Extracted isActive logic, added aria-current attribute

## Verification

- [x] Build passes
- [x] Visual styling unchanged (uses same `.active` class)
- [x] aria-current="page" only on active link

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility**
  * Enhanced navigation with improved active state detection and ARIA attributes, providing better support for screen readers and assistive technologies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->