### PR TITLE
fix: add global focus-visible styles (#31)

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -61,12 +61,6 @@ const filename = slugParts[slugParts.length - 1];
     color: var(--color-link);
   }
 
-  .post-title a:focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-    border-radius: 2px;
-  }
-
   .post-meta {
     display: flex;
     gap: 1rem;

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -46,9 +46,4 @@ const { tags, linked = true } = Astro.props;
   a.tag:hover {
     background: var(--color-bg-elevated);
   }
-
-  a.tag:focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
 </style>

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -47,12 +47,6 @@
     opacity: 1;
   }
 
-  .theme-toggle:focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-    border-radius: 4px;
-  }
-
   .icon {
     display: block;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,6 +86,17 @@ body {
   line-height: 1.6;
 }
 
+/* Global Focus Styles */
+:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
 /* Reduced Motion */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## Summary

- Added centralized `:focus-visible` styles to global.css
- Removed duplicate focus styles from individual components
- All interactive elements now have consistent focus indicators

## Changes

- `src/styles/global.css`: Added global focus-visible styles
- `src/components/PostCard.astro`: Removed duplicate focus styles
- `src/components/TagList.astro`: Removed duplicate focus styles
- `src/components/ThemeToggle.svelte`: Removed duplicate focus styles

## Verification

- [x] Build passes
- [x] Focus indicators work on all interactive elements
- [x] Reduced code duplication

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)