### PR TITLE
feat: Phase 8 writing enhancements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import svelte from '@astrojs/svelte';
 import sitemap from '@astrojs/sitemap';
+import rehypeSlug from 'rehype-slug';
 
 const shikiTheme = JSON.parse(
   readFileSync(new URL('./src/styles/shiki-gvns.json', import.meta.url), 'utf-8')
@@ -17,9 +18,15 @@ export default defineConfig({
     shikiConfig: {
       theme: shikiTheme,
     },
+    rehypePlugins: [rehypeSlug],
   },
   vite: {
-    plugins: [tailwindcss()]
+    plugins: [tailwindcss()],
+    build: {
+      rollupOptions: {
+        external: ['/pagefind/pagefind-ui.js'],
+      },
+    },
   },
 
   integrations: [svelte(), sitemap()]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "temp",
+  "name": "gvns-ca",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "temp",
+      "name": "gvns-ca",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/rss": "^4.0.15",
@@ -15,6 +15,7 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.17.1",
+        "rehype-slug": "^6.0.0",
         "svelte": "^5.49.1",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3"
@@ -2938,6 +2939,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -3025,6 +3039,19 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4692,6 +4719,23 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -16,6 +16,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.17.1",
+    "rehype-slug": "^6.0.0",
     "svelte": "^5.49.1",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -29,6 +29,9 @@ const ogHeight = imageHeight || DEFAULT_OG_HEIGHT;
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
 
+<!-- RSS Autodiscovery -->
+<link rel="alternate" type="application/rss+xml" title="gvns.ca RSS Feed" href="/rss.xml" />
+
 <!-- Primary Meta Tags -->
 <title>{title}</title>
 <meta name="title" content={title} />

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,72 @@
+---
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface Props {
+  items: BreadcrumbItem[];
+}
+
+const { items } = Astro.props;
+---
+
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <ol>
+    {items.map((item, i) => (
+      <li>
+        {i > 0 && <span class="separator" aria-hidden="true">/</span>}
+        {item.href ? (
+          <a href={item.href}>{item.label}</a>
+        ) : (
+          <span aria-current="page">{item.label}</span>
+        )}
+      </li>
+    ))}
+  </ol>
+</nav>
+
+<style>
+  .breadcrumb {
+    margin-bottom: 1.5rem;
+  }
+
+  ol {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: var(--text-sm);
+  }
+
+  li {
+    display: flex;
+    align-items: center;
+  }
+
+  .separator {
+    margin: 0 0.5rem;
+    color: var(--colour-text-muted);
+  }
+
+  a {
+    color: var(--colour-text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  a:hover {
+    color: var(--colour-accent-primary);
+  }
+
+  span[aria-current="page"] {
+    color: var(--colour-text-primary);
+    max-width: 20ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import ThemeToggle from './ThemeToggle.svelte';
 import MobileNav from './MobileNav.svelte';
+import Search from './Search.svelte';
 
 const navItems = [
   { href: '/about', label: 'About' },
@@ -36,6 +37,9 @@ const currentPath = Astro.url.pathname;
       </ul>
       <ThemeToggle client:load />
     </div>
+
+    <!-- Search (single instance, visible at all breakpoints) -->
+    <Search client:load />
 
     <!-- Mobile Navigation -->
     <div class="mobile-nav-wrapper">
@@ -101,7 +105,9 @@ const currentPath = Astro.url.pathname;
 
   /* Mobile Navigation */
   .mobile-nav-wrapper {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
   }
 
   @media (min-width: 768px) {

--- a/src/components/ReadingProgress.svelte
+++ b/src/components/ReadingProgress.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  let progress = $state(0);
+
+  $effect(() => {
+    const prose = document.querySelector('.prose');
+    if (!prose) return;
+
+    let start: number;
+    let end: number;
+
+    function computeBounds() {
+      const rect = prose!.getBoundingClientRect();
+      start = rect.top + window.scrollY;
+      end = start + rect.height - window.innerHeight;
+    }
+
+    function handleScroll() {
+      const scrolled = window.scrollY;
+      if (scrolled <= start) {
+        progress = 0;
+      } else if (scrolled >= end) {
+        progress = 100;
+      } else {
+        progress = ((scrolled - start) / (end - start)) * 100;
+      }
+    }
+
+    computeBounds();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', computeBounds, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', computeBounds);
+    };
+  });
+</script>
+
+<div
+  class="reading-progress"
+  style="width: {progress}%"
+  role="presentation"
+  aria-hidden="true"
+></div>
+
+<style>
+  .reading-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    background: var(--colour-accent-primary);
+    z-index: 100;
+    transition: width 100ms ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reading-progress {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -1,0 +1,292 @@
+<script lang="ts">
+  let dialogEl: HTMLDialogElement | undefined = $state();
+  let searchContainerEl: HTMLDivElement | undefined = $state();
+  let isOpen = $state(false);
+  let pagefindLoaded = $state(false);
+  let pagefindError = $state(false);
+
+  async function loadPagefind() {
+    if (pagefindLoaded) return;
+    try {
+      const pagefind = await import(/* @vite-ignore */ '/pagefind/pagefind-ui.js');
+      if (searchContainerEl) {
+        new pagefind.PagefindUI({
+          element: searchContainerEl,
+          showSubResults: true,
+          showImages: false,
+        });
+        pagefindLoaded = true;
+        // Focus the input after Pagefind renders
+        requestAnimationFrame(() => {
+          const input = searchContainerEl?.querySelector<HTMLInputElement>('input');
+          input?.focus();
+        });
+      }
+    } catch {
+      pagefindError = true;
+    }
+  }
+
+  function openDialog() {
+    if (!dialogEl) return;
+    dialogEl.showModal();
+    isOpen = true;
+    loadPagefind();
+    // If already loaded, focus the input
+    if (pagefindLoaded) {
+      requestAnimationFrame(() => {
+        const input = searchContainerEl?.querySelector<HTMLInputElement>('input');
+        input?.focus();
+      });
+    }
+  }
+
+  function closeDialog() {
+    if (!dialogEl) return;
+    dialogEl.close();
+    isOpen = false;
+  }
+
+  // Keyboard shortcut: Cmd/Ctrl+K
+  $effect(() => {
+    function handleKeydown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        if (isOpen) {
+          closeDialog();
+        } else {
+          openDialog();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeydown);
+    return () => document.removeEventListener('keydown', handleKeydown);
+  });
+
+  // Close on click outside (on backdrop)
+  function handleDialogClick(e: MouseEvent) {
+    if (e.target === dialogEl) {
+      closeDialog();
+    }
+  }
+</script>
+
+<button
+  onclick={openDialog}
+  class="search-trigger"
+  aria-label="Search (Cmd+K)"
+  title="Search (Cmd+K)"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="8"></circle>
+    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+  </svg>
+</button>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<dialog
+  bind:this={dialogEl}
+  class="search-dialog"
+  aria-label="Site search"
+  onclick={handleDialogClick}
+  onclose={() => isOpen = false}
+>
+  <div class="search-dialog-inner">
+    <div class="search-header">
+      <h2 class="search-title">Search</h2>
+      <kbd class="search-kbd">
+        <span class="kbd-symbol">&#8984;</span>K
+      </kbd>
+    </div>
+    <div class="search-container" bind:this={searchContainerEl}>
+      {#if pagefindError}
+        <p class="search-fallback">
+          Search is not available in development mode. Run a production build to enable search.
+        </p>
+      {/if}
+    </div>
+  </div>
+</dialog>
+
+<style>
+  .search-trigger {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    color: var(--colour-text-secondary);
+    transition: color var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .search-trigger:hover {
+    color: var(--colour-accent-primary);
+  }
+
+  .search-dialog {
+    position: fixed;
+    border: none;
+    border-radius: 12px;
+    padding: 0;
+    max-width: 600px;
+    width: calc(100% - 2rem);
+    background: var(--colour-bg-primary);
+    color: var(--colour-text-primary);
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    top: 15%;
+    margin: 0 auto;
+
+    /* Pagefind UI CSS variable overrides */
+    --pagefind-ui-primary: var(--colour-accent-primary);
+    --pagefind-ui-text: var(--colour-text-primary);
+    --pagefind-ui-background: var(--colour-bg-primary);
+    --pagefind-ui-border: var(--colour-border);
+    --pagefind-ui-tag: var(--colour-bg-tertiary);
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 8px;
+    --pagefind-ui-font: var(--font-sans);
+  }
+
+  .search-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+  }
+
+  .search-dialog-inner {
+    padding: var(--space-6, 1.5rem);
+  }
+
+  .search-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-4, 1rem);
+    padding-bottom: var(--space-3, 0.75rem);
+    border-bottom: 1px solid var(--colour-border);
+  }
+
+  .search-title {
+    font-size: var(--text-lg, 1.25rem);
+    font-weight: 600;
+    margin: 0;
+    color: var(--colour-text-primary);
+  }
+
+  .search-kbd {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs, 0.75rem);
+    padding: 0.2em 0.5em;
+    background: var(--colour-bg-tertiary);
+    border: 1px solid var(--colour-border);
+    border-radius: 4px;
+    color: var(--colour-text-secondary);
+    line-height: 1;
+  }
+
+  .kbd-symbol {
+    font-size: 0.85em;
+  }
+
+  .search-container {
+    min-height: 60px;
+  }
+
+  .search-fallback {
+    color: var(--colour-text-secondary);
+    font-size: var(--text-sm, 0.875rem);
+    text-align: center;
+    padding: var(--space-8, 2rem) var(--space-4, 1rem);
+    margin: 0;
+  }
+
+  /* Pagefind UI style overrides */
+  .search-container :global(.pagefind-ui__search-input) {
+    background: var(--colour-bg-secondary) !important;
+    color: var(--colour-text-primary) !important;
+    font-family: var(--font-sans) !important;
+    border: 1px solid var(--colour-border) !important;
+    border-radius: 8px !important;
+    padding: 0.75rem 1rem !important;
+    font-size: var(--text-base) !important;
+    width: 100% !important;
+    outline: none !important;
+    transition: border-color var(--transition-fast) !important;
+  }
+
+  .search-container :global(.pagefind-ui__search-input:focus) {
+    border-color: var(--colour-accent-primary) !important;
+  }
+
+  .search-container :global(.pagefind-ui__search-clear) {
+    color: var(--colour-text-secondary) !important;
+    background: none !important;
+  }
+
+  .search-container :global(.pagefind-ui__result) {
+    padding: var(--space-3) !important;
+    border-radius: 8px !important;
+    border-bottom: 1px solid var(--colour-border) !important;
+    transition: background var(--transition-fast) !important;
+  }
+
+  .search-container :global(.pagefind-ui__result:hover) {
+    background: var(--colour-bg-tertiary) !important;
+  }
+
+  .search-container :global(.pagefind-ui__result-link) {
+    color: var(--colour-accent-primary) !important;
+    text-decoration: none !important;
+    font-weight: 500 !important;
+  }
+
+  .search-container :global(.pagefind-ui__result-excerpt) {
+    color: var(--colour-text-secondary) !important;
+    font-size: var(--text-sm) !important;
+  }
+
+  .search-container :global(.pagefind-ui__message) {
+    color: var(--colour-text-secondary) !important;
+    font-size: var(--text-sm) !important;
+  }
+
+  .search-container :global(.pagefind-ui__button) {
+    background: var(--colour-bg-tertiary) !important;
+    color: var(--colour-text-primary) !important;
+    border: 1px solid var(--colour-border) !important;
+    border-radius: 8px !important;
+    transition: background var(--transition-fast) !important;
+  }
+
+  .search-container :global(.pagefind-ui__button:hover) {
+    background: var(--colour-bg-secondary) !important;
+  }
+
+  .search-container :global(.pagefind-ui__form::before) {
+    display: none !important;
+  }
+
+  .search-container :global(.pagefind-ui__search-input::placeholder) {
+    color: var(--colour-text-muted) !important;
+  }
+
+  .search-container :global(.pagefind-ui__result-title) {
+    color: var(--colour-text-primary) !important;
+  }
+</style>

--- a/src/components/TableOfContents.svelte
+++ b/src/components/TableOfContents.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  interface Heading {
+    id: string;
+    text: string;
+    level: number;
+  }
+
+  let headings: Heading[] = $state([]);
+  let activeId = $state('');
+  let isExpanded = $state(false);
+
+  $effect(() => {
+    const prose = document.querySelector('.prose');
+    if (!prose) return;
+
+    const elements = prose.querySelectorAll('h2, h3');
+    const extracted: Heading[] = [];
+    for (const el of elements) {
+      if (el.id && el.textContent) {
+        extracted.push({
+          id: el.id,
+          text: el.textContent.trim(),
+          level: el.tagName === 'H2' ? 2 : 3,
+        });
+      }
+    }
+    headings = extracted;
+
+    if (headings.length < 3) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            activeId = entry.target.id;
+          }
+        }
+      },
+      { rootMargin: '-80px 0px -70% 0px' }
+    );
+
+    for (const el of elements) {
+      if (el.id) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  });
+
+  function scrollToHeading(id: string) {
+    const el = document.getElementById(id);
+    if (!el) return;
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+    isExpanded = false;
+  }
+</script>
+
+{#if headings.length >= 3}
+  <aside class="toc" aria-label="Table of contents">
+    <button
+      class="toc-toggle"
+      onclick={() => isExpanded = !isExpanded}
+      aria-expanded={isExpanded}
+    >
+      <span class="toc-toggle-label">On this page</span>
+      <svg
+        class="toc-toggle-icon"
+        class:rotated={isExpanded}
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg>
+    </button>
+
+    <nav class="toc-nav" class:expanded={isExpanded}>
+      <h2 class="toc-heading">On this page</h2>
+      <ol class="toc-list">
+        {#each headings as heading}
+          <li class="toc-item" class:indent={heading.level === 3}>
+            <button
+              class="toc-link"
+              class:active={activeId === heading.id}
+              onclick={() => scrollToHeading(heading.id)}
+            >
+              {heading.text}
+            </button>
+          </li>
+        {/each}
+      </ol>
+    </nav>
+  </aside>
+{/if}
+
+<style>
+  .toc {
+    margin-bottom: 2rem;
+    border: 1px solid var(--colour-border);
+    border-radius: 8px;
+    background: var(--colour-bg-secondary);
+    overflow: hidden;
+  }
+
+  /* Mobile: collapsible */
+  .toc-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--colour-text-primary);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    font-family: var(--font-sans);
+  }
+
+  .toc-toggle-icon {
+    transition: transform var(--transition-fast);
+  }
+
+  .toc-toggle-icon.rotated {
+    transform: rotate(180deg);
+  }
+
+  .toc-nav {
+    display: none;
+    padding: 0 1rem 0.75rem;
+  }
+
+  .toc-nav.expanded {
+    display: block;
+  }
+
+  .toc-heading {
+    display: none;
+  }
+
+  /* Desktop: always visible */
+  @media (min-width: 768px) {
+    .toc-toggle {
+      display: none;
+    }
+
+    .toc-nav {
+      display: block;
+      padding: 1rem;
+    }
+
+    .toc-heading {
+      display: block;
+      font-size: var(--text-sm);
+      font-weight: 600;
+      color: var(--colour-text-primary);
+      margin: 0 0 0.75rem;
+    }
+  }
+
+  .toc-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-item {
+    margin: 0;
+  }
+
+  .toc-item.indent {
+    padding-left: 1rem;
+  }
+
+  .toc-link {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.25rem 0.5rem;
+    border: none;
+    border-left: 2px solid transparent;
+    background: none;
+    cursor: pointer;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    transition: color var(--transition-fast), border-color var(--transition-fast);
+    line-height: 1.5;
+  }
+
+  .toc-link:hover {
+    color: var(--colour-text-primary);
+  }
+
+  .toc-link.active {
+    color: var(--colour-accent-primary);
+    border-left-color: var(--colour-accent-primary);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toc-toggle-icon {
+      transition: none;
+    }
+  }
+</style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -11,7 +11,7 @@ const { title, description } = Astro.props;
 
 <BaseLayout title={`${title} | gvns.ca`} description={description || title}>
   <slot name="head" slot="head" />
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" data-pagefind-body>
     <header class="page-header">
       <h1>{title}</h1>
     </header>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,6 +1,9 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import BaseLayout from './BaseLayout.astro';
+import Breadcrumb from '@components/Breadcrumb.astro';
+import ReadingProgress from '@components/ReadingProgress.svelte';
+import TableOfContents from '@components/TableOfContents.svelte';
 import TagList from '@components/TagList.astro';
 import { formatDate } from '@utils/date';
 import { getReadingTime } from '@utils/reading-time';
@@ -41,8 +44,14 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 <BaseLayout title={`${title} | gvns.ca`} description={description} image={heroImageUrl} imageWidth={heroImageWidth} imageHeight={heroImageHeight}>
   <script type="application/ld+json" set:html={articleJsonLd} slot="head" />
   <script type="application/ld+json" set:html={breadcrumbJsonLd} slot="head" />
-  <main id="main-content">
+  <ReadingProgress client:idle />
+  <main id="main-content" data-pagefind-body>
     <article class="post">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Write', href: '/write' },
+      { label: title },
+    ]} />
     <header class="post-header">
       <h1>{title}</h1>
       <div class="post-meta">
@@ -58,6 +67,8 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
       </div>
       <TagList tags={tags} />
     </header>
+
+    <TableOfContents client:idle />
 
     <div class="prose">
       <slot />

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,54 @@
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const siteUrl = (context.site || 'https://gvns.ca').toString().replace(/\/$/, '');
+
+  const posts = (await getCollection('writing'))
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+  const projects = await getCollection('work');
+
+  const getFilename = (slug: string) => {
+    const parts = slug.split('/');
+    return parts[parts.length - 1];
+  };
+
+  const writingLines = posts
+    .map((post) => `- [${post.data.title}](${siteUrl}/write/${getFilename(post.slug)}/): ${post.data.description}`)
+    .join('\n');
+
+  const workLines = projects
+    .map((project) => `- [${project.data.title}](${siteUrl}/work/${project.slug}/): ${project.data.description}`)
+    .join('\n');
+
+  const body = `# gvns.ca
+
+> Personal site of Gareth Evans — writing on software, design, and technology, plus a portfolio of work.
+
+## Writing
+
+${writingLines}
+
+## Work
+
+${workLines}
+
+## About
+
+- [About](${siteUrl}/about/): Background and contact info
+- [Resume](${siteUrl}/resume/): Professional experience
+
+## Optional
+
+- [Tags](${siteUrl}/write/tags/): Browse writing by topic
+- [Reading](${siteUrl}/read/): What I'm reading
+`;
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/src/pages/write/tags/[tag].astro
+++ b/src/pages/write/tags/[tag].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
+import Breadcrumb from '@components/Breadcrumb.astro';
 import PostCard from '@components/PostCard.astro';
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 
@@ -48,8 +49,13 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 >
   <script type="application/ld+json" set:html={breadcrumbJsonLd} slot="head" />
   <main id="main-content" class="tag-page">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Write', href: '/write' },
+      { label: 'Tags', href: '/write/tags' },
+      { label: tag },
+    ]} />
     <header>
-      <a href="/write/tags" class="back-link">&larr; All tags</a>
       <h1>Posts tagged: <span class="tag-name">{tag}</span></h1>
       <p class="count">{posts.length} post{posts.length !== 1 ? 's' : ''}</p>
     </header>
@@ -70,18 +76,6 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 
   header {
     margin-bottom: 2rem;
-  }
-
-  .back-link {
-    display: inline-block;
-    color: var(--colour-accent-primary);
-    text-decoration: none;
-    margin-bottom: 1rem;
-    transition: color var(--transition-fast);
-  }
-
-  .back-link:hover {
-    color: var(--colour-accent-hover);
   }
 
   h1 {


### PR DESCRIPTION
## Summary

Implements all 6 Phase 8 issues — writing enhancements with zero inter-issue conflicts:

- **#37** RSS feed autodiscovery `<link>` in `BaseHead.astro`
- **#103** Dynamic `/llms.txt` endpoint generated from content collections at build time
- **#42** Pagefind search with `Cmd/K` shortcut, styled dialog, dev-mode fallback
- **#43** Breadcrumb navigation on posts and tag pages with semantic HTML
- **#44** Reading progress bar (violet accent, 3px fixed top, respects `prefers-reduced-motion`)
- **#41** Table of contents with `IntersectionObserver` active-section highlighting, collapsible on mobile

### Additional changes
- `rehype-slug` configured for automatic heading IDs (TOC dependency)
- `data-pagefind-body` on `PostLayout` and `PageLayout` for targeted search indexing (6 content pages, not all 11)
- `client:idle` for ReadingProgress and TOC (non-critical islands)
- Rollup external config for Pagefind dynamic import

### New files
- `src/components/Breadcrumb.astro`
- `src/components/ReadingProgress.svelte`
- `src/components/Search.svelte`
- `src/components/TableOfContents.svelte`
- `src/pages/llms.txt.ts`

## Test plan
- [x] `npm run build` passes (11 pages built, Pagefind indexes 6 content pages)
- [ ] Visual: breadcrumbs render on `/write/hello-world/` and `/write/tags/meta/`
- [ ] Visual: reading progress bar fills on scroll through a post
- [ ] Visual: TOC renders and highlights active section (on posts with 3+ headings)
- [ ] Keyboard: `Cmd/K` opens search dialog, `Escape` closes
- [ ] Verify `/llms.txt` contains writing and work entries with absolute URLs
- [ ] Verify `/rss.xml` autodiscovery link in page source

Closes #37, #41, #42, #43, #44, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-page search modal with keyboard shortcut (Cmd/Ctrl+K).
  * Added reading progress indicator bar for posts.
  * Added collapsible table of contents for post navigation.
  * Added breadcrumb navigation for improved site traversal.
  * Added RSS feed autodiscovery link in page metadata.
  * Added new `/llms.txt` endpoint for LLM-friendly content discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->