### PR TITLE
chore: add CI workflow for PR build verification (#77)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         patterns:
           - "astro"
           - "@astrojs/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
       dev-dependencies:
         dependency-type: "development"
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build


### PR DESCRIPTION
## Summary

Adds build verification for all PRs (including Dependabot) and groups Tailwind packages.

## Changes

### New: `.github/workflows/ci.yml`
- Runs on all PRs to `main`
- Executes `npm ci` and `npm run build`
- Catches breaking dependency updates before merge

### Updated: `.github/dependabot.yml`
- Added `tailwind` group for `tailwindcss` and `@tailwindcss/*` packages
- Reduces PR noise by bundling related Tailwind updates

## Verification

- [x] Build passes locally
- [x] CI workflow syntax is valid

## Acceptance Criteria

- [x] Dependabot PRs run full build verification
- [x] Tailwind packages are grouped together

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency management for Tailwind packages.
  * Implemented continuous integration automation for project builds and testing on pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->