### PR TITLE
chore: remove redundant hero CTA links from homepage (#235)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,11 +34,6 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         Web developer on Vancouver Island. I write about homelab, self-hosting,
         web development, BJJ, and the occasional life observation.
       </p>
-      <nav class="hero-cta" aria-label="Quick links">
-        <a href="/write" class="cta-link">Writing</a>
-        <a href="/work" class="cta-link">Work</a>
-        <a href="/now" class="cta-link">Now</a>
-      </nav>
     </section>
 
     <section class="status-section" aria-label="Current status">
@@ -109,22 +104,6 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     line-height: 1.6;
     margin-bottom: var(--space-8);
   }
-  .hero-cta {
-    display: flex;
-    gap: var(--space-6);
-    justify-content: center;
-  }
-  .cta-link {
-    color: var(--colour-accent-primary);
-    text-decoration: none;
-    font-weight: 600;
-    font-size: var(--text-lg);
-    transition: color var(--transition-fast);
-  }
-  .cta-link:hover {
-    color: var(--colour-accent-hover);
-  }
-
   /* Status — these :global() selectors target StatusWidget's internal classes
      to restyle it inline on the homepage. Update if StatusWidget class names change. */
   .status-section {


### PR DESCRIPTION
## **User description**
## Summary
- Removes the `hero-cta` block (Writing/Work/Now) from the homepage hero
- Removes the now-unused `.hero-cta` and `.cta-link` styles
- These same links live in the global `Header.astro` nav, so the hero block was redundant

## Test Plan
- [x] \`npm run build\` succeeds
- [x] CodeRabbit review: no findings
- [ ] Visual check on preview deploy: hero still reads cleanly without CTA row

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the quick-links navigation from the homepage hero section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Remove duplicate quick links from the homepage hero**

### What Changed
- Removed the Writing, Work, and Now links from the homepage hero
- Kept those links in the main site navigation, so they no longer appear twice on the page
- Removed the unused hero link styling that supported the deleted links

### Impact
`✅ Cleaner homepage hero`
`✅ Less repeated navigation on the home page`
`✅ Clearer path to Writing, Work, and Now pages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=wAv-nO5hRW7RTVWh6cdUnh6vK9vBc74RYoaqQbbKEgo&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
