### PR TITLE
fix: address CodeAnt review feedback on Now dashboard widgets

### DIFF
--- a/src/components/widgets/CodeWidget.astro
+++ b/src/components/widgets/CodeWidget.astro
@@ -18,8 +18,18 @@ interface GitHubData {
 
 let data: GitHubData = { lastUpdated: null, recentCommits: [], stats: { commitsThisWeek: 0, commitsThisMonth: 0, repositoriesThisWeek: 0 }, repositories: [] };
 try {
-  data = (await import('../../data/github.json')).default as GitHubData;
-} catch { /* data unavailable */ }
+  const imported = (await import('../../data/github.json')).default as Partial<GitHubData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    recentCommits: Array.isArray(imported.recentCommits) ? imported.recentCommits : [],
+    stats: imported.stats && typeof imported.stats === 'object'
+      ? { commitsThisWeek: imported.stats.commitsThisWeek ?? 0, commitsThisMonth: imported.stats.commitsThisMonth ?? 0, repositoriesThisWeek: imported.stats.repositoriesThisWeek ?? 0 }
+      : { commitsThisWeek: 0, commitsThisMonth: 0, repositoriesThisWeek: 0 },
+    repositories: Array.isArray(imported.repositories) ? imported.repositories : [],
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load GitHub data for CodeWidget:', e);
+}
 
 const latestCommit = data.recentCommits[0] ?? null;
 ---

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { relativeTime } from '@utils/format';
+import { relativeTime, safeUrl } from '@utils/format';
 
 interface Track {
   name: string;
@@ -18,19 +18,30 @@ interface ListeningData {
 
 let data: ListeningData = { lastUpdated: null, recentTracks: [], topArtists: [], stats: { tracksToday: 0, artistsToday: 0 } };
 try {
-  data = (await import('../../data/listening.json')).default as ListeningData;
-} catch { /* data unavailable */ }
+  const imported = (await import('../../data/listening.json')).default as Partial<ListeningData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    recentTracks: Array.isArray(imported.recentTracks) ? imported.recentTracks : [],
+    topArtists: Array.isArray(imported.topArtists) ? imported.topArtists : [],
+    stats: imported.stats && typeof imported.stats === 'object'
+      ? { tracksToday: imported.stats.tracksToday ?? 0, artistsToday: imported.stats.artistsToday ?? 0 }
+      : { tracksToday: 0, artistsToday: 0 },
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load listening data for ListenWidget:', e);
+}
 
 const latestTrack = data.recentTracks[0] ?? null;
+const artSrc = safeUrl(latestTrack?.albumArtUrl);
 ---
 
 <article class="gvns-widget gvns-widget--listen">
   <div class="gvns-widget__label">Listen</div>
   {latestTrack ? (
     <div class="gvns-widget__content gvns-widget__content--row">
-      {latestTrack.albumArtUrl ? (
+      {artSrc ? (
         <img
-          src={latestTrack.albumArtUrl}
+          src={artSrc}
           alt={`${latestTrack.album || latestTrack.name} album art`}
           class="gvns-widget__art"
           width="64"

--- a/src/components/widgets/ReadWidget.astro
+++ b/src/components/widgets/ReadWidget.astro
@@ -1,4 +1,6 @@
 ---
+import { safeUrl } from '@utils/format';
+
 interface Book {
   title: string;
   author: string;
@@ -15,12 +17,22 @@ interface ReadingData {
 
 let data: ReadingData = { lastUpdated: null, currentlyReading: [], finished: [], wantToRead: [] };
 try {
-  data = (await import('../../data/reading.json')).default as ReadingData;
-} catch { /* data unavailable */ }
+  const imported = (await import('../../data/reading.json')).default as Partial<ReadingData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    currentlyReading: Array.isArray(imported.currentlyReading) ? imported.currentlyReading : [],
+    finished: Array.isArray(imported.finished) ? imported.finished : [],
+    wantToRead: Array.isArray(imported.wantToRead) ? imported.wantToRead : [],
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load reading data for ReadWidget:', e);
+}
 
 const currentBook = data.currentlyReading[0] ?? null;
-const progress = currentBook && typeof currentBook.progress === 'number'
-  ? Math.max(0, Math.min(100, currentBook.progress))
+const coverSrc = safeUrl(currentBook?.coverUrl);
+const rawProgress = currentBook?.progress;
+const progress = typeof rawProgress === 'number' && !Number.isNaN(rawProgress)
+  ? Math.max(0, Math.min(100, rawProgress))
   : null;
 ---
 
@@ -28,9 +40,9 @@ const progress = currentBook && typeof currentBook.progress === 'number'
   <div class="gvns-widget__label">Read</div>
   {currentBook ? (
     <div class="gvns-widget__content gvns-widget__content--row">
-      {currentBook.coverUrl && (
+      {coverSrc && (
         <img
-          src={currentBook.coverUrl}
+          src={coverSrc}
           alt={`Cover of ${currentBook.title}`}
           class="gvns-widget__cover"
           width="64"

--- a/src/components/widgets/WatchWidget.astro
+++ b/src/components/widgets/WatchWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { relativeTime } from '@utils/format';
+import { relativeTime, safeUrl } from '@utils/format';
 
 interface WatchItem {
   title: string;
@@ -16,19 +16,29 @@ interface WatchingData {
 
 let data: WatchingData = { lastUpdated: null, recentlyWatched: [], stats: { moviesThisMonth: 0, showsThisMonth: 0 } };
 try {
-  data = (await import('../../data/watching.json')).default as WatchingData;
-} catch { /* data unavailable */ }
+  const imported = (await import('../../data/watching.json')).default as Partial<WatchingData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    recentlyWatched: Array.isArray(imported.recentlyWatched) ? imported.recentlyWatched : [],
+    stats: imported.stats && typeof imported.stats === 'object'
+      ? { moviesThisMonth: imported.stats.moviesThisMonth ?? 0, showsThisMonth: imported.stats.showsThisMonth ?? 0 }
+      : { moviesThisMonth: 0, showsThisMonth: 0 },
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load watching data for WatchWidget:', e);
+}
 
 const latestWatch = data.recentlyWatched[0] ?? null;
+const posterSrc = safeUrl(latestWatch?.posterUrl);
 ---
 
 <article class="gvns-widget gvns-widget--watch">
   <div class="gvns-widget__label">Watch</div>
   {latestWatch ? (
     <div class="gvns-widget__content gvns-widget__content--row">
-      {latestWatch.posterUrl && (
+      {posterSrc && (
         <img
-          src={latestWatch.posterUrl}
+          src={posterSrc}
           alt={`Poster for ${latestWatch.title}`}
           class="gvns-widget__poster"
           width="48"

--- a/src/components/widgets/WriteWidget.astro
+++ b/src/components/widgets/WriteWidget.astro
@@ -3,17 +3,18 @@ import { getCollection } from 'astro:content';
 import { formatDate } from '@utils/date';
 
 const posts = (await getCollection('writing'))
-  .filter((p) => !p.data.draft)
+  .filter((p) => (import.meta.env.PROD ? !p.data.draft : true))
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
 const latestPost = posts[0] ?? null;
+const postSlug = latestPost?.slug.split('/').pop();
 ---
 
 <article class="gvns-widget gvns-widget--write">
   <div class="gvns-widget__label">Write</div>
   {latestPost ? (
     <div class="gvns-widget__content">
-      <a href={`/write/${latestPost.slug}`} class="gvns-widget__post-link">
+      <a href={`/write/${postSlug}`} class="gvns-widget__post-link">
         <p class="gvns-widget__detail gvns-widget__detail--bold">{latestPost.data.title}</p>
       </a>
       <time class="gvns-widget__time" datetime={latestPost.data.pubDate.toISOString()}>


### PR DESCRIPTION
## **User description**
## Summary

Addresses all actionable issues from CodeAnt's review of PR #107.

- **Defensive JSON parsing**: All 5 data-consuming widgets now validate imported JSON with `Array.isArray()` before indexing, matching the pattern established by `/read` page. Prevents runtime crashes from malformed data files.
- **DEV error logging**: Import failures now log to console in development mode for debuggability (previously silently swallowed).
- **URL sanitization**: External image URLs (`coverUrl`, `albumArtUrl`, `posterUrl`) are validated through `safeUrl()` which rejects non-http(s) protocols — defense-in-depth against data pipeline producing malformed URLs.
- **WriteWidget slug fix**: Strips nested folder path from content collection slug (e.g. `2024/12/hello-world` → `hello-world`), matching `PostCard.astro` and `[slug].astro` routing convention. Prevents 404s.
- **WriteWidget draft filter**: Uses `import.meta.env.PROD` conditional to show drafts in development, matching home page and `/write` listing behavior.
- **Progress bar NaN guard**: Adds `Number.isNaN()` check alongside existing `typeof` guard, since `typeof NaN === 'number'` would produce `width: NaN%`.

### CodeAnt issues intentionally not addressed

- **StatusWidget missing "View Full Activity" link**: No `/status` page exists. Adding a dead link is worse than omitting it.
- **WriteWidget pubDate assumption**: `pubDate` is a required field in the content schema (`z.coerce.date()`), so it always exists at build time.

## Test Plan

- [x] `npm run build` passes
- [ ] Visit `/now` — verify all widgets render correctly with empty data
- [ ] Verify Write widget links resolve correctly for nested content entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make Now widgets resilient to bad data, sanitize external images, and fix Write links

### What Changed
- Widgets that load local JSON (Code, Listen, Read, Watch, etc.) now validate imported data and fall back to safe defaults so malformed or missing JSON no longer causes widget failures; import errors are logged in development.
- External image URLs for track art, book covers, and posters are validated and rejected if unsafe, so only valid http(s) images are shown.
- The Write widget now shows drafts in development (matching the site listing) and uses the file's final path segment for post links so links to nested content resolve correctly.
- The Read widget's progress bar guards against NaN values so an invalid progress value won't render as "NaN%".

### Impact
`✅ Fewer widget crashes when data files are malformed`
`✅ Fewer broken or unsafe images shown in widgets`
`✅ No 404s from Write widget links for nested posts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
