### PR TITLE
fix: use self-hosted runner for deployment (#54)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,16 +22,26 @@ jobs:
       - name: Build site
         run: npm run build
 
-      - name: Deploy to Linode
-        uses: burnett01/rsync-deployments@6.0.0
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
-          switches: -avzr --delete
+          name: dist
           path: dist/
-          remote_path: /var/www/gvns/
-          remote_host: ${{ secrets.LINODE_HOST }}
-          remote_port: ${{ secrets.LINODE_SSH_PORT }}
-          remote_user: ${{ secrets.LINODE_USER }}
-          remote_key: ${{ secrets.LINODE_SSH_KEY }}
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Deploy to web root
+        run: |
+          rsync -avz --delete dist/ /var/www/gvns/
 
       - name: Purge Cloudflare cache
         run: |


### PR DESCRIPTION
## Summary

Switch deployment from SSH-based rsync to self-hosted runner approach. This works with the Tailscale-only firewall configuration.

## Changes

**Before:** Single job tried to SSH from GitHub-hosted runner → blocked by firewall

**After:** Two-job approach:
1. **Build** (ubuntu-latest): Checkout, npm ci, npm run build, upload artifact
2. **Deploy** (self-hosted): Download artifact, local rsync to `/var/www/gvns/`, purge Cloudflare cache

## Why This Works

- Self-hosted runner (`vps-web-gvnsca`) runs on the Linode itself
- No inbound SSH needed - runner pulls work from GitHub
- Local rsync is fast and doesn't need network access
- Matches the pattern used in RackulaLives/Rackula

## Verification

After merge:
- [ ] Workflow completes successfully
- [ ] Site is accessible at https://gvns.ca
- [ ] Timeline section appears on About page
- [ ] Cloudflare cache is purged

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline infrastructure to use artifact-based deployment strategy, improving reliability and maintainability of the release process. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->