### PR TITLE
refactor: use hardcover-github-action instead of inline script

### DIFF
--- a/.github/workflows/fetch-listening.yml
+++ b/.github/workflows/fetch-listening.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Fetch ListenBrainz data
         id: fetch
-        uses: ggfevans/listenbrainz-github-action@v1
+        uses: ggfevans/listenbrainz-github-action@a39e89ecc366d5f8bc90e8d56cdc3d9e6a2237a9 # v1
         with:
           username: ${{ secrets.LISTENBRAINZ_USERNAME }}
           output_path: src/data/listening.json

--- a/.github/workflows/fetch-reading.yml
+++ b/.github/workflows/fetch-reading.yml
@@ -2,7 +2,7 @@ name: Fetch Reading Data
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Daily at midnight UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -14,121 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch Hardcover data
-        id: fetch
-        env:
-          HARDCOVER_TOKEN: ${{ secrets.HARDCOVER_TOKEN }}
-          HARDCOVER_USER_ID: ${{ secrets.HARDCOVER_USER_ID }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${HARDCOVER_TOKEN:-}" ] || [ -z "${HARDCOVER_USER_ID:-}" ]; then
-            echo "Hardcover credentials not configured, skipping"
-            exit 0
-          fi
-
-          QUERY='query GetUserBooks($userId: Int!) {
-            user_books(
-              where: { user_id: { _eq: $userId } }
-              order_by: { updated_at: desc }
-              limit: 50
-            ) {
-              status_id
-              rating
-              updated_at
-              book {
-                title
-                contributions(limit: 1) {
-                  author { name }
-                }
-                image { url }
-                slug
-              }
-            }
-          }'
-
-          PAYLOAD=$(jq -n \
-            --arg query "$QUERY" \
-            --argjson userId "$HARDCOVER_USER_ID" \
-            '{ query: $query, variables: { userId: $userId } }')
-
-          HTTP_CODE=$(curl -s -o /tmp/hc_response.json -w "%{http_code}" \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${HARDCOVER_TOKEN}" \
-            -d "$PAYLOAD" \
-            "https://api.hardcover.app/v1/graphql")
-
-          if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "Error: Hardcover API returned HTTP $HTTP_CODE"
-            exit 1
-          fi
-
-          RESPONSE=$(cat /tmp/hc_response.json)
-          rm -f /tmp/hc_response.json
-
-          # Check for GraphQL errors
-          if echo "$RESPONSE" | jq -e '.errors' > /dev/null 2>&1; then
-            echo "Error: GraphQL errors from Hardcover API"
-            echo "$RESPONSE" | jq -r '.errors[].message' 2>/dev/null
-            echo "Full error details: $(echo "$RESPONSE" | jq '.errors' 2>/dev/null)"
-            exit 1
-          fi
-
-          # Validate response has data
-          if ! echo "$RESPONSE" | jq -e '.data.user_books' > /dev/null 2>&1; then
-            echo "Error: Invalid response structure from Hardcover API"
-            exit 1
-          fi
-
-          mkdir -p src/data
-
-          # Map status_id: 1=want, 2=reading, 3=finished, 4=dnf, 5=dropped
-          echo "$RESPONSE" | jq '{
-            lastUpdated: (now | todate),
-            currentlyReading: [
-              .data.user_books[]
-              | select(.status_id == 2)
-              | {
-                  title: .book.title,
-                  author: (.book.contributions[0].author.name // "Unknown"),
-                  coverUrl: .book.image.url,
-                  hardcoverUrl: ("https://hardcover.app/books/" + .book.slug)
-                }
-            ],
-            finished: [
-              .data.user_books[]
-              | select(.status_id == 3)
-              | {
-                  title: .book.title,
-                  author: (.book.contributions[0].author.name // "Unknown"),
-                  coverUrl: .book.image.url,
-                  hardcoverUrl: ("https://hardcover.app/books/" + .book.slug),
-                  rating: (.rating // null),
-                  dateFinished: .updated_at
-                }
-            ],
-            wantToRead: [
-              .data.user_books[]
-              | select(.status_id == 1)
-              | {
-                  title: .book.title,
-                  author: (.book.contributions[0].author.name // "Unknown"),
-                  coverUrl: .book.image.url,
-                  hardcoverUrl: ("https://hardcover.app/books/" + .book.slug)
-                }
-            ]
-          }' > src/data/reading.json
-
-          echo "Successfully fetched reading data"
-          cat src/data/reading.json | jq '{
-            currently_reading: (.currentlyReading | length),
-            finished: (.finished | length),
-            want_to_read: (.wantToRead | length)
-          }'
+      - name: Fetch reading data
+        uses: ggfevans/hardcover-github-action@f68d44fb791e471a33a52f04f61052faa8654cb4 # v1
+        with:
+          token: ${{ secrets.HARDCOVER_TOKEN }}
+          user_id: ${{ secrets.HARDCOVER_USER_ID }}
+          output_path: src/data/reading.json
 
       - name: Commit and push if changed
-        if: steps.fetch.outcome == 'success' && hashFiles('src/data/reading.json') != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/fetch-watching.yml
+++ b/.github/workflows/fetch-watching.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ggfevans/trakt-github-action@main
+      - uses: ggfevans/trakt-github-action@840686406bb160c82d5bfde1bb9e7f137a3b7b6d # main
         with:
           trakt_client_id: ${{ secrets.TRAKT_CLIENT_ID }}
           trakt_username: 'gvns'


### PR DESCRIPTION
## **User description**
## Summary
- Replace 155-line inline Hardcover workflow with published `ggfevans/hardcover-github-action@v1`
- Maintains identical output schema (`reading.json`)
- Follows same pattern as trakt-github-action migration

## Test Plan
- [ ] Manually trigger workflow after merge
- [ ] Verify reading.json output unchanged (only lastUpdated differs)
- [ ] Verify site builds

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use hardcover GitHub Action to fetch reading data

### What Changed
- Replaced the long inline shell script that queried the Hardcover API and built src/data/reading.json with the published ggfevans/hardcover-github-action@v1; the workflow now provides the Hardcover token and user ID as inputs
- Workflow still runs on the same daily schedule and continues to add/commit src/data/reading.json when the fetched data changes
- Simplifies credential handling by passing secrets directly to the action instead of executing a custom curl/jq pipeline in the job

### Impact
`✅ Fewer CI maintenance tasks`
`✅ Unchanged reading.json output`
`✅ Easier workflow updates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the automated reading-data workflow to use an external fetch step that writes data directly.
  * Simplified commit/push logic to run after fetching and commit only when there are changes (retry behaviour retained).
  * Pinned external fetch actions for listening and watching workflows to specific commits for deterministic, immutable retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->