### PR TITLE
feat: update colour palette to GVNS brand guide

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Personal blog and portfolio site for gvns.ca. Currently in documentation/plannin
 ## Tech Stack
 
 - **Framework**: Astro 5.x with Svelte 5 islands for interactivity
-- **Styling**: Tailwind CSS 4.x with Dracula theme colour palette
+- **Styling**: Tailwind CSS 4.x with GVNS brand palette (forest green + warm gold)
 - **Content**: Astro Content Collections (type-safe markdown)
 - **Hosting**: Linode Nanode (rsync deploy via GitHub Actions)
 - **Analytics**: Self-hosted Umami
@@ -66,12 +66,12 @@ Post URLs derive from filename, not folder structure:
 
 ## Design System
 
-Based on Dracula theme. Key semantic tokens:
-- `--color-bg-primary`, `--color-bg-secondary`
-- `--color-text-primary`, `--color-text-secondary`
-- `--color-link`, `--color-accent-primary`
+Based on GVNS Brand Guide. Key semantic tokens:
+- `--colour-bg-primary`, `--colour-bg-secondary`, `--colour-bg-tertiary`
+- `--colour-text-primary`, `--colour-text-secondary`
+- `--colour-accent-primary` (forest green `#4a7c59`), `--colour-accent-warm` (gold `#c9a959`)
 
-Uses system font stack (no external fonts). Code highlighting via Shiki with Dracula theme.
+Uses system font stack (no external fonts). Code highlighting via Shiki.
 
 ## Deployment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@
 | **UI Framework** | Svelte 5 | Islands only when interactivity needed |
 | **Styling** | Tailwind CSS 4.x | Utility-first, design tokens via CSS variables |
 | **Content** | Astro Content Collections | Type-safe markdown with frontmatter validation |
-| **Code Highlighting** | Shiki | Built into Astro, Dracula theme |
+| **Code Highlighting** | Shiki | Built into Astro |
 | **Fonts** | System font stack | No external requests, fast loading |
 
 ## Site Structure
@@ -193,4 +193,4 @@ const { title, description = 'Default description' } = Astro.props;
 
 ---
 
-*Last updated: 2024-12-09*
+*Last updated: 2026-01-02*

--- a/docs/CONTENT-SCHEMA.md
+++ b/docs/CONTENT-SCHEMA.md
@@ -162,10 +162,36 @@ Posts generate URLs from filename:
 
 ### Writing Style
 
-- **Voice**: Conversational but technically precise
+Based on GVNS Brand Guide voice attributes:
+
+| Attribute | Meaning | Example |
+|-----------|---------|---------|
+| **Direct** | Lead with the point, then riff | "This solves X. Yes, I'm rather proud of that name." |
+| **Technical** | Precise terminology, accessibly delivered | Explain the thing, then joke about the thing |
+| **Warm** | Genuinely friendly, not corporate-friendly | First person, contractions, personality |
+| **Witty** | Puns, wordplay, dry observations | Earned, not forced — quality over quantity |
+| **Self-aware** | Can laugh at yourself | Acknowledge absurdity when it's there |
+
+**The "Gareth Test"**: Before publishing, ask *"Would I actually say this to someone?"*
+- If it sounds like a LinkedIn post → rewrite
+- If it sounds like a Discord message to a technical friend → ship it
+
+**Mechanics:**
 - **Perspective**: First person ("I discovered..." not "One discovers...")
+- **Contractions**: Yes, always
+- **Spelling**: Canadian (colour, organisation, behaviour)
+- **Oxford comma**: Yes
+- **Exclamation marks**: Rarely, one at a time max
 - **Code**: Always include context, explain non-obvious parts
 - **Links**: Prefer inline links over reference-style
+
+**Humour calibration by context:**
+
+| Context | Level | Notes |
+|---------|-------|-------|
+| Blog posts | Full | Puns, metaphors, tangents, personality |
+| Tutorials | Medium | Dry wit, occasional asides |
+| Error states | Permission granted | "Well, that didn't work" > "An error occurred" |
 
 ### Code Blocks
 
@@ -222,4 +248,4 @@ export const collections = { blog };
 
 ---
 
-*Last updated: 2024-12-09*
+*Last updated: 2026-01-02*

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -75,7 +75,7 @@ WCAG AA requires 4.5:1 for normal text, 3:1 for large text/UI components.
 
 **Usage guidance:**
 - Forest green (`#4a7c59`): Safe for large text (18px+), UI components, and decorative elements on dark backgrounds
-- Link text (`#5d9a6e`): Use `--color-link-text` for body/prose links — passes 4.5:1 for normal text
+- Link text (`#5d9a6e`): Use `--colour-link-text` for body/prose links — passes 4.5:1 for normal text (alias: `--color-link-text`)
 - Warm gold (`#c9a959`): Use only on dark backgrounds for text; decorative only on light
 
 ## Typography
@@ -129,7 +129,7 @@ For blog content, custom prose styles are defined in `global.css` (not using `@t
 }
 
 .prose a {
-  color: var(--color-link-text); /* #5d9a6e - passes 4.5:1 for body text */
+  color: var(--colour-link-text); /* #5d9a6e - passes 4.5:1 for body text */
 }
 
 .prose blockquote {

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -2,80 +2,63 @@
 
 ## Colour Palette
 
-Based on [Dracula Theme](https://draculatheme.com/) with semantic mappings.
+Based on [GVNS Brand Guide v1.1](/Users/gvns/notes/gVault/01-PROJECTS/gvns-site/gvns-brand-guide.md). Dark-first, light-available. Colours are functional first, decorative second.
 
-### Core Colours
+### Base Colours — Dark Theme (Default)
 
 | Token | Hex | RGB | Usage |
 |-------|-----|-----|-------|
-| `--background` | `#282a36` | `40, 42, 54` | Page background |
-| `--current-line` | `#44475a` | `68, 71, 90` | Hover states, borders |
-| `--foreground` | `#f8f8f2` | `248, 248, 242` | Primary text |
-| `--comment` | `#6272a4` | `98, 114, 164` | Secondary text, muted |
-| `--cyan` | `#8be9fd` | `139, 233, 253` | Links, interactive |
-| `--green` | `#50fa7b` | `80, 250, 123` | Success, positive |
-| `--orange` | `#ffb86c` | `255, 184, 108` | Warnings, highlights |
-| `--pink` | `#ff79c6` | `255, 121, 198` | Accents, tags |
-| `--purple` | `#bd93f9` | `189, 147, 249` | Primary accent |
-| `--red` | `#ff5555` | `255, 85, 85` | Errors, destructive |
-| `--yellow` | `#f1fa8c` | `241, 250, 140` | Caution, attention |
+| `--colour-bg-primary` | `#0f1114` | `15, 17, 20` | Page background |
+| `--colour-bg-secondary` | `#1a1d23` | `26, 29, 35` | Cards, elevated surfaces |
+| `--colour-bg-tertiary` | `#252a33` | `37, 42, 51` | Hover states, code blocks |
+| `--colour-border` | `#2e3440` | `46, 52, 64` | Subtle borders, dividers |
 
-### Semantic Tokens
+### Base Colours — Light Theme
 
-```css
-:root {
-  /* Backgrounds */
-  --color-bg-primary: var(--background);
-  --color-bg-secondary: var(--current-line);
-  --color-bg-elevated: #343746; /* Slightly lighter than current-line */
-  
-  /* Text */
-  --color-text-primary: var(--foreground);
-  --color-text-secondary: var(--comment);
-  --color-text-muted: #6272a4;
-  
-  /* Interactive */
-  --color-link: var(--cyan);
-  --color-link-hover: var(--purple);
-  --color-link-visited: var(--pink);
-  
-  /* Accent */
-  --color-accent-primary: var(--purple);
-  --color-accent-secondary: var(--pink);
-  
-  /* Feedback */
-  --color-success: var(--green);
-  --color-warning: var(--orange);
-  --color-error: var(--red);
-  --color-info: var(--cyan);
-  
-  /* Code */
-  --color-code-bg: var(--current-line);
-  --color-code-text: var(--foreground);
-}
-```
+| Token | Hex | RGB | Usage |
+|-------|-----|-----|-------|
+| `--colour-bg-primary` | `#f8f9fa` | `248, 249, 250` | Page background |
+| `--colour-bg-secondary` | `#ffffff` | `255, 255, 255` | Cards, elevated surfaces |
+| `--colour-bg-tertiary` | `#e9ecef` | `233, 236, 239` | Hover states, code blocks |
+| `--colour-border` | `#dee2e6` | `222, 226, 230` | Subtle borders, dividers |
 
-### Light Theme (Optional)
+### Text Colours
 
-For accessibility and user preference. Derived from Dracula colours, not a separate palette.
+| Token | Dark | Light | Usage |
+|-------|------|-------|-------|
+| `--colour-text-primary` | `#eceff4` | `#1a1d23` | Body text, headings |
+| `--colour-text-secondary` | `#a3aab5` | `#4a5568` | Secondary text, captions |
+| `--colour-text-muted` | `#6b7280` | `#718096` | Timestamps, metadata |
 
-```css
-[data-theme="light"] {
-  --color-bg-primary: #f8f8f2;
-  --color-bg-secondary: #e9e9e4;
-  --color-bg-elevated: #ffffff;
-  
-  --color-text-primary: #282a36;
-  --color-text-secondary: #44475a;
-  --color-text-muted: #6272a4;
-  
-  --color-link: #6f42c1; /* Darker purple for contrast */
-  --color-link-hover: #bd93f9;
-  
-  --color-code-bg: #282a36;
-  --color-code-text: #f8f8f2;
-}
-```
+### Accent Colours
+
+| Token | Hex | RGB | Usage |
+|-------|-----|-----|-------|
+| `--colour-accent-primary` | `#4a7c59` | `74, 124, 89` | Primary actions, links, focus |
+| `--colour-accent-hover` | `#5d9a6e` | `93, 154, 110` | Hover state for primary |
+| `--colour-accent-secondary` | `#8fbc8f` | `143, 188, 143` | Secondary highlights, tags |
+| `--colour-accent-warm` | `#c9a959` | `201, 169, 89` | Warmth, warnings, variety |
+
+### Semantic Colours
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `--colour-success` | `#4a7c59` | Success states (maps to primary) |
+| `--colour-warning` | `#c9a959` | Warning states |
+| `--colour-error` | `#bf616a` | Error states |
+| `--colour-info` | `#81a1c1` | Informational states |
+
+### Colour Rationale
+
+**Forest green (`#4a7c59`)** is the signature:
+- Desaturated enough to not vibrate on dark backgrounds
+- Warm enough to feel organic, not clinical
+- Underused in tech (differentiator)
+
+**Warm gold (`#c9a959`)** provides contrast:
+- Think aged brass, not caution tape
+- Pairs beautifully with the green
+- Adds sophistication without competing
 
 ## Typography
 
@@ -120,17 +103,16 @@ Based on 1.25 ratio (Major Third) with 16px base.
 
 ### Prose Styling
 
-For blog content, using Tailwind Typography plugin defaults with Dracula overrides:
+For blog content, custom prose styles in global.css:
 
 ```css
 .prose {
-  --tw-prose-body: var(--color-text-primary);
-  --tw-prose-headings: var(--color-text-primary);
-  --tw-prose-links: var(--color-link);
-  --tw-prose-bold: var(--color-text-primary);
-  --tw-prose-code: var(--pink);
-  --tw-prose-pre-bg: var(--current-line);
-  --tw-prose-quote-borders: var(--purple);
+  --tw-prose-body: var(--colour-text-primary);
+  --tw-prose-headings: var(--colour-text-primary);
+  --tw-prose-links: var(--colour-accent-primary);
+  --tw-prose-bold: var(--colour-text-primary);
+  --tw-prose-pre-bg: var(--colour-bg-tertiary);
+  --tw-prose-quote-borders: var(--colour-accent-primary);
 }
 ```
 
@@ -217,7 +199,7 @@ Using Tailwind defaults:
 
 ```css
 a {
-  color: var(--color-link);
+  color: var(--colour-accent-primary);
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 2px;
@@ -225,11 +207,11 @@ a {
 }
 
 a:hover {
-  text-decoration-color: var(--color-link);
+  text-decoration-color: var(--colour-accent-primary);
 }
 
 a:focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--colour-accent-primary);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -244,27 +226,27 @@ a:focus-visible {
   gap: var(--space-2);
   padding: var(--space-2) var(--space-4);
   font-weight: var(--font-medium);
-  border-radius: 6px;
+  border-radius: 4px;
   transition: all 150ms ease;
 }
 
 .btn-primary {
-  background: var(--color-accent-primary);
-  color: var(--background);
+  background: var(--colour-accent-primary);
+  color: var(--colour-bg-primary);
 }
 
 .btn-primary:hover {
-  background: var(--pink);
+  background: var(--colour-accent-hover);
 }
 
 .btn-ghost {
   background: transparent;
-  color: var(--color-text-primary);
-  border: 1px solid var(--current-line);
+  color: var(--colour-text-primary);
+  border: 1px solid var(--colour-border);
 }
 
 .btn-ghost:hover {
-  background: var(--current-line);
+  background: var(--colour-bg-secondary);
 }
 ```
 
@@ -272,15 +254,15 @@ a:focus-visible {
 
 ```css
 .card {
-  background: var(--color-bg-secondary);
+  background: var(--colour-bg-secondary);
   border-radius: 8px;
-  padding: var(--space-4);
-  border: 1px solid transparent;
+  padding: var(--space-6);
+  border: 1px solid var(--colour-border);
   transition: border-color 150ms ease;
 }
 
 .card:hover {
-  border-color: var(--color-accent-primary);
+  border-color: var(--colour-accent-primary);
 }
 ```
 
@@ -292,20 +274,22 @@ a:focus-visible {
   padding: var(--space-1) var(--space-2);
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
-  background: var(--current-line);
-  color: var(--pink);
+  background: var(--colour-bg-tertiary);
+  color: var(--colour-accent-secondary);
   border-radius: 4px;
 }
 ```
 
 ### Code Blocks
 
-Handled by Shiki with Dracula theme. Additional styling:
+Handled by Shiki. Additional styling:
 
 ```css
 pre {
+  background: var(--colour-bg-tertiary);
+  border: 1px solid var(--colour-border);
   padding: var(--space-4);
-  border-radius: 8px;
+  border-radius: 6px;
   overflow-x: auto;
   font-size: var(--text-sm);
   line-height: 1.7;
@@ -317,7 +301,7 @@ code {
 
 /* Inline code */
 :not(pre) > code {
-  background: var(--current-line);
+  background: var(--colour-bg-tertiary);
   padding: 0.125em 0.375em;
   border-radius: 4px;
   font-size: 0.9em;
@@ -360,4 +344,4 @@ Use [Lucide](https://lucide.dev/) icons via `astro-icon` or inline SVG.
 
 ---
 
-*Last updated: 2024-12-09*
+*Last updated: 2026-01-02*

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Colour Palette
 
-Based on [GVNS Brand Guide v1.1](/Users/gvns/notes/gVault/01-PROJECTS/gvns-site/gvns-brand-guide.md). Dark-first, light-available. Colours are functional first, decorative second.
+Based on GVNS Brand Guide v1.1. Dark-first, light-available. Colours are functional first, decorative second.
 
 ### Base Colours — Dark Theme (Default)
 
@@ -60,6 +60,22 @@ Based on [GVNS Brand Guide v1.1](/Users/gvns/notes/gVault/01-PROJECTS/gvns-site/
 - Pairs beautifully with the green
 - Adds sophistication without competing
 
+### Contrast & Accessibility
+
+WCAG AA requires 4.5:1 for normal text, 3:1 for large text/UI components.
+
+| Pairing | Ratio | Status |
+|---------|-------|--------|
+| Primary text on dark bg | 16.3:1 | ✓ Pass |
+| Primary text on light bg | 14.8:1 | ✓ Pass |
+| Forest green on dark bg | 3.89:1 | ⚠ Large text/UI only |
+| Warm gold on dark bg | 8.38:1 | ✓ Pass |
+| Warm gold on light bg | 2.14:1 | ✗ Avoid for text |
+
+**Usage guidance:**
+- Forest green (`#4a7c59`): Safe for large text (18px+), UI components, and decorative elements on dark backgrounds
+- Warm gold (`#c9a959`): Use only on dark backgrounds for text; decorative only on light
+
 ## Typography
 
 ### Font Stack
@@ -103,16 +119,24 @@ Based on 1.25 ratio (Major Third) with 16px base.
 
 ### Prose Styling
 
-For blog content, custom prose styles in global.css:
+For blog content, custom prose styles are defined in `global.css` (not using `@tailwindcss/typography`):
 
 ```css
 .prose {
-  --tw-prose-body: var(--colour-text-primary);
-  --tw-prose-headings: var(--colour-text-primary);
-  --tw-prose-links: var(--colour-accent-primary);
-  --tw-prose-bold: var(--colour-text-primary);
-  --tw-prose-pre-bg: var(--colour-bg-tertiary);
-  --tw-prose-quote-borders: var(--colour-accent-primary);
+  line-height: 1.7;
+}
+
+.prose a {
+  color: var(--colour-accent-primary);
+}
+
+.prose blockquote {
+  border-left: 3px solid var(--colour-accent-primary);
+  color: var(--colour-text-secondary);
+}
+
+.prose pre, .prose code {
+  background: var(--colour-bg-tertiary);
 }
 ```
 

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -69,11 +69,13 @@ WCAG AA requires 4.5:1 for normal text, 3:1 for large text/UI components.
 | Primary text on dark bg | 16.3:1 | ✓ Pass |
 | Primary text on light bg | 14.8:1 | ✓ Pass |
 | Forest green on dark bg | 3.89:1 | ⚠ Large text/UI only |
+| Link text green on dark bg | 5.1:1 | ✓ Pass (body text safe) |
 | Warm gold on dark bg | 8.38:1 | ✓ Pass |
 | Warm gold on light bg | 2.14:1 | ✗ Avoid for text |
 
 **Usage guidance:**
 - Forest green (`#4a7c59`): Safe for large text (18px+), UI components, and decorative elements on dark backgrounds
+- Link text (`#5d9a6e`): Use `--color-link-text` for body/prose links — passes 4.5:1 for normal text
 - Warm gold (`#c9a959`): Use only on dark backgrounds for text; decorative only on light
 
 ## Typography
@@ -127,7 +129,7 @@ For blog content, custom prose styles are defined in `global.css` (not using `@t
 }
 
 .prose a {
-  color: var(--colour-accent-primary);
+  color: var(--color-link-text); /* #5d9a6e - passes 4.5:1 for body text */
 }
 
 .prose blockquote {
@@ -306,7 +308,20 @@ a:focus-visible {
 
 ### Code Blocks
 
-Handled by Shiki. Additional styling:
+Syntax highlighting is handled by Shiki (Astro's default). Currently using Astro's default theme (`github-dark`). To customize, add `markdown.shikiConfig.theme` in `astro.config.mjs`:
+
+```javascript
+// astro.config.mjs
+export default defineConfig({
+  markdown: {
+    shikiConfig: {
+      theme: 'github-dark', // or 'dracula', 'nord', etc.
+    },
+  },
+});
+```
+
+Additional styling in `global.css`:
 
 ```css
 pre {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,7 +17,9 @@
   --colour-text-secondary: #a3aab5;
   --colour-text-muted: #6b7280;
 
-  /* Accent Colours */
+  /* Accent Colours
+     Note: Forest green (3.89:1 on dark) is for large text/UI only.
+     Warm gold passes on dark (8.38:1) but fails on light (2.14:1). */
   --colour-accent-primary: #4a7c59;
   --colour-accent-hover: #5d9a6e;
   --colour-accent-secondary: #8fbc8f;
@@ -86,7 +88,7 @@
   --colour-text-secondary: #4a5568;
   --colour-text-muted: #718096;
 
-  /* Legacy aliases */
+  /* Legacy aliases (accent/semantic colours unchanged from dark theme) */
   --color-bg-primary: var(--colour-bg-primary);
   --color-bg-secondary: var(--colour-bg-secondary);
   --color-bg-elevated: var(--colour-bg-tertiary);
@@ -189,7 +191,7 @@ body {
 }
 
 .prose a {
-  color: var(--color-link);
+  color: var(--colour-accent-primary);
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 2px;
@@ -197,7 +199,7 @@ body {
 }
 
 .prose a:hover {
-  text-decoration-color: var(--color-link);
+  text-decoration-color: var(--colour-accent-primary);
 }
 
 .prose code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,6 +25,10 @@
   --colour-accent-secondary: #8fbc8f;
   --colour-accent-warm: #c9a959;
 
+  /* High-contrast link color for body text (5.1:1 on dark bg)
+     Use --color-link-text for prose/body links to meet WCAG AA 4.5:1 */
+  --color-link-text: #5d9a6e;
+
   /* Semantic Colours */
   --colour-success: #4a7c59;
   --colour-warning: #c9a959;
@@ -191,7 +195,7 @@ body {
 }
 
 .prose a {
-  color: var(--colour-accent-primary);
+  color: var(--color-link-text);
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 2px;
@@ -199,7 +203,7 @@ body {
 }
 
 .prose a:hover {
-  text-decoration-color: var(--colour-accent-primary);
+  text-decoration-color: var(--color-link-text);
 }
 
 .prose code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,9 +25,9 @@
   --colour-accent-secondary: #8fbc8f;
   --colour-accent-warm: #c9a959;
 
-  /* High-contrast link color for body text (5.1:1 on dark bg)
-     Use --color-link-text for prose/body links to meet WCAG AA 4.5:1 */
-  --color-link-text: #5d9a6e;
+  /* High-contrast link colour for body text (5.1:1 on dark bg)
+     Use --colour-link-text for prose/body links to meet WCAG AA 4.5:1 */
+  --colour-link-text: #5d9a6e;
 
   /* Semantic Colours */
   --colour-success: #4a7c59;
@@ -44,6 +44,7 @@
   --color-text-muted: var(--colour-text-muted);
   --color-link: var(--colour-accent-primary);
   --color-link-hover: var(--colour-accent-hover);
+  --color-link-text: var(--colour-link-text);
   --color-accent-primary: var(--colour-accent-primary);
   --color-accent-secondary: var(--colour-accent-secondary);
   --color-success: var(--colour-success);
@@ -195,7 +196,7 @@ body {
 }
 
 .prose a {
-  color: var(--color-link-text);
+  color: var(--colour-link-text);
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 2px;
@@ -203,7 +204,7 @@ body {
 }
 
 .prose a:hover {
-  text-decoration-color: var(--color-link-text);
+  text-decoration-color: var(--colour-link-text);
 }
 
 .prose code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,46 +2,50 @@
 
 /* ============================================
    gvns.ca Design Tokens
-   Based on Dracula Theme
+   Based on GVNS Brand Guide v1.1
    ============================================ */
 
 :root {
-  /* Core Dracula Palette */
-  --background: #282a36;
-  --current-line: #44475a;
-  --foreground: #f8f8f2;
-  --comment: #6272a4;
-  --cyan: #8be9fd;
-  --green: #50fa7b;
-  --orange: #ffb86c;
-  --pink: #ff79c6;
-  --purple: #bd93f9;
-  --red: #ff5555;
-  --yellow: #f1fa8c;
+  /* Core Palette — Dark Theme (Default) */
+  --colour-bg-primary: #0f1114;
+  --colour-bg-secondary: #1a1d23;
+  --colour-bg-tertiary: #252a33;
+  --colour-border: #2e3440;
 
-  /* Semantic Backgrounds */
-  --color-bg-primary: var(--background);
-  --color-bg-secondary: var(--current-line);
-  --color-bg-elevated: #343746;
+  /* Text Colours */
+  --colour-text-primary: #eceff4;
+  --colour-text-secondary: #a3aab5;
+  --colour-text-muted: #6b7280;
 
-  /* Semantic Text */
-  --color-text-primary: var(--foreground);
-  --color-text-secondary: var(--comment);
-  --color-text-muted: #6272a4;
+  /* Accent Colours */
+  --colour-accent-primary: #4a7c59;
+  --colour-accent-hover: #5d9a6e;
+  --colour-accent-secondary: #8fbc8f;
+  --colour-accent-warm: #c9a959;
 
-  /* Interactive */
-  --color-link: var(--cyan);
-  --color-link-hover: var(--purple);
+  /* Semantic Colours */
+  --colour-success: #4a7c59;
+  --colour-warning: #c9a959;
+  --colour-error: #bf616a;
+  --colour-info: #81a1c1;
 
-  /* Accent */
-  --color-accent-primary: var(--purple);
-  --color-accent-secondary: var(--pink);
-
-  /* Feedback */
-  --color-success: var(--green);
-  --color-warning: var(--orange);
-  --color-error: var(--red);
-  --color-info: var(--cyan);
+  /* Legacy aliases for compatibility */
+  --color-bg-primary: var(--colour-bg-primary);
+  --color-bg-secondary: var(--colour-bg-secondary);
+  --color-bg-elevated: var(--colour-bg-tertiary);
+  --color-text-primary: var(--colour-text-primary);
+  --color-text-secondary: var(--colour-text-secondary);
+  --color-text-muted: var(--colour-text-muted);
+  --color-link: var(--colour-accent-primary);
+  --color-link-hover: var(--colour-accent-hover);
+  --color-accent-primary: var(--colour-accent-primary);
+  --color-accent-secondary: var(--colour-accent-secondary);
+  --color-success: var(--colour-success);
+  --color-warning: var(--colour-warning);
+  --color-error: var(--colour-error);
+  --color-info: var(--colour-info);
+  --current-line: var(--colour-bg-secondary);
+  --purple: var(--colour-accent-primary);
 
   /* Typography */
   --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
@@ -73,21 +77,23 @@
 
 /* Light Theme */
 [data-theme="light"] {
-  --background: #f8f8f2;
-  --current-line: #e9e9e4;
-  --foreground: #282a36;
-  --comment: #44475a;
+  --colour-bg-primary: #f8f9fa;
+  --colour-bg-secondary: #ffffff;
+  --colour-bg-tertiary: #e9ecef;
+  --colour-border: #dee2e6;
 
-  --color-bg-primary: #f8f8f2;
-  --color-bg-secondary: #e9e9e4;
-  --color-bg-elevated: #ffffff;
+  --colour-text-primary: #1a1d23;
+  --colour-text-secondary: #4a5568;
+  --colour-text-muted: #718096;
 
-  --color-text-primary: #282a36;
-  --color-text-secondary: #44475a;
-  --color-text-muted: #6272a4;
-
-  --color-link: #6f42c1;
-  --color-link-hover: #bd93f9;
+  /* Legacy aliases */
+  --color-bg-primary: var(--colour-bg-primary);
+  --color-bg-secondary: var(--colour-bg-secondary);
+  --color-bg-elevated: var(--colour-bg-tertiary);
+  --color-text-primary: var(--colour-text-primary);
+  --color-text-secondary: var(--colour-text-secondary);
+  --color-text-muted: var(--colour-text-muted);
+  --current-line: var(--colour-bg-secondary);
 }
 
 /* Base Styles */
@@ -175,11 +181,11 @@ body {
 }
 
 .prose blockquote {
-  border-left: 3px solid var(--purple);
+  border-left: 3px solid var(--colour-accent-primary);
   padding-left: 1rem;
   margin: 1.5rem 0;
   font-style: italic;
-  color: var(--color-text-secondary);
+  color: var(--colour-text-secondary);
 }
 
 .prose a {
@@ -197,13 +203,13 @@ body {
 .prose code {
   font-family: var(--font-mono);
   font-size: 0.9em;
-  background: var(--current-line);
+  background: var(--colour-bg-tertiary);
   padding: 0.125em 0.375em;
   border-radius: 4px;
 }
 
 .prose pre {
-  background: var(--current-line);
+  background: var(--colour-bg-tertiary);
   padding: 1rem;
   border-radius: 8px;
   overflow-x: auto;
@@ -223,6 +229,6 @@ body {
 
 .prose hr {
   border: none;
-  border-top: 1px solid var(--current-line);
+  border-top: 1px solid var(--colour-border);
   margin: 2rem 0;
 }


### PR DESCRIPTION
## Summary

Replaces Dracula theme with the forest green + warm gold palette from the GVNS Brand Guide v1.1.

### Colour Changes

| Token | Before (Dracula) | After (GVNS) |
|-------|------------------|--------------|
| Primary accent | `#bd93f9` (purple) | `#4a7c59` (forest green) |
| Secondary accent | `#ff79c6` (pink) | `#8fbc8f` (sage green) |
| Warm accent | `#ffb86c` (orange) | `#c9a959` (aged brass) |
| Dark background | `#282a36` | `#0f1114` |
| Links | `#8be9fd` (cyan) | `#4a7c59` (forest green) |

### Files Changed

- `src/styles/global.css` - New colour tokens + legacy aliases for compatibility
- `docs/DESIGN-SYSTEM.md` - Updated to document new palette
- `CLAUDE.md` - Updated tech stack description

## Test plan

- [x] Build passes
- [ ] Visual verification of new colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Rebranded UI to GVNS (forest green + warm gold), updated site surfaces, prose, links and code-block styling; added dark-first with light-theme support and compatibility aliases.

* **Documentation**
  * Updated design system, architecture and content guidance with GVNS brand voice, accessibility/contrast notes, expanded writing guidelines and refreshed timestamps.

* **Chores**
  * Automated update schedule refined for package and workflow dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->