### PR TITLE
fix: use Compare API for commits after Events API payload change

### DIFF
--- a/.github/workflows/fetch-github.yml
+++ b/.github/workflows/fetch-github.yml
@@ -84,7 +84,7 @@ jobs:
                   repo: ($repo | split("/") | last),
                   message: (.commit.message | split("\n") | first),
                   sha: .sha,
-                  date: $date,
+                  date: ((.commit.author.date // .commit.committer.date // $date) | if . == "" then $date else . end),
                   url: .html_url
                 }
             ]' 2>/dev/null) || continue

--- a/.github/workflows/fetch-github.yml
+++ b/.github/workflows/fetch-github.yml
@@ -50,21 +50,49 @@ jobs:
             echo "::warning::No events fetched — output will be sparse"
           fi
 
-          # Extract PushEvent commits with metadata
-          ALL_COMMITS=$(echo "$EVENTS" | jq '[
+          # Extract PushEvent before/head pairs (API no longer includes commits in payload)
+          PUSHES=$(echo "$EVENTS" | jq -c '[
             .[]
-            | select(.type == "PushEvent")
-            | .created_at as $date
-            | .repo.name as $repo
-            | (.payload.commits // [])[]
+            | select(.type == "PushEvent" and .payload.before != null and .payload.head != null)
             | {
-                repo: ($repo | split("/") | last),
-                message: (.message | split("\n") | first),
-                sha: .sha,
-                date: $date,
-                url: ("https://github.com/" + $repo + "/commit/" + .sha)
+                repo: .repo.name,
+                before: .payload.before,
+                head: .payload.head,
+                date: .created_at
               }
-          ] | unique_by(.sha) | sort_by(.date) | reverse')
+          ] | unique_by(.head)')
+
+          # Fetch actual commits via Compare API for each push
+          ALL_COMMITS="[]"
+          for PUSH in $(echo "$PUSHES" | jq -c '.[]'); do
+            REPO=$(echo "$PUSH" | jq -r '.repo')
+            BEFORE=$(echo "$PUSH" | jq -r '.before')
+            HEAD=$(echo "$PUSH" | jq -r '.head')
+            DATE=$(echo "$PUSH" | jq -r '.date')
+
+            COMPARE=$(curl -sf \
+              --connect-timeout 10 \
+              --max-time 30 \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/compare/${BEFORE}...${HEAD}" \
+            ) || { echo "::warning::Failed to compare ${REPO} ${BEFORE}...${HEAD}"; continue; }
+
+            PUSH_COMMITS=$(echo "$COMPARE" | jq --arg repo "$REPO" --arg date "$DATE" '[
+              .commits[]
+              | {
+                  repo: ($repo | split("/") | last),
+                  message: (.commit.message | split("\n") | first),
+                  sha: .sha,
+                  date: $date,
+                  url: .html_url
+                }
+            ]' 2>/dev/null) || continue
+
+            ALL_COMMITS=$(echo "$ALL_COMMITS" "$PUSH_COMMITS" | jq -s '.[0] + .[1]')
+          done
+
+          ALL_COMMITS=$(echo "$ALL_COMMITS" | jq 'unique_by(.sha) | sort_by(.date) | reverse')
 
           RECENT_COMMITS=$(echo "$ALL_COMMITS" | jq '.[0:30]')
 

--- a/.github/workflows/fetch-github.yml
+++ b/.github/workflows/fetch-github.yml
@@ -139,11 +139,20 @@ jobs:
           git add src/data/github.json
           if ! git diff --staged --quiet; then
             git commit -m "chore: update github activity data"
-            if ! git push; then
-              echo "::error::git push failed (branch may be protected). Rolling back local commit."
-              git reset --soft HEAD~1
-              exit 1
-            fi
+
+            MAX_RETRIES=3
+            for i in $(seq 1 $MAX_RETRIES); do
+              git pull --rebase 2>&1 || true
+              if git push 2>&1; then
+                echo "Push succeeded on attempt $i"
+                exit 0
+              fi
+              echo "::warning::git push failed (attempt $i/$MAX_RETRIES)"
+              sleep $((i * 5))
+            done
+
+            echo "::error::git push failed after $MAX_RETRIES attempts"
+            exit 1
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/fetch-listening.yml
+++ b/.github/workflows/fetch-listening.yml
@@ -34,6 +34,7 @@ jobs:
 
           MAX_RETRIES=3
           for i in $(seq 1 $MAX_RETRIES); do
+            git pull --rebase 2>&1 || true
             if git push 2>&1; then
               echo "Push succeeded on attempt $i"
               exit 0

--- a/.github/workflows/fetch-reading.yml
+++ b/.github/workflows/fetch-reading.yml
@@ -35,7 +35,6 @@ jobs:
             ) {
               status_id
               rating
-              progress
               updated_at
               book {
                 title
@@ -94,8 +93,7 @@ jobs:
                   title: .book.title,
                   author: (.book.contributions[0].author.name // "Unknown"),
                   coverUrl: .book.image.url,
-                  hardcoverUrl: ("https://hardcover.app/books/" + .book.slug),
-                  progress: (.progress // 0)
+                  hardcoverUrl: ("https://hardcover.app/books/" + .book.slug)
                 }
             ],
             finished: [
@@ -140,6 +138,7 @@ jobs:
 
             MAX_RETRIES=3
             for i in $(seq 1 $MAX_RETRIES); do
+              git pull --rebase 2>&1 || true
               if git push 2>&1; then
                 echo "Push succeeded on attempt $i"
                 exit 0


### PR DESCRIPTION
## **User description**
## Summary
- GitHub Events API PushEvent payload no longer includes `commits[]`
- Workflow now extracts `before`/`head` SHA pairs from PushEvents
- Calls the Compare API for each push to get actual commit details

## Root cause
The Events API changed its PushEvent structure to only include `before`, `head`, `push_id`, `ref`, `repository_id` — no more inline commits.

Closes #126

## Test plan
- [ ] PR build passes
- [ ] After merge, manually trigger `fetch-github.yml`
- [ ] Verify `src/data/github.json` has populated `recentCommits`
- [ ] Verify CodeWidget on `/now` shows latest commit
- [ ] Verify `/code` page shows commit timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use Compare API to populate commits and make workflow pushes resilient**

### What Changed
- When GitHub PushEvent no longer includes commit details, the workflow now extracts before/head SHAs and calls the GitHub Compare API to build the recent commit list shown in data and the site.
- Workflow push steps now run a pull --rebase before pushing and retry up to 3 times, reducing failed pushes from concurrent workflow runs.
- Removed a now-missing "progress" field from the reading fetch so Hardcover data no longer triggers GraphQL validation issues during fetch.

### Impact
`✅ Accurate recent commits on profiles and code widgets`
`✅ Fewer failed workflow pushes due to concurrent updates`
`✅ Fewer reading-data GraphQL validation errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable commit retrieval with per-push aggregation, deduplication and chronological ordering.
  * Improved error handling: failed fetches emit warnings and processing continues; push attempts now retry with recovery attempts before final failure.

* **Chores**
  * Added pre-push pull with rebase to reduce conflicts during automated pushes.
  * Trimmed data shapes by removing an unused field from reading entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->