### PR TITLE
chore: centralize container and spacing design tokens

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,7 +20,7 @@ const currentYear = new Date().getFullYear();
   }
 
   .footer-content {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
     display: flex;
     justify-content: space-between;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -52,7 +52,7 @@ const currentPath = Astro.url.pathname;
   }
 
   .nav {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
     display: flex;
     justify-content: space-between;

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -22,7 +22,7 @@ const { title, description } = Astro.props;
 
 <style>
   .page {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
   }
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -46,7 +46,7 @@ const readingTime = getReadingTime(post.body);
 
 <style>
   .post {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
   }
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -18,7 +18,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
 <style>
   .error-page {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
     text-align: center;
     padding-top: 2rem;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -32,7 +32,7 @@ const posts = (await getCollection('blog'))
 
 <style>
   .blog-listing {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
   }
 

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -54,7 +54,7 @@ const { tag, posts } = Astro.props;
 
 <style>
   .tag-page {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
   }
 

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -47,7 +47,7 @@ const sortedTags = [...tagCounts.entries()].sort((a, b) =>
 
 <style>
   .tags-page {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const posts = (await getCollection('blog'))
 
 <style>
   .home {
-    max-width: 65ch;
+    max-width: var(--width-content);
     margin: 0 auto;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,6 +53,22 @@
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
   --transition-slow: 350ms ease;
+
+  /* Container Widths */
+  --width-content: 65ch;
+  --width-wide: 80rem;
+
+  /* Spacing Scale (4px base) */
+  --space-1: 0.25rem;   /* 4px */
+  --space-2: 0.5rem;    /* 8px */
+  --space-3: 0.75rem;   /* 12px */
+  --space-4: 1rem;      /* 16px */
+  --space-6: 1.5rem;    /* 24px */
+  --space-8: 2rem;      /* 32px */
+  --space-10: 2.5rem;   /* 40px */
+  --space-12: 3rem;     /* 48px */
+  --space-16: 4rem;     /* 64px */
+  --space-24: 6rem;     /* 96px */
 }
 
 /* Light Theme */
@@ -84,6 +100,19 @@ body {
   background-color: var(--color-bg-primary);
   color: var(--color-text-primary);
   line-height: 1.6;
+}
+
+/* Container Utility */
+.container {
+  max-width: var(--width-content);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+}
+
+.container-wide {
+  max-width: var(--width-wide);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
 }
 
 /* Global Focus Styles */


### PR DESCRIPTION
## Summary

- Adds container width tokens (`--width-content: 65ch`, `--width-wide: 80rem`) to global.css
- Adds spacing scale tokens (`--space-1` through `--space-24`) based on 4px grid
- Adds `.container` and `.container-wide` utility classes
- Updates 9 components to use `var(--width-content)` instead of hardcoded `65ch`

Closes #34

## Test plan

- [x] Build passes
- [ ] Visual verification that layouts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced responsive design tokens for consistent spacing and content widths across all pages, improving layout flexibility and adaptation.
  * Added reusable container utility classes to standardize layout patterns and enhance visual consistency throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->