### PR TITLE
chore: shared getPostSlug() utility for content IDs

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import { formatDate } from '@utils/date';
 import { getReadingTime } from '@utils/reading-time';
 import TagList from './TagList.astro';
+import { getPostSlug } from '@utils/content';
 
 interface Props {
   post: CollectionEntry<'writing'>;
@@ -15,10 +16,7 @@ const { title, description, pubDate, tags } = post.data;
 const readingTime = getReadingTime(post.body);
 const HeadingTag = headingLevel;
 
-// Extract just the filename from the full slug path
-// e.g., "2024/12/hello-world" -> "hello-world"
-const slugParts = post.slug.split('/');
-const filename = slugParts[slugParts.length - 1];
+const filename = getPostSlug(post.slug);
 ---
 
 <article class="post-card">

--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from 'astro:content';
 import TagList from './TagList.astro';
 import { safeUrl } from '@utils/format';
+import { getPostSlug } from '@utils/content';
 
 interface Props {
   project: CollectionEntry<'work'>;
@@ -16,7 +17,7 @@ const safeLiveUrl = safeUrl(url);
 <article class="gvns-work-card">
   <div class="gvns-work-card__header">
     <h3>
-      <a href={`/work/${project.slug}`}>{title}</a>
+      <a href={`/work/${getPostSlug(project.slug)}`}>{title}</a>
     </h3>
     <span class={`gvns-work-card__status gvns-work-card__status--${status}`}>{status}</span>
   </div>

--- a/src/components/widgets/WriteWidget.astro
+++ b/src/components/widgets/WriteWidget.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import { formatDate } from '@utils/date';
+import { getPostSlug } from '@utils/content';
 
 interface Props { compact?: boolean; }
 const { compact = false } = Astro.props;
@@ -10,7 +11,7 @@ const posts = (await getCollection('writing'))
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
 const latestPost = posts[0] ?? null;
-const postSlug = latestPost?.slug.split('/').pop();
+const postSlug = latestPost ? getPostSlug(latestPost.slug) : undefined;
 ---
 
 {compact ? (

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,5 +1,6 @@
 import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
+import { getPostSlug } from "@utils/content";
 
 export async function GET(context: APIContext) {
   const siteUrl = (context.site || "https://gvns.ca")
@@ -12,22 +13,17 @@ export async function GET(context: APIContext) {
 
   const projects = await getCollection("work");
 
-  const getFilename = (slug: string) => {
-    const parts = slug.split("/");
-    return parts[parts.length - 1];
-  };
-
   const writingLines = posts
     .map(
       (post) =>
-        `- [${post.data.title}](${siteUrl}/write/${getFilename(post.slug)}/): ${post.data.description}`,
+        `- [${post.data.title}](${siteUrl}/write/${getPostSlug(post.slug)}/): ${post.data.description}`,
     )
     .join("\n");
 
   const workLines = projects
     .map(
       (project) =>
-        `- [${project.data.title}](${siteUrl}/work/${project.slug}/): ${project.data.description}`,
+        `- [${project.data.title}](${siteUrl}/work/${getPostSlug(project.slug)}/): ${project.data.description}`,
     )
     .join("\n");
 

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,17 +1,12 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
+import { getPostSlug } from "@utils/content";
 
 export async function GET(context: APIContext) {
   const posts = (await getCollection("writing"))
     .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-  // Extract filename from full slug path
-  const getFilename = (slug: string) => {
-    const parts = slug.split("/");
-    return parts[parts.length - 1];
-  };
 
   return rss({
     title: "gvns.ca",
@@ -22,7 +17,7 @@ export async function GET(context: APIContext) {
       title: post.data.title,
       pubDate: post.data.pubDate,
       description: post.data.description,
-      link: `/write/${getFilename(post.slug)}/`,
+      link: `/write/${getPostSlug(post.slug)}/`,
       categories: post.data.tags,
     })),
     customData: "<language>en-CA</language>",

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import PageLayout from '@layouts/PageLayout.astro';
 import TagList from '@components/TagList.astro';
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
+import { getPostSlug } from '@utils/content';
 
 const siteUrl = normalizeSiteUrl(Astro.site);
 const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
@@ -31,7 +32,7 @@ const projects = (await getCollection('work'))
       <article class="project-card">
         <div class="card-header">
           <h3>
-            <a href={`/work/${project.slug}`}>{project.data.title}</a>
+            <a href={`/work/${getPostSlug(project.slug)}`}>{project.data.title}</a>
           </h3>
           <span class={`status status-${project.data.status}`}>{project.data.status}</span>
         </div>

--- a/src/pages/write/[slug].astro
+++ b/src/pages/write/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import PostLayout from '@layouts/PostLayout.astro';
+import { getPostSlug } from '@utils/content';
 
 export async function getStaticPaths() {
   const posts = await getCollection('writing', ({ data }) => {
@@ -8,13 +9,8 @@ export async function getStaticPaths() {
   });
 
   return posts.map((post) => {
-    // Extract just the filename from the full slug path
-    // e.g., "2024/12/hello-world" -> "hello-world"
-    const slugParts = post.slug.split('/');
-    const filename = slugParts[slugParts.length - 1];
-
     return {
-      params: { slug: filename },
+      params: { slug: getPostSlug(post.slug) },
       props: { post },
     };
   });

--- a/src/pages/write/archive.astro
+++ b/src/pages/write/archive.astro
@@ -5,6 +5,7 @@ import TagList from "@components/TagList.astro";
 import WriteNav from "@components/WriteNav.astro";
 import { formatDate } from "@utils/date";
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from "@utils/json-ld";
+import { getPostSlug } from "@utils/content";
 
 const posts = (await getCollection("writing"))
     .filter((post) => (import.meta.env.PROD ? !post.data.draft : true))
@@ -65,13 +66,11 @@ const breadcrumbJsonLd = toJsonLd(
                             <div class="timeline-month">
                                 <h3 class="month-heading">{month}</h3>
                                 <div class="month-entries">
-                                    {monthPosts.map((post) => {
-                                        const canonicalSlug = post.slug.replace(/\/+$/, "");
-                                        return (
+                                    {monthPosts.map((post) => (
                                             <article class="timeline-entry">
                                                 <div class="entry-dot" />
                                                 <div class="entry-content">
-                                                    <a href={`/write/${canonicalSlug}/`} class="entry-title">
+                                                    <a href={`/write/${getPostSlug(post.slug)}/`} class="entry-title">
                                                         {post.data.title}
                                                     </a>
                                                     <time datetime={post.data.pubDate.toISOString()}>
@@ -81,8 +80,7 @@ const breadcrumbJsonLd = toJsonLd(
                                                     <TagList tags={post.data.tags} />
                                                 </div>
                                             </article>
-                                        );
-                                    })}
+                                    ))}
                                 </div>
                             </div>
                         ))}

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,0 +1,7 @@
+/**
+ * Extract the filename portion from a content collection slug/id.
+ * e.g., "2024/12/hello-world" → "hello-world"
+ */
+export function getPostSlug(slug: string): string {
+  return slug.split('/').pop() ?? slug;
+}


### PR DESCRIPTION
## **User description**
## Summary

- Creates `src/utils/content.ts` with a shared `getPostSlug()` utility that extracts filenames from content collection slugs/IDs (e.g., `2024/12/hello-world` → `hello-world`)
- Replaces 6 inline `slug.split('/')` patterns and 2 local `getFilename()` functions across writing-related files
- Hardens work collection ID usage in `llms.txt.ts`, `work/index.astro`, and `WorkCard.astro` to extract filenames instead of using raw IDs directly

Closes #193, closes #194

## Test plan

- [x] `npm run build` passes
- [x] No remaining inline `.split('/')` slug extraction in `src/` (only in the utility itself)
- [x] No remaining local `getFilename()` functions
- [x] Archive page links point to `/write/<filename>/`
- [x] RSS feed has correct `/write/<filename>/` URLs
- [x] `llms.txt` has correct URLs for both writing and work entries
- [x] Work index page has correct `/work/<filename>/` links

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use filename-only slugs for writing and work links sitewide

### What Changed
- Links to posts and work items now use only the filename portion of content IDs (e.g., "2024/12/hello-world" → "hello-world") across archive pages, post pages, work index, widgets, RSS, and llms.txt
- Replaced duplicated inline slug extraction with a single shared utility so all generated URLs are consistent
- Archive and widget listings, RSS feed items, and work cards now point to the corrected /write/<filename>/ and /work/<filename>/ URLs

### Impact
`✅ Consistent article and project URLs`
`✅ Correct RSS feed links for posts`
`✅ Fewer incorrect/archive link mismatches`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization by centralizing slug handling logic across the application. This enhances maintainability without affecting user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->