### PR TITLE
fix: prevent claude-mem CLAUDE.md files from becoming Astro routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# claude-mem context files (cause Astro routing issues in src/pages/)
+src/**/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
-# claude-mem context files (cause Astro routing issues in src/pages/)
-src/**/CLAUDE.md
+# claude-mem context files (keep root CLAUDE.md, ignore all others)
+**/CLAUDE.md
+!/CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
+    "prebuild": "find src/pages -name 'CLAUDE.md' -delete 2>/dev/null || true",
     "build": "astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "prebuild": "find src/pages -name 'CLAUDE.md' -delete 2>/dev/null || true",
+    "prebuild": "node scripts/prebuild-clean.js",
     "build": "astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"

--- a/scripts/prebuild-clean.js
+++ b/scripts/prebuild-clean.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform cleanup of claude-mem CLAUDE.md files from subdirectories.
+ *
+ * The claude-mem plugin creates CLAUDE.md context files in subdirectories.
+ * These can cause issues (e.g., Astro builds them as routes in src/pages/).
+ * This script removes all CLAUDE.md files except the root project one.
+ *
+ * Upstream bug: https://github.com/thedotmack/claude-mem/issues/760
+ */
+
+import { readdirSync, unlinkSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+const targetFile = 'CLAUDE.md';
+
+try {
+  const files = readdirSync('.', { recursive: true, withFileTypes: true });
+
+  for (const file of files) {
+    if (file.isFile() && file.name === targetFile) {
+      const parentDir = file.parentPath ?? file.path;
+      // Skip root-level CLAUDE.md (parentDir is '.')
+      if (parentDir === '.') continue;
+
+      const filePath = join(parentDir, file.name);
+      unlinkSync(filePath);
+      console.log(`Removed: ${filePath}`);
+    }
+  }
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    console.error(`Warning: ${err.message}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `**/CLAUDE.md` to `.gitignore` (with `!/CLAUDE.md` exception) to prevent committing claude-mem context files
- Add cross-platform `scripts/prebuild-clean.js` that removes all CLAUDE.md files except root before builds

## Problem

The `claude-mem` plugin creates `CLAUDE.md` context files in subdirectories. When placed in `src/pages/`, Astro builds them as routes, producing:
- Broken pages at `/about/CLAUDE/`, `/write/CLAUDE/`, etc.
- "no `<html>` element" build warnings

Upstream bug: thedotmack/claude-mem#760 (setting `CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED` is never checked)

## Solution

Two-layer defense:
1. **Gitignore** — prevents all CLAUDE.md except root from being committed
2. **Prebuild cleanup** — cross-platform Node.js script removes any CLAUDE.md files (except root) before build

The script uses only Node.js built-in modules (`fs`, `path`) for zero dependencies and Windows/macOS/Linux compatibility.

## Test plan

- [x] `npm run build` succeeds with no "no `<html>` element" warnings
- [x] Script removes test CLAUDE.md files from `src/`, `public/`, etc.
- [x] Script preserves root `./CLAUDE.md`
- [x] Script exits cleanly when no files to delete

Closes #131

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build/prebuild process to automatically remove duplicate context files across the project while preserving the primary root reference. This reduces accidental inclusion of extra context files in builds, logs removals for traceability, and handles missing-file errors gracefully to avoid interrupting the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->