### PR TITLE
fix: hide ThemeToggle emoji from screen readers (#30)

### DIFF
--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -25,9 +25,9 @@
   class="theme-toggle"
 >
   {#if theme === 'dark'}
-    <span class="icon">☀️</span>
+    <span class="icon" aria-hidden="true">☀️</span>
   {:else}
-    <span class="icon">🌙</span>
+    <span class="icon" aria-hidden="true">🌙</span>
   {/if}
 </button>
 


### PR DESCRIPTION
## Summary

- Added `aria-hidden="true"` to emoji spans in ThemeToggle
- Prevents confusing double announcements by screen readers

## Changes

- `src/components/ThemeToggle.svelte`: Added aria-hidden to icon spans

## Verification

- [x] Build passes
- [x] Visual appearance unchanged
- [x] Only aria-label will be announced

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for the theme toggle by ensuring decorative icons are properly ignored by screen readers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->