### PR TITLE
fix: improve prebuild script error handling

### DIFF
--- a/scripts/prebuild-clean.js
+++ b/scripts/prebuild-clean.js
@@ -18,12 +18,15 @@ let files;
 try {
   files = readdirSync('.', { recursive: true, withFileTypes: true });
 } catch (err) {
-  // Directory read failed — nothing to clean
-  if (err.code !== 'ENOENT') {
-    console.error(`Warning: ${err.message}`);
+  if (err.code === 'ENOENT') {
+    // Directory doesn't exist — nothing to clean
+    process.exit(0);
   }
-  process.exit(0);
+  console.error(`Error reading directory: ${err.message}`);
+  process.exit(1);
 }
+
+let hadDeleteError = false;
 
 for (const file of files) {
   if (file.isFile() && file.name === targetFile) {
@@ -38,7 +41,12 @@ for (const file of files) {
     } catch (err) {
       if (err.code !== 'ENOENT') {
         console.error(`Warning: failed to remove ${filePath}: ${err.message}`);
+        hadDeleteError = true;
       }
     }
   }
+}
+
+if (hadDeleteError) {
+  process.exitCode = 1;
 }

--- a/scripts/prebuild-clean.js
+++ b/scripts/prebuild-clean.js
@@ -10,26 +10,35 @@
  */
 
 import { readdirSync, unlinkSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 
 const targetFile = 'CLAUDE.md';
 
+let files;
 try {
-  const files = readdirSync('.', { recursive: true, withFileTypes: true });
-
-  for (const file of files) {
-    if (file.isFile() && file.name === targetFile) {
-      const parentDir = file.parentPath ?? file.path;
-      // Skip root-level CLAUDE.md (parentDir is '.')
-      if (parentDir === '.') continue;
-
-      const filePath = join(parentDir, file.name);
-      unlinkSync(filePath);
-      console.log(`Removed: ${filePath}`);
-    }
-  }
+  files = readdirSync('.', { recursive: true, withFileTypes: true });
 } catch (err) {
+  // Directory read failed — nothing to clean
   if (err.code !== 'ENOENT') {
     console.error(`Warning: ${err.message}`);
+  }
+  process.exit(0);
+}
+
+for (const file of files) {
+  if (file.isFile() && file.name === targetFile) {
+    const parentDir = file.parentPath ?? file.path;
+    // Skip root-level CLAUDE.md (parentDir is '.')
+    if (parentDir === '.') continue;
+
+    const filePath = join(parentDir, file.name);
+    try {
+      unlinkSync(filePath);
+      console.log(`Removed: ${filePath}`);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        console.error(`Warning: failed to remove ${filePath}: ${err.message}`);
+      }
+    }
   }
 }


### PR DESCRIPTION
## **User description**
## Summary

Follow-up improvements to the prebuild cleanup script from #132:

- Remove unused `dirname` import
- Move try/catch into loop so one file failure doesn't abort remaining deletions

## Problem

The original script had:
1. An unused `dirname` import (lint warning)
2. A single try/catch around the entire loop — if one `unlinkSync` failed (e.g., permission error), all remaining files would be skipped

## Solution

- Each file removal now has its own try/catch
- One failure logs a warning but doesn't prevent removing other files

## Test plan

- [x] Script removes multiple CLAUDE.md files successfully
- [x] Script handles missing files gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
**Improve prebuild cleanup: continue removing CLAUDE.md files even if individual operations fail**

### What Changed
- If reading the directory fails, the script exits quietly for missing directories and logs unexpected read errors instead of crashing the process
- Each CLAUDE.md removal runs independently so a failure to delete one file does not stop other files from being removed; missing files are ignored and failed deletions emit a warning
- Script no longer includes an unused import (removes lint noise)

### Impact
`✅ Fewer prebuild failures`
`✅ Cleaner build outputs by removing stray CLAUDE.md files`
`✅ Clearer cleanup warnings during prebuild`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the build initialization script’s file-cleanup behavior: better handling of missing files and read errors, silent skips for absent files, clearer warnings for deletion failures, and sets a non-zero exit status when deletions fail. Enhanced logging and recovery to make the build startup more reliable and diagnosable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->