### PR TITLE
feat: create /now dashboard page (#97)

### DIFF
--- a/src/components/widgets/CodeWidget.astro
+++ b/src/components/widgets/CodeWidget.astro
@@ -1,0 +1,60 @@
+---
+import { relativeTime } from '@utils/format';
+
+interface Commit {
+  repo: string;
+  message: string;
+  sha: string;
+  date: string;
+  url: string;
+}
+
+interface GitHubData {
+  lastUpdated: string | null;
+  recentCommits: Commit[];
+  stats: { commitsThisWeek: number; commitsThisMonth: number; repositoriesThisWeek: number };
+  repositories: { name: string; description: string; language: string; stars: number; url: string }[];
+}
+
+let data: GitHubData = { lastUpdated: null, recentCommits: [], stats: { commitsThisWeek: 0, commitsThisMonth: 0, repositoriesThisWeek: 0 }, repositories: [] };
+try {
+  data = (await import('../../data/github.json')).default as GitHubData;
+} catch { /* data unavailable */ }
+
+const latestCommit = data.recentCommits[0] ?? null;
+---
+
+<article class="gvns-widget gvns-widget--code">
+  <div class="gvns-widget__label">Code</div>
+  {latestCommit ? (
+    <div class="gvns-widget__content">
+      <p class="gvns-widget__repo">{latestCommit.repo}</p>
+      <p class="gvns-widget__detail">{latestCommit.message}</p>
+      <time class="gvns-widget__time" datetime={latestCommit.date}>
+        {relativeTime(latestCommit.date)}
+      </time>
+    </div>
+  ) : (
+    <p class="gvns-widget__empty">No recent commits.</p>
+  )}
+  <a href="/code" class="gvns-widget__link">
+    View Full Activity <span aria-hidden="true">&rarr;</span>
+  </a>
+</article>
+
+<style>
+  .gvns-widget--code {
+    border-left-color: var(--colour-p1-violet);
+  }
+
+  .gvns-widget--code .gvns-widget__link:hover {
+    color: var(--colour-p1-violet);
+  }
+
+  .gvns-widget__repo {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--colour-p1-violet);
+    margin: 0 0 var(--space-1) 0;
+  }
+</style>

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -1,0 +1,92 @@
+---
+import { relativeTime } from '@utils/format';
+
+interface Track {
+  name: string;
+  artist: string;
+  album?: string;
+  albumArtUrl?: string;
+  listenedAt?: string;
+}
+
+interface ListeningData {
+  lastUpdated: string | null;
+  recentTracks: Track[];
+  topArtists: { name: string; playCount: number; imageUrl?: string }[];
+  stats: { tracksToday: number; artistsToday: number };
+}
+
+let data: ListeningData = { lastUpdated: null, recentTracks: [], topArtists: [], stats: { tracksToday: 0, artistsToday: 0 } };
+try {
+  data = (await import('../../data/listening.json')).default as ListeningData;
+} catch { /* data unavailable */ }
+
+const latestTrack = data.recentTracks[0] ?? null;
+---
+
+<article class="gvns-widget gvns-widget--listen">
+  <div class="gvns-widget__label">Listen</div>
+  {latestTrack ? (
+    <div class="gvns-widget__content gvns-widget__content--row">
+      {latestTrack.albumArtUrl ? (
+        <img
+          src={latestTrack.albumArtUrl}
+          alt={`${latestTrack.album || latestTrack.name} album art`}
+          class="gvns-widget__art"
+          width="64"
+          height="64"
+          loading="lazy"
+          decoding="async"
+        />
+      ) : (
+        <div class="gvns-widget__art-placeholder" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="24" height="24"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+        </div>
+      )}
+      <div>
+        <p class="gvns-widget__detail gvns-widget__detail--bold">{latestTrack.name}</p>
+        <p class="gvns-widget__meta">{latestTrack.artist}</p>
+        {latestTrack.listenedAt && (
+          <time class="gvns-widget__time" datetime={latestTrack.listenedAt}>
+            {relativeTime(latestTrack.listenedAt)}
+          </time>
+        )}
+      </div>
+    </div>
+  ) : (
+    <p class="gvns-widget__empty">Nothing playing right now.</p>
+  )}
+  <a href="/listen" class="gvns-widget__link">
+    View Full Activity <span aria-hidden="true">&rarr;</span>
+  </a>
+</article>
+
+<style>
+  .gvns-widget--listen {
+    border-left-color: var(--colour-p3-emerald);
+  }
+
+  .gvns-widget--listen .gvns-widget__link:hover {
+    color: var(--colour-p3-emerald);
+  }
+
+  .gvns-widget__art {
+    width: 64px;
+    height: 64px;
+    border-radius: 6px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .gvns-widget__art-placeholder {
+    width: 64px;
+    height: 64px;
+    border-radius: 6px;
+    background: var(--colour-bg-tertiary);
+    color: var(--colour-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/components/widgets/ReadWidget.astro
+++ b/src/components/widgets/ReadWidget.astro
@@ -1,0 +1,88 @@
+---
+interface Book {
+  title: string;
+  author: string;
+  coverUrl?: string;
+  progress?: number;
+}
+
+interface ReadingData {
+  lastUpdated: string | null;
+  currentlyReading: Book[];
+  finished: Book[];
+  wantToRead: Book[];
+}
+
+let data: ReadingData = { lastUpdated: null, currentlyReading: [], finished: [], wantToRead: [] };
+try {
+  data = (await import('../../data/reading.json')).default as ReadingData;
+} catch { /* data unavailable */ }
+
+const currentBook = data.currentlyReading[0] ?? null;
+---
+
+<article class="gvns-widget gvns-widget--read">
+  <div class="gvns-widget__label">Read</div>
+  {currentBook ? (
+    <div class="gvns-widget__content gvns-widget__content--row">
+      {currentBook.coverUrl && (
+        <img
+          src={currentBook.coverUrl}
+          alt={`Cover of ${currentBook.title}`}
+          class="gvns-widget__cover"
+          width="64"
+          height="96"
+          loading="lazy"
+          decoding="async"
+        />
+      )}
+      <div>
+        <p class="gvns-widget__detail gvns-widget__detail--bold">{currentBook.title}</p>
+        <p class="gvns-widget__meta">{currentBook.author}</p>
+        {typeof currentBook.progress === 'number' && (
+          <div class="gvns-widget__progress">
+            <div class="gvns-widget__progress-bar" style={`width: ${currentBook.progress}%`} role="progressbar" aria-valuenow={currentBook.progress} aria-valuemin={0} aria-valuemax={100}>
+              <span class="sr-only">{currentBook.progress}% complete</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  ) : (
+    <p class="gvns-widget__empty">Nothing on the nightstand.</p>
+  )}
+  <a href="/read" class="gvns-widget__link">
+    View Full Activity <span aria-hidden="true">&rarr;</span>
+  </a>
+</article>
+
+<style>
+  .gvns-widget--read {
+    border-left-color: var(--colour-p2-rose);
+  }
+
+  .gvns-widget--read .gvns-widget__link:hover {
+    color: var(--colour-p2-rose);
+  }
+
+  .gvns-widget__cover {
+    border-radius: 4px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .gvns-widget__progress {
+    height: 4px;
+    background: var(--colour-bg-tertiary);
+    border-radius: 2px;
+    margin-top: var(--space-2);
+    overflow: hidden;
+  }
+
+  .gvns-widget__progress-bar {
+    height: 100%;
+    background: var(--colour-p2-rose);
+    border-radius: 2px;
+    transition: width var(--transition-base);
+  }
+</style>

--- a/src/components/widgets/ReadWidget.astro
+++ b/src/components/widgets/ReadWidget.astro
@@ -19,6 +19,9 @@ try {
 } catch { /* data unavailable */ }
 
 const currentBook = data.currentlyReading[0] ?? null;
+const progress = currentBook && typeof currentBook.progress === 'number'
+  ? Math.max(0, Math.min(100, currentBook.progress))
+  : null;
 ---
 
 <article class="gvns-widget gvns-widget--read">
@@ -39,10 +42,10 @@ const currentBook = data.currentlyReading[0] ?? null;
       <div>
         <p class="gvns-widget__detail gvns-widget__detail--bold">{currentBook.title}</p>
         <p class="gvns-widget__meta">{currentBook.author}</p>
-        {typeof currentBook.progress === 'number' && (
+        {progress !== null && (
           <div class="gvns-widget__progress">
-            <div class="gvns-widget__progress-bar" style={`width: ${currentBook.progress}%`} role="progressbar" aria-valuenow={currentBook.progress} aria-valuemin={0} aria-valuemax={100}>
-              <span class="sr-only">{currentBook.progress}% complete</span>
+            <div class="gvns-widget__progress-bar" style={`width: ${progress}%`} role="progressbar" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
+              <span class="sr-only">{progress}% complete</span>
             </div>
           </div>
         )}

--- a/src/components/widgets/StatusWidget.astro
+++ b/src/components/widgets/StatusWidget.astro
@@ -1,0 +1,40 @@
+---
+const status = 'Open to freelance work';
+const isActive = true;
+---
+
+<article class="gvns-widget gvns-widget--status">
+  <div class="gvns-widget__label">Status</div>
+  <div class="gvns-widget__content">
+    <div class="gvns-status__row">
+      {isActive && <span class="gvns-status__pulse" aria-hidden="true" />}
+      <p class="gvns-widget__detail gvns-widget__detail--bold">{status}</p>
+    </div>
+  </div>
+</article>
+
+<style>
+  .gvns-widget--status {
+    border-left-color: var(--colour-p5-sky);
+  }
+
+  .gvns-status__row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .gvns-status__pulse {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--colour-p5-sky);
+    flex-shrink: 0;
+    animation: gvns-pulse 2s ease-in-out infinite;
+  }
+
+  @keyframes gvns-pulse {
+    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(14, 165, 233, 0.4); }
+    50% { opacity: 0.7; box-shadow: 0 0 0 6px rgba(14, 165, 233, 0); }
+  }
+</style>

--- a/src/components/widgets/StatusWidget.astro
+++ b/src/components/widgets/StatusWidget.astro
@@ -34,7 +34,7 @@ const isActive = true;
   }
 
   @keyframes gvns-pulse {
-    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(14, 165, 233, 0.4); }
-    50% { opacity: 0.7; box-shadow: 0 0 0 6px rgba(14, 165, 233, 0); }
+    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--colour-p5-sky) 40%, transparent); }
+    50% { opacity: 0.7; box-shadow: 0 0 0 6px transparent; }
   }
 </style>

--- a/src/components/widgets/WatchWidget.astro
+++ b/src/components/widgets/WatchWidget.astro
@@ -1,0 +1,72 @@
+---
+import { relativeTime } from '@utils/format';
+
+interface WatchItem {
+  title: string;
+  type: string;
+  posterUrl?: string;
+  watchedAt?: string;
+}
+
+interface WatchingData {
+  lastUpdated: string | null;
+  recentlyWatched: WatchItem[];
+  stats: { moviesThisMonth: number; showsThisMonth: number };
+}
+
+let data: WatchingData = { lastUpdated: null, recentlyWatched: [], stats: { moviesThisMonth: 0, showsThisMonth: 0 } };
+try {
+  data = (await import('../../data/watching.json')).default as WatchingData;
+} catch { /* data unavailable */ }
+
+const latestWatch = data.recentlyWatched[0] ?? null;
+---
+
+<article class="gvns-widget gvns-widget--watch">
+  <div class="gvns-widget__label">Watch</div>
+  {latestWatch ? (
+    <div class="gvns-widget__content gvns-widget__content--row">
+      {latestWatch.posterUrl && (
+        <img
+          src={latestWatch.posterUrl}
+          alt={`Poster for ${latestWatch.title}`}
+          class="gvns-widget__poster"
+          width="48"
+          height="72"
+          loading="lazy"
+          decoding="async"
+        />
+      )}
+      <div>
+        <p class="gvns-widget__detail gvns-widget__detail--bold">{latestWatch.title}</p>
+        <p class="gvns-widget__meta">{latestWatch.type}</p>
+        {latestWatch.watchedAt && (
+          <time class="gvns-widget__time" datetime={latestWatch.watchedAt}>
+            {relativeTime(latestWatch.watchedAt)}
+          </time>
+        )}
+      </div>
+    </div>
+  ) : (
+    <p class="gvns-widget__empty">Nothing watched recently.</p>
+  )}
+  <a href="/watch" class="gvns-widget__link">
+    View Full Activity <span aria-hidden="true">&rarr;</span>
+  </a>
+</article>
+
+<style>
+  .gvns-widget--watch {
+    border-left-color: var(--colour-p4-amber);
+  }
+
+  .gvns-widget--watch .gvns-widget__link:hover {
+    color: var(--colour-p4-amber);
+  }
+
+  .gvns-widget__poster {
+    border-radius: 4px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/components/widgets/WriteWidget.astro
+++ b/src/components/widgets/WriteWidget.astro
@@ -1,0 +1,60 @@
+---
+import { getCollection } from 'astro:content';
+import { formatDate } from '@utils/date';
+
+const posts = (await getCollection('writing'))
+  .filter((p) => !p.data.draft)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+const latestPost = posts[0] ?? null;
+---
+
+<article class="gvns-widget gvns-widget--write">
+  <div class="gvns-widget__label">Write</div>
+  {latestPost ? (
+    <div class="gvns-widget__content">
+      <a href={`/write/${latestPost.slug}`} class="gvns-widget__post-link">
+        <p class="gvns-widget__detail gvns-widget__detail--bold">{latestPost.data.title}</p>
+      </a>
+      <time class="gvns-widget__time" datetime={latestPost.data.pubDate.toISOString()}>
+        {formatDate(latestPost.data.pubDate)}
+      </time>
+      <p class="gvns-widget__excerpt">{latestPost.data.description}</p>
+    </div>
+  ) : (
+    <p class="gvns-widget__empty">No posts yet.</p>
+  )}
+  <a href="/write" class="gvns-widget__link">
+    View Full Activity <span aria-hidden="true">&rarr;</span>
+  </a>
+</article>
+
+<style>
+  .gvns-widget--write {
+    border-left-color: var(--colour-p4-amber);
+  }
+
+  .gvns-widget--write .gvns-widget__link:hover {
+    color: var(--colour-p4-amber);
+  }
+
+  .gvns-widget__post-link {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .gvns-widget__post-link:hover .gvns-widget__detail {
+    color: var(--colour-p4-amber);
+  }
+
+  .gvns-widget__excerpt {
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    margin: var(--space-2) 0 0 0;
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/widgets/WriteWidget.astro
+++ b/src/components/widgets/WriteWidget.astro
@@ -54,6 +54,7 @@ const latestPost = posts[0] ?? null;
     line-height: 1.5;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -113,7 +113,8 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
   }
 
   .gvns-now__grid :global(.gvns-widget:hover) {
-    border-color: var(--colour-border);
+    border-color: var(--colour-text-muted);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
   }
 
   .gvns-now__grid :global(.gvns-widget__label) {

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -1,6 +1,13 @@
 ---
-import PageLayout from '@layouts/PageLayout.astro';
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Breadcrumb from '@components/Breadcrumb.astro';
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
+import CodeWidget from '@components/widgets/CodeWidget.astro';
+import ReadWidget from '@components/widgets/ReadWidget.astro';
+import ListenWidget from '@components/widgets/ListenWidget.astro';
+import WatchWidget from '@components/widgets/WatchWidget.astro';
+import WriteWidget from '@components/widgets/WriteWidget.astro';
+import StatusWidget from '@components/widgets/StatusWidget.astro';
 
 const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
@@ -9,16 +16,199 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 ]));
 ---
 
-<PageLayout
-  title="Now"
-  description="What I'm up to right now."
+<BaseLayout
+  title="Now | gvns.ca"
+  description="What I'm up to right now — code, reading, music, and more."
 >
   <script type="application/ld+json" set:html={breadcrumbJsonLd} slot="head" />
-  <p class="text-lg text-zinc-400 dark:text-zinc-300 leading-relaxed">
-    Dashboard coming soon. In the meantime, check out what I'm
-    <a href="/read" class="text-violet-500 dark:text-violet-400 no-underline transition-colors hover:text-violet-400 dark:hover:text-violet-300">reading</a>,
-    <a href="/listen" class="text-violet-500 dark:text-violet-400 no-underline transition-colors hover:text-violet-400 dark:hover:text-violet-300">listening to</a>,
-    <a href="/code" class="text-violet-500 dark:text-violet-400 no-underline transition-colors hover:text-violet-400 dark:hover:text-violet-300">coding</a>, and
-    <a href="/watch" class="text-violet-500 dark:text-violet-400 no-underline transition-colors hover:text-violet-400 dark:hover:text-violet-300">watching</a>.
-  </p>
-</PageLayout>
+
+  <main id="main-content" class="gvns-now" data-pagefind-body>
+    <div class="gvns-now__container">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Now' },
+      ]} />
+
+      <header class="gvns-now__header">
+        <h1>Now</h1>
+        <p class="gvns-now__subtitle">What I'm up to right now.</p>
+      </header>
+
+      <div class="gvns-now__grid">
+        <div class="gvns-now__cell gvns-now__cell--wide">
+          <CodeWidget />
+        </div>
+        <div class="gvns-now__cell">
+          <ReadWidget />
+        </div>
+        <div class="gvns-now__cell">
+          <ListenWidget />
+        </div>
+        <div class="gvns-now__cell">
+          <WatchWidget />
+        </div>
+        <div class="gvns-now__cell">
+          <WriteWidget />
+        </div>
+        <div class="gvns-now__cell">
+          <StatusWidget />
+        </div>
+      </div>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .gvns-now__container {
+    max-width: var(--width-wide);
+    margin-inline: auto;
+    padding-inline: var(--space-6);
+  }
+
+  .gvns-now__header {
+    margin-bottom: var(--space-10);
+  }
+
+  .gvns-now__header h1 {
+    font-size: var(--text-4xl);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin-bottom: var(--space-2);
+  }
+
+  .gvns-now__subtitle {
+    font-size: var(--text-lg);
+    color: var(--colour-text-secondary);
+    margin: 0;
+  }
+
+  /* Grid layout */
+  .gvns-now__grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: var(--space-6);
+  }
+
+  .gvns-now__cell {
+    grid-column: span 6;
+  }
+
+  .gvns-now__cell--wide {
+    grid-column: span 12;
+  }
+
+  /* Shared widget base styles (consumed by all widget components) */
+  .gvns-now__grid :global(.gvns-widget) {
+    background: var(--colour-bg-secondary);
+    border: 1px solid var(--colour-border);
+    border-left-width: 3px;
+    border-radius: 12px;
+    padding: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    height: 100%;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  }
+
+  .gvns-now__grid :global(.gvns-widget:hover) {
+    border-color: var(--colour-border);
+  }
+
+  .gvns-now__grid :global(.gvns-widget__label) {
+    font-size: var(--text-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--colour-text-muted);
+  }
+
+  .gvns-now__grid :global(.gvns-widget__content) {
+    flex: 1;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__content--row) {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-4);
+  }
+
+  .gvns-now__grid :global(.gvns-widget__detail) {
+    font-size: var(--text-base);
+    color: var(--colour-text-primary);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__detail--bold) {
+    font-weight: 600;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__meta) {
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    margin: var(--space-1) 0 0 0;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__time) {
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
+    color: var(--colour-text-muted);
+    margin: var(--space-1) 0 0 0;
+    display: block;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__empty) {
+    font-size: var(--text-sm);
+    color: var(--colour-text-muted);
+    font-style: italic;
+    margin: 0;
+    flex: 1;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__link) {
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+    margin-top: auto;
+  }
+
+  .gvns-now__grid :global(.gvns-widget__link span) {
+    display: inline-block;
+    transition: transform var(--transition-fast);
+  }
+
+  .gvns-now__grid :global(.gvns-widget__link:hover span) {
+    transform: translateX(3px);
+  }
+
+  .gvns-now__grid :global(.sr-only) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .gvns-now__grid {
+      grid-template-columns: 1fr;
+    }
+
+    .gvns-now__cell,
+    .gvns-now__cell--wide {
+      grid-column: span 1;
+    }
+
+    .gvns-now__header h1 {
+      font-size: var(--text-3xl);
+    }
+  }
+</style>


### PR DESCRIPTION
## **User description**
## Summary

- Build the Now dashboard page with 6 activity widget cards in a responsive 12-column grid
- **Code** (violet): latest GitHub commit with repo name, message, and relative timestamp
- **Read** (rose): currently reading book with cover thumbnail and progress bar
- **Listen** (emerald): latest track with album art placeholder and artist
- **Watch** (amber): latest watch with poster and type
- **Write** (amber): latest blog post from content collection with excerpt
- **Status** (sky): availability status with animated pulse indicator
- Each widget loads its own data, handles empty states gracefully, and links to its dedicated activity page
- Replaces the placeholder stub page from PR #105

## Test Plan

- [x] `npm run build` passes — `/now/index.html` generated
- [ ] Visit `/now` — verify all 6 widget cards render
- [ ] Verify colour discipline (each widget uses its assigned P1-P5 accent)
- [ ] Verify responsive layout (single column on mobile, grid on desktop)
- [ ] Verify empty states display correctly (data files are empty by default)
- [ ] Verify "View Full Activity →" links work for all widgets

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add Now dashboard with activity widgets for Code, Read, Listen, Watch, Write, and Status

### What Changed
- Replaces the placeholder Now page with a full dashboard that displays six activity widgets in a responsive grid (Code, Read, Listen, Watch, Write, Status); each widget shows the latest item and links to its full activity page
- Read widget shows a clamped progress bar (0–100%) when a current book has progress; Listen/Watch/Code/Write widgets show album art/poster/repo/post excerpt when available and friendly empty-state messages when not
- Widgets now have a visible hover border and shadow for clearer affordance; Status widget shows an animated pulse indicator using the theme color
- Page includes breadcrumb JSON‑LD and a page header for clearer navigation and discovery

### Impact
`✅ Faster discovery of recent activity`
`✅ Clearer availability status`
`✅ Easier navigation to full activity pages`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
