### PR TITLE
chore: consolidate theme initialization logic (#35)

### DIFF
--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-  let theme = $state<'dark' | 'light'>('dark');
-
-  // Initialize theme from localStorage or system preference
-  $effect(() => {
-    const stored = localStorage.getItem('theme');
-    if (stored === 'light' || stored === 'dark') {
-      theme = stored;
-    } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      theme = 'light';
+  // Read initial theme from BaseLayout's inline script (avoids re-initialization)
+  // Falls back to 'dark' during SSR or if window.__theme isn't set
+  function getInitialTheme(): 'dark' | 'light' {
+    if (typeof window !== 'undefined' && (window as any).__theme) {
+      return (window as any).__theme;
     }
-    document.documentElement.setAttribute('data-theme', theme);
-  });
+    return 'dark';
+  }
+
+  let theme = $state<'dark' | 'light'>(getInitialTheme());
 
   function toggle() {
     theme = theme === 'dark' ? 'light' : 'dark';

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,9 +18,12 @@ const { title, description } = Astro.props;
     <BaseHead title={title} description={description} />
     <script is:inline>
       // Initialize theme before page renders to prevent flash
+      // This is the single source of truth for theme initialization
       const theme = localStorage.getItem('theme')
         || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
       document.documentElement.setAttribute('data-theme', theme);
+      // Expose to Svelte components so they can read initial state without re-initializing
+      window.__theme = theme;
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- BaseLayout.astro now exposes theme via `window.__theme` after initialization
- ThemeToggle.svelte reads initial state from `window.__theme` instead of re-initializing
- Eliminates duplicate initialization logic and potential race conditions

## Changes

- `src/layouts/BaseLayout.astro`: Added `window.__theme = theme` after initialization
- `src/components/ThemeToggle.svelte`: Replaced `$effect` init with `getInitialTheme()` function that reads from `window.__theme`

## Verification

- [x] Build passes
- [x] Theme initialization happens exactly once
- [x] ThemeToggle reads initial state, doesn't re-initialize
- [x] No flash of wrong theme (inline script runs before hydration)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated theme initialization to ensure consistent theme application across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->