### PR TITLE
fix: harden reading and github data-fetching workflows

### DIFF
--- a/.github/workflows/fetch-github.yml
+++ b/.github/workflows/fetch-github.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Fetch GitHub activity
         id: fetch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -56,7 +56,7 @@ jobs:
             | select(.type == "PushEvent")
             | .created_at as $date
             | .repo.name as $repo
-            | .payload.commits[]
+            | (.payload.commits // [])[]
             | {
                 repo: ($repo | split("/") | last),
                 message: (.message | split("\n") | first),
@@ -94,7 +94,7 @@ jobs:
 
           REPOSITORIES=$(echo "$REPOS" | jq '[
             .[]
-            | select(.fork == false and .archived == false)
+            | select((.fork // false) == false and (.archived // false) == false)
             | {
                 name: .name,
                 description: (.description // ""),

--- a/.github/workflows/fetch-reading.yml
+++ b/.github/workflows/fetch-reading.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch Hardcover data
+        id: fetch
         env:
           HARDCOVER_TOKEN: ${{ secrets.HARDCOVER_TOKEN }}
           HARDCOVER_USER_ID: ${{ secrets.HARDCOVER_USER_ID }}
@@ -71,6 +72,7 @@ jobs:
           if echo "$RESPONSE" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: GraphQL errors from Hardcover API"
             echo "$RESPONSE" | jq -r '.errors[].message' 2>/dev/null
+            echo "Full error details: $(echo "$RESPONSE" | jq '.errors' 2>/dev/null)"
             exit 1
           fi
 
@@ -128,9 +130,26 @@ jobs:
           }'
 
       - name: Commit and push if changed
+        if: steps.fetch.outcome == 'success' && hashFiles('src/data/reading.json') != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/data/reading.json
-          git diff --staged --quiet || git commit -m "chore: update reading data"
-          git push
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update reading data"
+
+            MAX_RETRIES=3
+            for i in $(seq 1 $MAX_RETRIES); do
+              if git push 2>&1; then
+                echo "Push succeeded on attempt $i"
+                exit 0
+              fi
+              echo "::warning::git push failed (attempt $i/$MAX_RETRIES)"
+              sleep $((i * 5))
+            done
+
+            echo "::error::git push failed after $MAX_RETRIES attempts"
+            exit 1
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
## **User description**
## Summary
- **Reading workflow (#121):** Added full error diagnostics for GraphQL failures, added `id: fetch` for step outcome gating, hardened push step with retry logic matching the listening workflow pattern
- **GitHub workflow (#122):** Fixed `jq: Cannot iterate over null` crash by null-coalescing `.payload.commits`, switched to `GH_PAT` for correct event attribution, added null safety to repo filter

## Context
- Listen workflow (#119) needs no code changes — secret was misconfigured, now fixed
- Watch workflow (#120) is an enhancement for later

Closes #121, closes #122

## Test plan
- [ ] PR build passes
- [ ] After merge, manually trigger `fetch-reading.yml` — verify `src/data/reading.json` populated
- [ ] After merge, manually trigger `fetch-github.yml` — verify `src/data/github.json` populated
- [ ] After merge, manually trigger `fetch-listening.yml` — verify `src/data/listening.json` populated (closes #119)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Harden reading and GitHub data-fetching workflows for reliable runs and clearer errors

### What Changed
- Reading fetch now exposes full GraphQL error details when the Hardcover API returns errors, and the workflow step has an outcome id so later steps only run if fetch succeeded
- Commit/push step in the reading workflow only runs when the fetch succeeded and the data file changed; pushes are retried up to 3 times with backoff and the job fails only after retries
- GitHub fetch uses a personal access token when available, treats missing commit lists as empty to avoid crashes, and treats fork/archived flags as potentially absent so repo listing won't fail

### Impact
`✅ Clearer error diagnostics when reading fetch fails`
`✅ Fewer failed or noisy push attempts from CI`
`✅ Fewer workflow crashes and more complete GitHub activity data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of automated data synchronization with enhanced error handling and retry mechanisms.
  * Strengthened data filtering for greater accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->