### PR TITLE
fix: use Astro.site for dynamic JSON-LD URLs

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -4,7 +4,7 @@ import BaseLayout from './BaseLayout.astro';
 import TagList from '@components/TagList.astro';
 import { formatDate } from '@utils/date';
 import { getReadingTime } from '@utils/reading-time';
-import { articleSchema, breadcrumbSchema, toJsonLd } from '@utils/json-ld';
+import { articleSchema, breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
 interface Props {
   post: CollectionEntry<'blog'>;
@@ -14,6 +14,7 @@ const { post } = Astro.props;
 const { title, description, pubDate, updatedDate, tags } = post.data;
 const readingTime = getReadingTime(post.body);
 
+const siteUrl = normalizeSiteUrl(Astro.site);
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 
 const articleJsonLd = toJsonLd(articleSchema({
@@ -22,11 +23,12 @@ const articleJsonLd = toJsonLd(articleSchema({
   pubDate,
   updatedDate,
   url: canonicalUrl,
+  siteUrl,
 }));
 
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
-  { name: 'Home', url: 'https://gvns.ca' },
-  { name: 'Blog', url: 'https://gvns.ca/blog' },
+  { name: 'Home', url: siteUrl },
+  { name: 'Blog', url: `${siteUrl}/blog` },
   { name: title, url: canonicalUrl },
 ]));
 ---

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,12 +1,13 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
 import Timeline from '@components/Timeline.astro';
-import { personSchema, breadcrumbSchema, toJsonLd } from '@utils/json-ld';
+import { personSchema, breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
-const personJsonLd = toJsonLd(personSchema());
+const siteUrl = normalizeSiteUrl(Astro.site);
+const personJsonLd = toJsonLd(personSchema(siteUrl));
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
-  { name: 'Home', url: 'https://gvns.ca' },
-  { name: 'About', url: 'https://gvns.ca/about' },
+  { name: 'Home', url: siteUrl },
+  { name: 'About', url: `${siteUrl}/about` },
 ]));
 ---
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,15 +2,16 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import PostCard from '@components/PostCard.astro';
-import { breadcrumbSchema, toJsonLd } from '@utils/json-ld';
+import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
 const posts = (await getCollection('blog'))
   .filter((post) => import.meta.env.PROD ? !post.data.draft : true)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
+const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
-  { name: 'Home', url: 'https://gvns.ca' },
-  { name: 'Blog', url: 'https://gvns.ca/blog' },
+  { name: 'Home', url: siteUrl },
+  { name: 'Blog', url: `${siteUrl}/blog` },
 ]));
 ---
 

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -2,7 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import PostCard from '@components/PostCard.astro';
-import { breadcrumbSchema, toJsonLd } from '@utils/json-ld';
+import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => {
@@ -33,11 +33,12 @@ interface Props {
 
 const { tag, posts } = Astro.props;
 
+const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
-  { name: 'Home', url: 'https://gvns.ca' },
-  { name: 'Blog', url: 'https://gvns.ca/blog' },
-  { name: 'Tags', url: 'https://gvns.ca/blog/tags' },
-  { name: tag, url: `https://gvns.ca/blog/tags/${tag}` },
+  { name: 'Home', url: siteUrl },
+  { name: 'Blog', url: `${siteUrl}/blog` },
+  { name: 'Tags', url: `${siteUrl}/blog/tags` },
+  { name: tag, url: `${siteUrl}/blog/tags/${encodeURIComponent(tag)}` },
 ]));
 ---
 

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
-import { breadcrumbSchema, toJsonLd } from '@utils/json-ld';
+import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
 const posts = await getCollection('blog', ({ data }) => {
   return import.meta.env.PROD ? !data.draft : true;
@@ -20,10 +20,11 @@ const sortedTags = [...tagCounts.entries()].sort((a, b) =>
   a[0].localeCompare(b[0])
 );
 
+const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
-  { name: 'Home', url: 'https://gvns.ca' },
-  { name: 'Blog', url: 'https://gvns.ca/blog' },
-  { name: 'Tags', url: 'https://gvns.ca/blog/tags' },
+  { name: 'Home', url: siteUrl },
+  { name: 'Blog', url: `${siteUrl}/blog` },
+  { name: 'Tags', url: `${siteUrl}/blog/tags` },
 ]));
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,14 +2,15 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import PostCard from '@components/PostCard.astro';
-import { websiteSchema, toJsonLd } from '@utils/json-ld';
+import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
 const posts = (await getCollection('blog'))
   .filter((post) => import.meta.env.PROD ? !post.data.draft : true)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 3);
 
-const jsonLd = toJsonLd(websiteSchema());
+const siteUrl = normalizeSiteUrl(Astro.site);
+const jsonLd = toJsonLd(websiteSchema(siteUrl));
 ---
 
 <BaseLayout

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,10 +1,11 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
-import { breadcrumbSchema, toJsonLd } from '@utils/json-ld';
+import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
+const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
-  { name: 'Home', url: 'https://gvns.ca' },
-  { name: 'Projects', url: 'https://gvns.ca/projects' },
+  { name: 'Home', url: siteUrl },
+  { name: 'Projects', url: `${siteUrl}/projects` },
 ]));
 
 const projects = [

--- a/src/utils/json-ld.ts
+++ b/src/utils/json-ld.ts
@@ -4,9 +4,9 @@
  * @see https://developers.google.com/search/docs/appearance/structured-data
  */
 
-const SITE_URL = 'https://gvns.ca';
 const SITE_NAME = 'gvns.ca';
 const AUTHOR_NAME = 'Gareth Evans';
+const DEFAULT_SITE_URL = 'https://gvns.ca';
 
 interface ArticleSchema {
   title: string;
@@ -14,6 +14,7 @@ interface ArticleSchema {
   pubDate: Date;
   updatedDate?: Date;
   url: string;
+  siteUrl?: string;
 }
 
 interface BreadcrumbItem {
@@ -22,14 +23,24 @@ interface BreadcrumbItem {
 }
 
 /**
- * Generate WebSite schema for the home page
+ * Normalize site URL by removing trailing slash
  */
-export function websiteSchema(): object {
+export function normalizeSiteUrl(siteUrl: URL | string | undefined): string {
+  if (!siteUrl) return DEFAULT_SITE_URL;
+  return siteUrl.toString().replace(/\/$/, '');
+}
+
+/**
+ * Generate WebSite schema for the home page
+ * @param siteUrl - The base URL of the site (from Astro.site)
+ */
+export function websiteSchema(siteUrl?: string): object {
+  const url = siteUrl || DEFAULT_SITE_URL;
   return {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: SITE_NAME,
-    url: SITE_URL,
+    url,
     author: {
       '@type': 'Person',
       name: AUTHOR_NAME,
@@ -41,13 +52,15 @@ export function websiteSchema(): object {
 
 /**
  * Generate Person schema for the about page
+ * @param siteUrl - The base URL of the site (from Astro.site)
  */
-export function personSchema(): object {
+export function personSchema(siteUrl?: string): object {
+  const url = siteUrl || DEFAULT_SITE_URL;
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',
     name: AUTHOR_NAME,
-    url: SITE_URL,
+    url,
     jobTitle: 'Web Developer',
     knowsAbout: [
       'Web Development',
@@ -68,7 +81,9 @@ export function articleSchema({
   pubDate,
   updatedDate,
   url,
+  siteUrl,
 }: ArticleSchema): object {
+  const baseUrl = siteUrl || DEFAULT_SITE_URL;
   return {
     '@context': 'https://schema.org',
     '@type': 'Article',
@@ -77,12 +92,12 @@ export function articleSchema({
     author: {
       '@type': 'Person',
       name: AUTHOR_NAME,
-      url: SITE_URL,
+      url: baseUrl,
     },
     publisher: {
       '@type': 'Person',
       name: AUTHOR_NAME,
-      url: SITE_URL,
+      url: baseUrl,
     },
     datePublished: pubDate.toISOString(),
     dateModified: (updatedDate || pubDate).toISOString(),


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #75 regarding hardcoded URLs in JSON-LD structured data.

## Changes

### `src/utils/json-ld.ts`
- Added `normalizeSiteUrl()` helper function for environment portability
- Updated `websiteSchema()`, `personSchema()`, and `articleSchema()` to accept optional `siteUrl` parameter
- Schemas now fall back to `https://gvns.ca` only when `Astro.site` is unavailable

### All page files
- Replaced hardcoded `'https://gvns.ca'` URLs with `Astro.site`-derived values
- Added `encodeURIComponent(tag)` in `[tag].astro` to handle special characters in tag URLs

## Files Changed
- `src/utils/json-ld.ts`
- `src/pages/index.astro`
- `src/pages/about/index.astro`
- `src/pages/blog/index.astro`
- `src/pages/blog/tags/index.astro`
- `src/pages/blog/tags/[tag].astro`
- `src/pages/projects/index.astro`
- `src/layouts/PostLayout.astro`

## Verification

- [x] Build passes
- [x] JSON-LD uses dynamic URLs from Astro.site
- [x] Tag URLs are properly encoded

Follow-up to #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved structured data generation to use dynamically normalized site URLs instead of hard-coded values, ensuring metadata accuracy across all pages
  * Enhanced breadcrumb navigation metadata to reference correct site URLs in search results and structured data

* **Refactor**
  * Standardized URL handling for JSON-LD schema generation across the site

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->