### PR TITLE
feat: dual font system — Space Grotesk headings + Inter body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ P1-P5 accent palette with zinc neutrals. Key semantic tokens:
 - `--colour-accent-primary` (violet-500 `#8b5cf6`)
 - P1 Violet (code), P2 Rose (read), P3 Emerald (listen), P4 Amber (write/watch), P5 Sky (status)
 
-Uses Inter (400/500/600/700) + JetBrains Mono (400), self-hosted via @fontsource. Code highlighting via Shiki.
+Uses Space Grotesk (600/700) for h1-h3 headings, Inter (400/500/600/700) for body text, and JetBrains Mono (400) for code — all self-hosted via @fontsource. Code highlighting via Shiki.
 
 Dark-first with `.dark` class toggle (Tailwind `dark:` variant via `@custom-variant`).
 

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -106,6 +106,9 @@ WCAG AA requires 4.5:1 for normal text, 3:1 for large text/UI components.
 
 ```css
 :root {
+  /* Headings — Space Grotesk (self-hosted, 600/700) */
+  --font-heading: "Space Grotesk", var(--font-sans);
+
   /* Primary — Inter (self-hosted) */
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -131,12 +134,12 @@ WCAG AA requires 4.5:1 for normal text, 3:1 for large text/UI components.
 
 ### Font Weights
 
-| Weight | Value | Usage |
-|--------|-------|-------|
-| `font-normal` | 400 | Body text |
-| `font-medium` | 500 | Labels, UI elements |
-| `font-semibold` | 600 | Subheadings, links |
-| `font-bold` | 700 | Headings, emphasis |
+| Weight | Value | Font | Usage |
+|--------|-------|------|-------|
+| `font-normal` | 400 | Inter | Body text |
+| `font-medium` | 500 | Inter | Labels, UI elements |
+| `font-semibold` | 600 | Inter, Space Grotesk | Subheadings, links, h2/h3 |
+| `font-bold` | 700 | Inter, Space Grotesk | Headings, emphasis, h1 |
 
 ### Letter Spacing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@astrojs/svelte": "^7.2.5",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/space-grotesk": "^5.2.10",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.17.1",
         "react": "^19.2.4",
@@ -926,6 +927,15 @@
     },
     "node_modules/@fontsource/jetbrains-mono": {
       "version": "5.2.8",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@astrojs/svelte": "^7.2.5",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/space-grotesk": "^5.2.10",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.17.1",
     "react": "^19.2.4",

--- a/src/pages/watch/index.astro
+++ b/src/pages/watch/index.astro
@@ -132,7 +132,6 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 
   .gvns-watch__title {
     font-size: var(--text-4xl);
-    font-family: var(--font-sans);
     line-height: 1.2;
     letter-spacing: -0.01em;
     color: var(--colour-text-primary);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,8 @@
 @import "@fontsource/inter/500.css";
 @import "@fontsource/inter/600.css";
 @import "@fontsource/inter/700.css";
+@import "@fontsource/space-grotesk/600.css";
+@import "@fontsource/space-grotesk/700.css";
 @import "@fontsource/jetbrains-mono/400.css";
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
@@ -56,6 +58,7 @@
   /* Typography */
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-heading: "Space Grotesk", var(--font-sans);
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
     Consolas, "Liberation Mono", monospace;
 
@@ -186,6 +189,10 @@ body {
   background-color: var(--colour-bg-primary);
   color: var(--colour-text-primary);
   line-height: 1.6;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-heading);
 }
 
 /* Container Utility */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -193,6 +193,11 @@ body {
 
 h1, h2, h3 {
   font-family: var(--font-heading);
+  font-weight: 700;
+}
+
+h2, h3 {
+  font-weight: 600;
 }
 
 /* Container Utility */


### PR DESCRIPTION
## **User description**
## Summary
- Adds Space Grotesk (600/700) as dedicated heading font for h1-h3 elements
- Introduces `--font-heading` CSS custom property with Inter fallback
- Body text, nav, breadcrumbs, h4+, and code blocks remain unchanged

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] Homepage hero heading renders in Space Grotesk
- [ ] Section page h1 titles (Now, Code, Read, etc.) render in Space Grotesk
- [ ] Blog post h2/h3 headings render in Space Grotesk
- [ ] Body text, nav, breadcrumbs remain Inter
- [ ] Code blocks remain JetBrains Mono
- [ ] h4 in prose remains Inter
- [ ] Dark and light mode both render correctly

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use Space Grotesk for h1–h3 headings while keeping Inter for body text**

### What Changed
- h1–h3 headings now use the self-hosted Space Grotesk (600/700) font across the site
- Body text, navigation, breadcrumbs, h4+ headings, and code blocks continue to use Inter and JetBrains Mono as before
- The Space Grotesk package is added so heading fonts are bundled with the site

### Impact
`✅ Clearer heading hierarchy`
`✅ Consistent heading typography across pages`
`✅ Body and code fonts unchanged`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style Updates**
  * Headings (h1–h3) now use a dedicated heading font with refined weight assignments for clearer hierarchy; a title style was simplified to inherit the new heading treatment.

* **Documentation**
  * Design system and docs updated with expanded typography guidance and explicit font/weight mappings for consistent use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->