### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Linode
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/ggfevans/gvns.ca/security/code-scanning/1](https://github.com/ggfevans/gvns.ca/security/code-scanning/1)

In general, the fix is to explicitly declare minimal `permissions` for the workflow or specific jobs so that the automatically generated `GITHUB_TOKEN` cannot perform unnecessary write operations. For a simple deploy workflow that only needs to read code and does not interact with GitHub APIs write operations, `contents: read` is sufficient.

For this workflow, the best fix without changing functionality is to add a `permissions` block at the top level (so it applies to all jobs) with `contents: read`. None of the steps require write access to GitHub resources: checkout only needs read, Node setup and build are local, rsync deploy uses an SSH key, and Cloudflare purge uses a separate API token. The change should be inserted just after the `name:` line and before the `on:` block in `.github/workflows/deploy.yml`. No additional imports or tools are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened deployment workflow security by implementing enhanced permission controls within the continuous integration pipeline. The workflow now operates with restricted access permissions following the principle of least privilege, ensuring each component has access only to the resources it requires. This improves overall system resilience and reduces potential security risks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->