### PR TITLE
feat: upgrade listen page to listenbrainz-github-action v1

### DIFF
--- a/.github/workflows/fetch-listening.yml
+++ b/.github/workflows/fetch-listening.yml
@@ -31,6 +31,16 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/data/listening.json
           git diff --staged --quiet || git commit -m "chore: update listening data"
-          if ! git push 2>&1; then
-            echo "::warning::git push failed. Data committed locally but not pushed."
-          fi
+
+          MAX_RETRIES=3
+          for i in $(seq 1 $MAX_RETRIES); do
+            if git push 2>&1; then
+              echo "Push succeeded on attempt $i"
+              exit 0
+            fi
+            echo "::warning::git push failed (attempt $i/$MAX_RETRIES)"
+            sleep $((i * 5))
+          done
+
+          echo "::error::git push failed after $MAX_RETRIES attempts"
+          exit 1

--- a/.github/workflows/fetch-listening.yml
+++ b/.github/workflows/fetch-listening.yml
@@ -2,7 +2,7 @@ name: Fetch Listening Data
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '17 2 * * *'  # Daily at 02:17 UTC (off-peak)
   workflow_dispatch:
 
 permissions:
@@ -15,17 +15,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch ListenBrainz data
-        uses: ggfevans/listenbrainz-github-action@c3a1eaf
+        id: fetch
+        uses: ggfevans/listenbrainz-github-action@v1
         with:
+          username: ${{ secrets.LISTENBRAINZ_USERNAME }}
           output_path: src/data/listening.json
-        env:
-          LISTENBRAINZ_USERNAME: ${{ secrets.LISTENBRAINZ_USERNAME }}
-        continue-on-error: true
+          stats_range: this_month
+          top_count: '10'
+          recent_count: '10'
 
       - name: Commit and push if changed
+        if: steps.fetch.outcome == 'success' && hashFiles('src/data/listening.json') != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/data/listening.json
           git diff --staged --quiet || git commit -m "chore: update listening data"
-          git push
+          if ! git push 2>&1; then
+            echo "::warning::git push failed. Data committed locally but not pushed."
+          fi

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { relativeTime } from '@utils/format';
+import { relativeTime, isValidMbid } from '@utils/format';
 
 interface Listen {
   track: string;
@@ -48,8 +48,8 @@ try {
   if (import.meta.env.DEV) console.error('Failed to load listening data for ListenWidget:', e);
 }
 
-const latestTrack = data.recentListens[0] ?? null;
-const artUrl = latestTrack?.caaReleaseMbid
+const latestTrack = data.recentListens?.[0] ?? null;
+const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
   ? `https://coverartarchive.org/release/${latestTrack.caaReleaseMbid}/front-250`
   : undefined;
 ---

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -1,48 +1,67 @@
 ---
-import { relativeTime, safeUrl } from '@utils/format';
+import { relativeTime } from '@utils/format';
 
-interface Track {
-  name: string;
+interface Listen {
+  track: string;
   artist: string;
   album?: string;
-  albumArtUrl?: string;
   listenedAt?: string;
+  caaReleaseMbid?: string | null;
+  caaId?: number | null;
+  recordingMbid?: string | null;
+  artistMbids?: string[];
 }
+
+type SectionStatus = 'ok' | 'no_data' | 'error';
 
 interface ListeningData {
   lastUpdated: string | null;
-  recentTracks: Track[];
-  topArtists: { name: string; playCount: number; imageUrl?: string }[];
-  stats: { tracksToday: number; artistsToday: number };
+  recentListens: Listen[];
+  recentListensStatus: SectionStatus;
+  topArtists: { name: string; listenCount: number; artistMbid?: string | null }[];
+  topArtistsStatus: SectionStatus;
+  topTracks: { track: string; artist: string; listenCount: number; caaReleaseMbid?: string | null; caaId?: number | null; recordingMbid?: string | null }[];
+  topTracksStatus: SectionStatus;
+  topAlbums: { album: string; artist: string; listenCount: number; caaReleaseMbid?: string | null; caaId?: number | null }[];
+  topAlbumsStatus: SectionStatus;
+  stats: { totalListenCount: number | null; range: string; artistCount: number | null; albumCount: number | null; trackCount: number | null };
 }
 
-let data: ListeningData = { lastUpdated: null, recentTracks: [], topArtists: [], stats: { tracksToday: 0, artistsToday: 0 } };
+const emptyData: ListeningData = {
+  lastUpdated: null,
+  recentListens: [],
+  recentListensStatus: 'ok',
+  topArtists: [],
+  topArtistsStatus: 'ok',
+  topTracks: [],
+  topTracksStatus: 'ok',
+  topAlbums: [],
+  topAlbumsStatus: 'ok',
+  stats: { totalListenCount: null, range: 'this_month', artistCount: null, albumCount: null, trackCount: null },
+};
+
+let data: ListeningData = emptyData;
 try {
   const imported = (await import('../../data/listening.json')).default as Partial<ListeningData>;
-  data = {
-    lastUpdated: imported.lastUpdated ?? null,
-    recentTracks: Array.isArray(imported.recentTracks) ? imported.recentTracks : [],
-    topArtists: Array.isArray(imported.topArtists) ? imported.topArtists : [],
-    stats: imported.stats && typeof imported.stats === 'object'
-      ? { tracksToday: imported.stats.tracksToday ?? 0, artistsToday: imported.stats.artistsToday ?? 0 }
-      : { tracksToday: 0, artistsToday: 0 },
-  };
+  data = { ...emptyData, ...imported };
 } catch (e) {
   if (import.meta.env.DEV) console.error('Failed to load listening data for ListenWidget:', e);
 }
 
-const latestTrack = data.recentTracks[0] ?? null;
-const artSrc = safeUrl(latestTrack?.albumArtUrl);
+const latestTrack = data.recentListens[0] ?? null;
+const artUrl = latestTrack?.caaReleaseMbid
+  ? `https://coverartarchive.org/release/${latestTrack.caaReleaseMbid}/front-250`
+  : undefined;
 ---
 
 <article class="gvns-widget gvns-widget--listen">
   <div class="gvns-widget__label">Listen</div>
   {latestTrack ? (
     <div class="gvns-widget__content gvns-widget__content--row">
-      {artSrc ? (
+      {artUrl ? (
         <img
-          src={artSrc}
-          alt={`${latestTrack.album || latestTrack.name} album art`}
+          src={artUrl}
+          alt={`${latestTrack.album || latestTrack.track} album art`}
           class="gvns-widget__art"
           width="64"
           height="64"
@@ -55,7 +74,7 @@ const artSrc = safeUrl(latestTrack?.albumArtUrl);
         </div>
       )}
       <div>
-        <p class="gvns-widget__detail gvns-widget__detail--bold">{latestTrack.name}</p>
+        <p class="gvns-widget__detail gvns-widget__detail--bold">{latestTrack.track}</p>
         <p class="gvns-widget__meta">{latestTrack.artist}</p>
         {latestTrack.listenedAt && (
           <time class="gvns-widget__time" datetime={latestTrack.listenedAt}>

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -43,7 +43,7 @@ const emptyData: ListeningData = {
 let data: ListeningData = emptyData;
 try {
   const imported = (await import('../../data/listening.json')).default as Partial<ListeningData>;
-  data = { ...emptyData, ...imported };
+  data = { ...emptyData, ...imported, stats: { ...emptyData.stats, ...(imported.stats || {}) } };
 } catch (e) {
   if (import.meta.env.DEV) console.error('Failed to load listening data for ListenWidget:', e);
 }

--- a/src/data/listening.json
+++ b/src/data/listening.json
@@ -1,9 +1,18 @@
 {
   "lastUpdated": null,
-  "recentTracks": [],
+  "recentListens": [],
+  "recentListensStatus": "ok",
   "topArtists": [],
+  "topArtistsStatus": "ok",
+  "topTracks": [],
+  "topTracksStatus": "ok",
+  "topAlbums": [],
+  "topAlbumsStatus": "ok",
   "stats": {
-    "tracksToday": 0,
-    "artistsToday": 0
+    "totalListenCount": null,
+    "range": "this_month",
+    "artistCount": null,
+    "albumCount": null,
+    "trackCount": null
   }
 }

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import Breadcrumb from '@components/Breadcrumb.astro';
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
-import { relativeTime } from '@utils/format';
+import { relativeTime, isValidMbid } from '@utils/format';
 
 interface Listen {
   track: string;
@@ -80,14 +80,14 @@ try {
   if (import.meta.env.DEV) console.error('Failed to load listening data:', e);
 }
 
-const hasData = listeningData.recentListens.length > 0
-  || listeningData.topArtists.length > 0
-  || listeningData.topTracks.length > 0
-  || listeningData.topAlbums.length > 0;
+const hasData = (listeningData.recentListens?.length ?? 0) > 0
+  || (listeningData.topArtists?.length ?? 0) > 0
+  || (listeningData.topTracks?.length ?? 0) > 0
+  || (listeningData.topAlbums?.length ?? 0) > 0;
 
 /** Construct a Cover Art Archive URL from a release MBID, or return undefined. */
 function coverArtUrl(mbid: string | null | undefined): string | undefined {
-  return mbid ? `https://coverartarchive.org/release/${mbid}/front-250` : undefined;
+  return isValidMbid(mbid) ? `https://coverartarchive.org/release/${mbid}/front-250` : undefined;
 }
 
 const siteUrl = normalizeSiteUrl(Astro.site);
@@ -129,49 +129,52 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
           )}
 
           {/* Recent listens */}
-          {listeningData.recentListens.length > 0 && listeningData.recentListensStatus === 'ok' && (
+          {listeningData.recentListens?.length > 0 && listeningData.recentListensStatus === 'ok' && (
             <section class="gvns-listen-section">
               <h2>Recent Listens</h2>
               <ul class="gvns-track-list">
-                {listeningData.recentListens.map((listen) => (
-                  <li class="gvns-track-item">
-                    <div class="gvns-track-art">
-                      {coverArtUrl(listen.caaReleaseMbid) ? (
-                        <img
-                          src={coverArtUrl(listen.caaReleaseMbid)}
-                          alt={`${listen.album || listen.track} album art`}
-                          width="48"
-                          height="48"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      ) : (
-                        <div class="gvns-track-art-placeholder" aria-hidden="true">
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
-                            <path d="M9 18V5l12-2v13" />
-                            <circle cx="6" cy="18" r="3" />
-                            <circle cx="18" cy="16" r="3" />
-                          </svg>
-                        </div>
+                {listeningData.recentListens.map((listen) => {
+                  const art = coverArtUrl(listen.caaReleaseMbid);
+                  return (
+                    <li class="gvns-track-item">
+                      <div class="gvns-track-art">
+                        {art ? (
+                          <img
+                            src={art}
+                            alt={`${listen.album || listen.track} album art`}
+                            width="48"
+                            height="48"
+                            loading="lazy"
+                            decoding="async"
+                          />
+                        ) : (
+                          <div class="gvns-track-art-placeholder" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
+                              <path d="M9 18V5l12-2v13" />
+                              <circle cx="6" cy="18" r="3" />
+                              <circle cx="18" cy="16" r="3" />
+                            </svg>
+                          </div>
+                        )}
+                      </div>
+                      <div class="gvns-track-info">
+                        <span class="gvns-track-name">{listen.track}</span>
+                        <span class="gvns-track-artist">{listen.artist}</span>
+                      </div>
+                      {listen.listenedAt && (
+                        <time class="gvns-track-time" datetime={listen.listenedAt}>
+                          {relativeTime(listen.listenedAt)}
+                        </time>
                       )}
-                    </div>
-                    <div class="gvns-track-info">
-                      <span class="gvns-track-name">{listen.track}</span>
-                      <span class="gvns-track-artist">{listen.artist}</span>
-                    </div>
-                    {listen.listenedAt && (
-                      <time class="gvns-track-time" datetime={listen.listenedAt}>
-                        {relativeTime(listen.listenedAt)}
-                      </time>
-                    )}
-                  </li>
-                ))}
+                    </li>
+                  );
+                })}
               </ul>
             </section>
           )}
 
           {/* Top artists */}
-          {listeningData.topArtists.length > 0 && listeningData.topArtistsStatus === 'ok' && (
+          {listeningData.topArtists?.length > 0 && listeningData.topArtistsStatus === 'ok' && (
             <section class="gvns-listen-section">
               <h2>Top Artists</h2>
               <div class="gvns-artist-grid">
@@ -196,78 +199,84 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
           )}
 
           {/* Top tracks */}
-          {listeningData.topTracks.length > 0 && listeningData.topTracksStatus === 'ok' && (
+          {listeningData.topTracks?.length > 0 && listeningData.topTracksStatus === 'ok' && (
             <section class="gvns-listen-section">
               <h2>Top Tracks</h2>
               <ul class="gvns-track-list">
-                {listeningData.topTracks.map((track) => (
-                  <li class="gvns-track-item">
-                    <div class="gvns-track-art">
-                      {coverArtUrl(track.caaReleaseMbid) ? (
-                        <img
-                          src={coverArtUrl(track.caaReleaseMbid)}
-                          alt={`${track.track} album art`}
-                          width="48"
-                          height="48"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      ) : (
-                        <div class="gvns-track-art-placeholder" aria-hidden="true">
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
-                            <path d="M9 18V5l12-2v13" />
-                            <circle cx="6" cy="18" r="3" />
-                            <circle cx="18" cy="16" r="3" />
-                          </svg>
-                        </div>
-                      )}
-                    </div>
-                    <div class="gvns-track-info">
-                      <span class="gvns-track-name">{track.track}</span>
-                      <span class="gvns-track-artist">{track.artist}</span>
-                    </div>
-                    <span class="gvns-track-time">{track.listenCount} plays</span>
-                  </li>
-                ))}
+                {listeningData.topTracks.map((track) => {
+                  const art = coverArtUrl(track.caaReleaseMbid);
+                  return (
+                    <li class="gvns-track-item">
+                      <div class="gvns-track-art">
+                        {art ? (
+                          <img
+                            src={art}
+                            alt={`${track.track} album art`}
+                            width="48"
+                            height="48"
+                            loading="lazy"
+                            decoding="async"
+                          />
+                        ) : (
+                          <div class="gvns-track-art-placeholder" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
+                              <path d="M9 18V5l12-2v13" />
+                              <circle cx="6" cy="18" r="3" />
+                              <circle cx="18" cy="16" r="3" />
+                            </svg>
+                          </div>
+                        )}
+                      </div>
+                      <div class="gvns-track-info">
+                        <span class="gvns-track-name">{track.track}</span>
+                        <span class="gvns-track-artist">{track.artist}</span>
+                      </div>
+                      <span class="gvns-track-time">{track.listenCount} plays</span>
+                    </li>
+                  );
+                })}
               </ul>
             </section>
           )}
 
           {/* Top albums */}
-          {listeningData.topAlbums.length > 0 && listeningData.topAlbumsStatus === 'ok' && (
+          {listeningData.topAlbums?.length > 0 && listeningData.topAlbumsStatus === 'ok' && (
             <section class="gvns-listen-section">
               <h2>Top Albums</h2>
               <div class="gvns-artist-grid">
-                {listeningData.topAlbums.map((album) => (
-                  <div class="gvns-artist-card">
-                    <div class="gvns-artist-image">
-                      {coverArtUrl(album.caaReleaseMbid) ? (
-                        <img
-                          src={coverArtUrl(album.caaReleaseMbid)}
-                          alt={`${album.album} cover art`}
-                          class="gvns-artist-image--square"
-                          width="64"
-                          height="64"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      ) : (
-                        <div class="gvns-artist-image-placeholder" aria-hidden="true">
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="28" height="28">
-                            <path d="M9 18V5l12-2v13" />
-                            <circle cx="6" cy="18" r="3" />
-                            <circle cx="18" cy="16" r="3" />
-                          </svg>
-                        </div>
-                      )}
+                {listeningData.topAlbums.map((album) => {
+                  const art = coverArtUrl(album.caaReleaseMbid);
+                  return (
+                    <div class="gvns-artist-card">
+                      <div class="gvns-artist-image">
+                        {art ? (
+                          <img
+                            src={art}
+                            alt={`${album.album} cover art`}
+                            class="gvns-artist-image--square"
+                            width="64"
+                            height="64"
+                            loading="lazy"
+                            decoding="async"
+                          />
+                        ) : (
+                          <div class="gvns-artist-image-placeholder" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="28" height="28">
+                              <path d="M9 18V5l12-2v13" />
+                              <circle cx="6" cy="18" r="3" />
+                              <circle cx="18" cy="16" r="3" />
+                            </svg>
+                          </div>
+                        )}
+                      </div>
+                      <div class="gvns-artist-info">
+                        <span class="gvns-artist-name">{album.album}</span>
+                        <span class="gvns-track-artist">{album.artist}</span>
+                        <span class="gvns-artist-plays">{album.listenCount} plays</span>
+                      </div>
                     </div>
-                    <div class="gvns-artist-info">
-                      <span class="gvns-artist-name">{album.album}</span>
-                      <span class="gvns-track-artist">{album.artist}</span>
-                      <span class="gvns-artist-plays">{album.listenCount} plays</span>
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </section>
           )}

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -74,7 +74,8 @@ const emptyData: ListeningData = {
 
 let listeningData: ListeningData = emptyData;
 try {
-  listeningData = { ...emptyData, ...(await import('../../data/listening.json')).default as Partial<ListeningData> };
+  const imported = (await import('../../data/listening.json')).default as Partial<ListeningData>;
+  listeningData = { ...emptyData, ...imported, stats: { ...emptyData.stats, ...(imported.stats || {}) } };
 } catch (e) {
   if (import.meta.env.DEV) console.error('Failed to load listening data:', e);
 }
@@ -244,11 +245,11 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
                         <img
                           src={coverArtUrl(album.caaReleaseMbid)}
                           alt={`${album.album} cover art`}
+                          class="gvns-artist-image--square"
                           width="64"
                           height="64"
                           loading="lazy"
                           decoding="async"
-                          style="border-radius: 6px;"
                         />
                       ) : (
                         <div class="gvns-artist-image-placeholder" aria-hidden="true">
@@ -474,6 +475,10 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 
   .gvns-artist-image img {
     object-fit: cover;
+  }
+
+  .gvns-artist-image--square {
+    border-radius: 6px;
   }
 
   .gvns-artist-image-placeholder {

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -4,35 +4,90 @@ import Breadcrumb from '@components/Breadcrumb.astro';
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 import { relativeTime } from '@utils/format';
 
-interface Track {
-  name: string;
+interface Listen {
+  track: string;
   artist: string;
   album?: string;
-  albumArtUrl?: string;
   listenedAt?: string;
+  caaReleaseMbid?: string | null;
+  caaId?: number | null;
+  recordingMbid?: string | null;
+  artistMbids?: string[];
 }
 
-interface Artist {
+interface TopArtist {
   name: string;
-  playCount: number;
-  imageUrl?: string;
+  listenCount: number;
+  artistMbid?: string | null;
 }
+
+interface TopTrack {
+  track: string;
+  artist: string;
+  listenCount: number;
+  caaReleaseMbid?: string | null;
+  caaId?: number | null;
+  recordingMbid?: string | null;
+}
+
+interface TopAlbum {
+  album: string;
+  artist: string;
+  listenCount: number;
+  caaReleaseMbid?: string | null;
+  caaId?: number | null;
+}
+
+type SectionStatus = 'ok' | 'no_data' | 'error';
 
 interface ListeningData {
   lastUpdated: string | null;
-  recentTracks: Track[];
-  topArtists: Artist[];
-  stats: { tracksToday: number; artistsToday: number };
+  recentListens: Listen[];
+  recentListensStatus: SectionStatus;
+  topArtists: TopArtist[];
+  topArtistsStatus: SectionStatus;
+  topTracks: TopTrack[];
+  topTracksStatus: SectionStatus;
+  topAlbums: TopAlbum[];
+  topAlbumsStatus: SectionStatus;
+  stats: {
+    totalListenCount: number | null;
+    range: string;
+    artistCount: number | null;
+    albumCount: number | null;
+    trackCount: number | null;
+  };
 }
 
-let listeningData: ListeningData = { lastUpdated: null, recentTracks: [], topArtists: [], stats: { tracksToday: 0, artistsToday: 0 } };
+const emptyData: ListeningData = {
+  lastUpdated: null,
+  recentListens: [],
+  recentListensStatus: 'ok',
+  topArtists: [],
+  topArtistsStatus: 'ok',
+  topTracks: [],
+  topTracksStatus: 'ok',
+  topAlbums: [],
+  topAlbumsStatus: 'ok',
+  stats: { totalListenCount: null, range: 'this_month', artistCount: null, albumCount: null, trackCount: null },
+};
+
+let listeningData: ListeningData = emptyData;
 try {
-  listeningData = (await import('../../data/listening.json')).default as ListeningData;
+  listeningData = { ...emptyData, ...(await import('../../data/listening.json')).default as Partial<ListeningData> };
 } catch (e) {
   if (import.meta.env.DEV) console.error('Failed to load listening data:', e);
 }
 
-const hasData = listeningData.recentTracks.length > 0 || listeningData.topArtists.length > 0;
+const hasData = listeningData.recentListens.length > 0
+  || listeningData.topArtists.length > 0
+  || listeningData.topTracks.length > 0
+  || listeningData.topAlbums.length > 0;
+
+/** Construct a Cover Art Archive URL from a release MBID, or return undefined. */
+function coverArtUrl(mbid: string | null | undefined): string | undefined {
+  return mbid ? `https://coverartarchive.org/release/${mbid}/front-250` : undefined;
+}
 
 const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
@@ -40,7 +95,6 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
   { name: 'Now', url: `${siteUrl}/now` },
   { name: 'Listen', url: `${siteUrl}/listen` },
 ]));
-
 ---
 
 <BaseLayout
@@ -65,27 +119,26 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
       {hasData ? (
         <div class="gvns-listen-content">
           {/* Stats bar */}
-          {(listeningData.stats.tracksToday > 0 || listeningData.stats.artistsToday > 0) && (
+          {listeningData.stats.totalListenCount != null && (
             <div class="gvns-stats-bar">
-              <span class="gvns-stats-accent">{listeningData.stats.tracksToday} tracks</span>
-              {' '}from{' '}
-              <span class="gvns-stats-accent">{listeningData.stats.artistsToday} artists</span>
-              {' '}today
+              <span class="gvns-stats-accent">{listeningData.stats.totalListenCount.toLocaleString()} listens</span>
+              {' \u00b7 '}
+              <span>{listeningData.stats.range.replace('_', ' ')}</span>
             </div>
           )}
 
-          {/* Recent tracks */}
-          {listeningData.recentTracks.length > 0 && (
+          {/* Recent listens */}
+          {listeningData.recentListens.length > 0 && listeningData.recentListensStatus === 'ok' && (
             <section class="gvns-listen-section">
-              <h2>Recent Tracks</h2>
+              <h2>Recent Listens</h2>
               <ul class="gvns-track-list">
-                {listeningData.recentTracks.map((track) => (
+                {listeningData.recentListens.map((listen) => (
                   <li class="gvns-track-item">
                     <div class="gvns-track-art">
-                      {track.albumArtUrl ? (
+                      {coverArtUrl(listen.caaReleaseMbid) ? (
                         <img
-                          src={track.albumArtUrl}
-                          alt={`${track.album || track.name} album art`}
+                          src={coverArtUrl(listen.caaReleaseMbid)}
+                          alt={`${listen.album || listen.track} album art`}
                           width="48"
                           height="48"
                           loading="lazy"
@@ -102,12 +155,12 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
                       )}
                     </div>
                     <div class="gvns-track-info">
-                      <span class="gvns-track-name">{track.name}</span>
-                      <span class="gvns-track-artist">{track.artist}</span>
+                      <span class="gvns-track-name">{listen.track}</span>
+                      <span class="gvns-track-artist">{listen.artist}</span>
                     </div>
-                    {track.listenedAt && (
-                      <time class="gvns-track-time" datetime={track.listenedAt}>
-                        {relativeTime(track.listenedAt)}
+                    {listen.listenedAt && (
+                      <time class="gvns-track-time" datetime={listen.listenedAt}>
+                        {relativeTime(listen.listenedAt)}
                       </time>
                     )}
                   </li>
@@ -117,34 +170,100 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
           )}
 
           {/* Top artists */}
-          {listeningData.topArtists.length > 0 && (
+          {listeningData.topArtists.length > 0 && listeningData.topArtistsStatus === 'ok' && (
             <section class="gvns-listen-section">
               <h2>Top Artists</h2>
               <div class="gvns-artist-grid">
                 {listeningData.topArtists.map((artist) => (
                   <div class="gvns-artist-card">
                     <div class="gvns-artist-image">
-                      {artist.imageUrl ? (
+                      <div class="gvns-artist-image-placeholder" aria-hidden="true">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="28" height="28">
+                          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                          <circle cx="12" cy="7" r="4" />
+                        </svg>
+                      </div>
+                    </div>
+                    <div class="gvns-artist-info">
+                      <span class="gvns-artist-name">{artist.name}</span>
+                      <span class="gvns-artist-plays">{artist.listenCount} plays</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Top tracks */}
+          {listeningData.topTracks.length > 0 && listeningData.topTracksStatus === 'ok' && (
+            <section class="gvns-listen-section">
+              <h2>Top Tracks</h2>
+              <ul class="gvns-track-list">
+                {listeningData.topTracks.map((track) => (
+                  <li class="gvns-track-item">
+                    <div class="gvns-track-art">
+                      {coverArtUrl(track.caaReleaseMbid) ? (
                         <img
-                          src={artist.imageUrl}
-                          alt={artist.name}
-                          width="64"
-                          height="64"
+                          src={coverArtUrl(track.caaReleaseMbid)}
+                          alt={`${track.track} album art`}
+                          width="48"
+                          height="48"
                           loading="lazy"
                           decoding="async"
                         />
                       ) : (
+                        <div class="gvns-track-art-placeholder" aria-hidden="true">
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
+                            <path d="M9 18V5l12-2v13" />
+                            <circle cx="6" cy="18" r="3" />
+                            <circle cx="18" cy="16" r="3" />
+                          </svg>
+                        </div>
+                      )}
+                    </div>
+                    <div class="gvns-track-info">
+                      <span class="gvns-track-name">{track.track}</span>
+                      <span class="gvns-track-artist">{track.artist}</span>
+                    </div>
+                    <span class="gvns-track-time">{track.listenCount} plays</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* Top albums */}
+          {listeningData.topAlbums.length > 0 && listeningData.topAlbumsStatus === 'ok' && (
+            <section class="gvns-listen-section">
+              <h2>Top Albums</h2>
+              <div class="gvns-artist-grid">
+                {listeningData.topAlbums.map((album) => (
+                  <div class="gvns-artist-card">
+                    <div class="gvns-artist-image">
+                      {coverArtUrl(album.caaReleaseMbid) ? (
+                        <img
+                          src={coverArtUrl(album.caaReleaseMbid)}
+                          alt={`${album.album} cover art`}
+                          width="64"
+                          height="64"
+                          loading="lazy"
+                          decoding="async"
+                          style="border-radius: 6px;"
+                        />
+                      ) : (
                         <div class="gvns-artist-image-placeholder" aria-hidden="true">
                           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="28" height="28">
-                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-                            <circle cx="12" cy="7" r="4" />
+                            <path d="M9 18V5l12-2v13" />
+                            <circle cx="6" cy="18" r="3" />
+                            <circle cx="18" cy="16" r="3" />
                           </svg>
                         </div>
                       )}
                     </div>
                     <div class="gvns-artist-info">
-                      <span class="gvns-artist-name">{artist.name}</span>
-                      <span class="gvns-artist-plays">{artist.playCount} plays</span>
+                      <span class="gvns-artist-name">{album.album}</span>
+                      <span class="gvns-track-artist">{album.artist}</span>
+                      <span class="gvns-artist-plays">{album.listenCount} plays</span>
                     </div>
                   </div>
                 ))}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -32,6 +32,12 @@ export function truncate(str: string, max: number): string {
   return str.slice(0, max).trimEnd() + '\u2026';
 }
 
+/** Validate a MusicBrainz ID (standard UUID format). */
+const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export function isValidMbid(id: string | null | undefined): id is string {
+  return typeof id === 'string' && MBID_RE.test(id);
+}
+
 /** Validate a URL is safe to use as an href (http/https only). Returns undefined for invalid URLs. */
 export function safeUrl(url: string | undefined | null): string | undefined {
   if (!url) return undefined;


### PR DESCRIPTION
## **User description**
## Summary
- Upgrade `fetch-listening.yml` to use `ggfevans/listenbrainz-github-action@v1`
- Update `/listen` page to consume v1 JSON schema with top tracks and top albums sections
- Update `ListenWidget` for `/now` dashboard compatibility
- Add push-failure handling and step outcome gating to workflow

## Changes
- **Workflow**: `@c3a1eaf` → `@v1` with `username` input, `stats_range: this_month`, `top_count: 10`, `recent_count: 10`
- **Listen page**: New sections for top tracks and top albums; cover art from CoverArtArchive MBIDs; per-section status handling; updated stats bar
- **ListenWidget**: Updated interfaces and cover art URL construction from `caaReleaseMbid`
- **Placeholder JSON**: Updated to match v1 schema

## Test plan
- [x] `npm run build` passes
- [ ] `/listen` renders empty state correctly (verify in preview deploy)
- [ ] `/now` ListenWidget renders correctly
- [ ] Trigger workflow manually after merge to verify end-to-end data flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Upgrade Listen page and data workflow to ListenBrainz v1 with top tracks/albums and cover art

### What Changed
- GitHub workflow now uses ggfevans/listenbrainz-github-action@v1, runs daily at 02:17 UTC, requests this_month stats and up to 10 top/recent items, and commits updates without failing the workflow if git push fails
- /listen page and ListenWidget now consume the v1 JSON schema (recentListens, topArtists, topTracks, topAlbums) and show per-section status; stats bar reports total listens and the selected range
- Top Tracks and Top Albums sections were added to the Listen page; cover art is fetched from CoverArtArchive when a release MBID is present; placeholders shown when art is missing
- Placeholder listening.json updated to match the v1 schema so the site renders correctly when no data is present

### Impact
`✅ Daily data fetch runs at off-peak time`
`✅ Show top tracks and top albums on Listen page`
`✅ Fewer blocked deploys when workflow push fails`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent Tracks renamed to Recent Listens with richer listen metadata.
  * Added Top Tracks and Top Albums sections with optional cover art.
  * Stats bar now shows total listens and selected range.

* **Improvements**
  * Section-level status indicators for recent listens, top artists, top tracks and albums.
  * Better cover-art fallbacks, placeholder visuals and square art styling.
  * Improved data refresh scheduling and more resilient sync handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->