### PR TITLE
fix: restore original font imports

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -46,7 +46,7 @@ const currentYear = new Date().getFullYear();
         display: flex;
         justify-content: space-between;
         align-items: center;
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
         font-size: 0.875rem;
     }
 
@@ -59,7 +59,7 @@ const currentYear = new Date().getFullYear();
     }
 
     .footer-links a {
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
         text-decoration: none;
         transition: color var(--transition-fast);
     }

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -7,11 +7,13 @@ import TagList from './TagList.astro';
 interface Props {
   post: CollectionEntry<'writing'>;
   showReadingTime?: boolean;
+  headingLevel?: 'h2' | 'h3';
 }
 
-const { post, showReadingTime = true } = Astro.props;
+const { post, showReadingTime = true, headingLevel = 'h3' } = Astro.props;
 const { title, description, pubDate, tags } = post.data;
 const readingTime = getReadingTime(post.body);
+const HeadingTag = headingLevel;
 
 // Extract just the filename from the full slug path
 // e.g., "2024/12/hello-world" -> "hello-world"
@@ -20,9 +22,9 @@ const filename = slugParts[slugParts.length - 1];
 ---
 
 <article class="post-card">
-  <h3 class="post-title">
+  <HeadingTag class="post-title">
     <a href={`/write/${filename}`}>{title}</a>
-  </h3>
+  </HeadingTag>
   <div class="post-meta">
     <time datetime={pubDate.toISOString()}>{formatDate(pubDate)}</time>
     {showReadingTime && <span class="reading-time">{readingTime} min read</span>}

--- a/src/components/book-card.astro
+++ b/src/components/book-card.astro
@@ -221,7 +221,7 @@ if (dateFinished) {
 
   .gvns-book-date {
     font-size: var(--text-xs);
-    color: var(--colour-text-muted);
+    color: var(--colour-text-secondary);
     margin: 0;
     margin-top: auto;
   }

--- a/src/pages/code/index.astro
+++ b/src/pages/code/index.astro
@@ -310,7 +310,7 @@ const breadcrumbJsonLd = toJsonLd(
 
     .gvns-code__stats__secondary {
         font-size: var(--text-xs);
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
     }
 
     .gvns-code__stat-value {
@@ -324,7 +324,7 @@ const breadcrumbJsonLd = toJsonLd(
     }
 
     .gvns-code__stat-sep {
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
     }
 
     .gvns-code__stat--streak {
@@ -392,13 +392,13 @@ const breadcrumbJsonLd = toJsonLd(
         font-family: var(--font-mono);
         font-size: var(--text-base);
         font-weight: 600;
-        color: var(--colour-p1-violet);
+        color: var(--colour-link-text);
         margin: 0 0 var(--space-2) 0;
         transition: color var(--transition-fast);
     }
 
     .gvns-code__repo-card:hover .gvns-code__repo-name {
-        color: var(--colour-p1-violet-hover);
+        color: var(--colour-accent-hover);
     }
 
     .gvns-code__repo-desc {
@@ -414,7 +414,7 @@ const breadcrumbJsonLd = toJsonLd(
         align-items: center;
         gap: var(--space-4);
         font-size: var(--text-xs);
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
     }
 
     .gvns-code__repo-lang {
@@ -437,7 +437,7 @@ const breadcrumbJsonLd = toJsonLd(
     }
 
     .gvns-code__repo-stars svg {
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
     }
 
     /* Empty state */
@@ -474,7 +474,7 @@ const breadcrumbJsonLd = toJsonLd(
 
     .gvns-code__updated p {
         font-size: var(--text-xs);
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
         margin: 0;
     }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -147,7 +147,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--colour-text-muted);
+    color: var(--colour-text-secondary);
   }
   .status-section :global(.gvns-widget__content) {
     flex: none;

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -122,7 +122,7 @@ const breadcrumbJsonLd = toJsonLd(
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
     }
 
     .gvns-now__grid :global(.gvns-widget__content) {
@@ -155,14 +155,14 @@ const breadcrumbJsonLd = toJsonLd(
     .gvns-now__grid :global(.gvns-widget__time) {
         font-size: var(--text-xs);
         font-family: var(--font-mono);
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
         margin: var(--space-1) 0 0 0;
         display: block;
     }
 
     .gvns-now__grid :global(.gvns-widget__empty) {
         font-size: var(--text-sm);
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
         font-style: italic;
         margin: 0;
         flex: 1;

--- a/src/pages/read/index.astro
+++ b/src/pages/read/index.astro
@@ -226,7 +226,7 @@ if (readingData.lastUpdated) {
 
     .last-updated {
         font-size: var(--text-sm);
-        color: var(--colour-text-muted);
+        color: var(--colour-text-secondary);
         margin: 0;
     }
 </style>

--- a/src/pages/write/index.astro
+++ b/src/pages/write/index.astro
@@ -40,7 +40,7 @@ const breadcrumbJsonLd = toJsonLd(
             posts.length > 0 ? (
                 <div class="post-list">
                     {posts.map((post) => (
-                        <PostCard post={post} />
+                        <PostCard post={post} headingLevel="h2" />
                     ))}
                 </div>
             ) : (

--- a/src/pages/write/tags/[tag].astro
+++ b/src/pages/write/tags/[tag].astro
@@ -74,7 +74,7 @@ const breadcrumbJsonLd = toJsonLd(
         </header>
 
         <div class="post-list">
-            {posts.map((post) => <PostCard post={post} />)}
+            {posts.map((post) => <PostCard post={post} headingLevel="h2" />)}
         </div>
     </main>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,6 @@
-@import "@fontsource/inter/400.css";
-@import "@fontsource/inter/500.css";
-@import "@fontsource/inter/600.css";
-@import "@fontsource/inter/700.css";
-@import "@fontsource/space-grotesk/600.css";
-@import "@fontsource/space-grotesk/700.css";
-@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/inter/latin.css";
+@import "@fontsource/space-grotesk/latin.css";
+@import "@fontsource/jetbrains-mono/latin.css";
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,10 @@
-@import "@fontsource/inter/latin.css";
-@import "@fontsource/space-grotesk/latin.css";
-@import "@fontsource/jetbrains-mono/latin.css";
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/500.css";
+@import "@fontsource/inter/600.css";
+@import "@fontsource/inter/700.css";
+@import "@fontsource/space-grotesk/600.css";
+@import "@fontsource/space-grotesk/700.css";
+@import "@fontsource/jetbrains-mono/400.css";
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -16,7 +16,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--colour-text-muted);
+  color: var(--colour-text-secondary);
 }
 
 .gvns-widget-compact__body {
@@ -58,7 +58,7 @@
 
 .gvns-widget-compact__empty {
   font-size: var(--text-sm);
-  color: var(--colour-text-muted);
+  color: var(--colour-text-secondary);
   font-style: italic;
   margin: 0;
 }


### PR DESCRIPTION
## **User description**
## Summary
- reverts the latin-subset font import change in src/styles/global.css
- restores the previous weight-based Fontsource imports for Inter, Space Grotesk, and JetBrains Mono

## Test Plan
- [x] npm run build


___

## **CodeAnt-AI Description**
Use secondary text color across UI and make post titles configurable (h2 in lists)

### What Changed
- Replaced muted text color with the site's secondary text color across widgets, lists, footers, code pages, reading pages, and other UI components so informational and meta text now uses a consistent color token.
- Updated repository link hover color to use the accent hover token for clearer hover feedback.
- Made post title heading level configurable with a default of h3 and set listing pages to render post titles as h2 to improve page structure and accessibility.

### Impact
`✅ More consistent informational text color across pages`
`✅ Clearer link/hover feedback on repository and footer links`
`✅ Improved document structure and accessibility for post listings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Text colour tokens have been refreshed across multiple sections of the site, including footer, post and book cards, code page elements, home page widgets, "Now" and "Read" page widgets, and widget component styles.

* **Features**
  * Post cards now support configurable heading levels, allowing h2 or h3 rendering to be specified as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->