### PR TITLE
chore: add retry logic to fetch-watching.yml push step

### DIFF
--- a/.github/workflows/fetch-watching.yml
+++ b/.github/workflows/fetch-watching.yml
@@ -25,7 +25,22 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/data/watching.json
-          git diff --staged --quiet || git commit -m "chore: update watching data"
-          if ! git push 2>&1; then
-            echo "::warning::git push failed (branch may be protected)"
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update watching data"
+
+            MAX_RETRIES=3
+            for i in $(seq 1 $MAX_RETRIES); do
+              git pull --rebase 2>&1 || true
+              if git push 2>&1; then
+                echo "Push succeeded on attempt $i"
+                exit 0
+              fi
+              echo "::warning::git push failed (attempt $i/$MAX_RETRIES)"
+              sleep $((i * 5))
+            done
+
+            echo "::error::git push failed after $MAX_RETRIES attempts"
+            exit 1
+          else
+            echo "No changes to commit"
           fi


### PR DESCRIPTION
## **User description**
## Summary

- Replaces single-attempt push with 3-retry loop using `git pull --rebase` and exponential backoff
- Matches the pattern already used in `fetch-reading.yml` and `fetch-listening.yml`
- Exits non-zero on persistent failure instead of silently warning

## Test Plan

- [x] YAML is syntactically valid
- [ ] Manual workflow dispatch succeeds
- [x] Pattern matches `fetch-reading.yml` push step exactly

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add retry and failure handling to the workflow push step

### What Changed
- Commits only if there are staged changes; when there are none it logs "No changes to commit"
- If a push is needed, the workflow now retries up to 3 times, running a pull with rebase before each push and waiting longer between attempts
- If all retries fail, the workflow exits with an error instead of leaving a warning

### Impact
`✅ Fewer failed workflow runs due to transient push conflicts`
`✅ More reliable updates to watching.json being pushed`
`✅ Clearer failure signals when pushes cannot be completed`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
