### PR TITLE
chore(infra): migrate to Cloudflare Workers (#249)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ pnpm-debug.log*
 **/CLAUDE.md
 !/CLAUDE.md
 .worktrees
+
+# wrangler local state
+.wrangler/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Personal writing + work site for gvns.ca. Brand guide aligned and in active buil
 - **Styling**: Tailwind CSS 4.x with P1-P5 accent palette (violet/rose/emerald/amber/sky) + zinc neutrals
 - **Components**: Starwind UI Pro (shadcn-style, copied into `src/components/starwind/`; add via `npx starwind@latest add <component>`)
 - **Content**: Astro Content Collections (type-safe markdown)
-- **Hosting**: Cloudflare Pages (auto-deploy from GitHub)
+- **Hosting**: Cloudflare Workers via Workers Builds (auto-deploy from GitHub); `@astrojs/cloudflare` adapter in `output: 'server'` mode with all current routes prerendered
 - **Analytics**: None (Umami removed)
 
 ## Development Commands
@@ -85,9 +85,9 @@ Dark-first with `.dark` class toggle (Tailwind `dark:` variant via `@custom-vari
 
 ## Deployment
 
-Cloudflare Pages auto-deploys on push to main via native Git integration (no GH Actions deploy step). PR pushes generate preview deploy URLs.
+Cloudflare Workers (via Workers Builds) auto-deploys on push to main using its native Git integration (no GH Actions deploy step). PR pushes generate preview deploy URLs. Worker config lives in `wrangler.jsonc` (root) plus the adapter-generated `dist/server/wrangler.json`.
 
-GitHub Actions runs `ci.yml` for build checks on PRs only. Scheduled data-fetching workflows commit to `src/data/` and push, triggering CF Pages rebuilds.
+GitHub Actions runs `ci.yml` for build checks on PRs only. Scheduled data-fetching workflows commit to `src/data/` and push, triggering Workers Builds rebuilds.
 
 ## Documentation
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import tailwindcss from "@tailwindcss/vite";
 import svelte from "@astrojs/svelte";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
+import cloudflare from "@astrojs/cloudflare";
 import rehypeSlug from "rehype-slug";
 import pagefind from "./src/integrations/pagefind.ts";
 
@@ -21,9 +22,12 @@ try {
   console.warn("Failed to load shiki-gvns.json, falling back to default theme:", error);
 }
 
-// https://astro.build/config
 export default defineConfig({
-	site: "https://gvns.ca",
+  site: "https://gvns.ca",
+  output: "server",
+  adapter: cloudflare({
+    imageService: "compile",
+  }),
   markdown: {
     shikiConfig: {
       theme: shikiTheme,
@@ -33,6 +37,5 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
-
   integrations: [svelte(), react(), sitemap({ filter: (page) => !page.includes("/sandbox/") }), pagefind()],
 });

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -6,55 +6,71 @@
 ┌─────────────────────────────────────────────────────┐
 │                    Cloudflare                        │
 │                                                     │
-│   gvns.ca ──────────► CF Pages (static site)       │
+│   gvns.ca ──────────► Workers (Static Assets + SSR) │
 │                                                     │
 │   www.gvns.ca ────────► 301 → gvns.ca (_redirects) │
 │                                                     │
 └─────────────────────────────────────────────────────┘
 
 GitHub Actions (scheduled):
-  fetch-reading.yml  → src/data/reading.json   → push → CF Pages rebuild
-  fetch-listening.yml → src/data/listening.json → push → CF Pages rebuild
-  fetch-github.yml   → src/data/github.json    → push → CF Pages rebuild
-  fetch-comments.yml → src/data/comments/*.json → push → CF Pages rebuild
+  fetch-reading.yml  → src/data/reading.json   → push → Workers Builds rebuild
+  fetch-listening.yml → src/data/listening.json → push → Workers Builds rebuild
+  fetch-github.yml   → src/data/github.json    → push → Workers Builds rebuild
+  fetch-comments.yml → src/data/comments/*.json → push → Workers Builds rebuild
   refresh-threads-token.yml → refreshes THREADS_ACCESS_TOKEN secret (twice monthly)
 ```
 
-## Site Hosting: Cloudflare Pages
+## Site Hosting: Cloudflare Workers
 
 | Setting | Value |
 |---------|-------|
-| **Provider** | Cloudflare Pages (free tier) |
+| **Provider** | Cloudflare Workers (Static Assets + SSR) |
+| **Adapter** | `@astrojs/cloudflare` (`output: 'server'`, all current routes prerendered) |
 | **Build command** | `npm run build` |
-| **Output directory** | `dist` |
+| **Output** | `dist/client/` (static assets) + `dist/server/` (SSR Worker bundle) |
+| **Worker config (root)** | `wrangler.jsonc` — assets binding + compat flags |
+| **Worker config (deploy)** | `dist/server/wrangler.json` — adapter-generated, includes resolved `main` |
 | **Node version** | 20 (via `.nvmrc`) |
 | **Production branch** | `main` |
-| **Preview deploys** | Enabled (auto on PRs) |
+| **Preview deploys** | Enabled (auto on PRs via Workers Builds) |
 
 ### Custom Domains
 
 | Domain | Purpose |
 |--------|---------|
-| `gvns.ca` | Primary (apex) |
+| `gvns.ca` | Primary (apex) — bound to `gvns-ca` Worker |
 | `www.gvns.ca` | Redirects to apex via `_redirects` |
 
 ### How Deploys Work
 
-1. Push to `main` → CF Pages auto-builds and deploys
-2. PR opened → CF Pages creates preview deploy with unique URL
-3. Scheduled GH Actions fetch external data → commit JSON → push → triggers rebuild
+1. Push to `main` → Workers Builds auto-builds and deploys.
+2. PR opened → Workers Builds creates a preview deploy on a unique URL.
+3. Scheduled GH Actions fetch external data → commit JSON → push → triggers Workers Builds rebuild (same model as the previous Pages setup).
 
-No deploy workflow needed. No wrangler. No secrets for deploys.
+No deploy workflow needed in `.github/workflows/`. No Cloudflare secrets in GitHub — Workers Builds uses the native git integration.
+
+### Local Worker Development
+
+```bash
+npm run build
+./node_modules/.bin/wrangler dev --config dist/server/wrangler.json
+```
+
+The `--config dist/server/wrangler.json` flag points wrangler at the adapter-generated config (which has the resolved `main: entry.mjs` and `assets.directory: ../client`). The root `wrangler.jsonc` intentionally omits `main` because `@cloudflare/vite-plugin` validates that path during `astro build` before the SSR bundle exists.
 
 ### Security Headers
 
-Served via `_headers` file:
+Served via `_headers` file (copied from `public/` to `dist/client/` during build):
 - `Content-Security-Policy`
 - `Strict-Transport-Security` with preload
 - `X-Content-Type-Options: nosniff`
 - `X-Frame-Options: DENY`
 - `Referrer-Policy: strict-origin-when-cross-origin`
 - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+
+### Migration History
+
+Migrated from Cloudflare Pages to Workers in 2026-04 (issue #249). Pages project retained for a 2-week soak window post-cutover, then archived.
 
 ## CI/CD
 
@@ -87,14 +103,14 @@ Served via `_headers` file:
 | `MASTODON_TOKEN` | syndicate | Mastodon access token |
 | `GH_PAT` | all data workflows, syndicate | GitHub PAT for pushing and secret management |
 
-No Cloudflare secrets needed in GitHub — deploys are handled by CF Pages native integration.
+No Cloudflare secrets needed in GitHub — deploys are handled by Workers Builds' native git integration.
 
 ## DNS Records (Cloudflare)
 
 | Type | Name | Content | Proxy |
 |------|------|---------|-------|
-| CNAME | `gvns.ca` | `<project>.pages.dev` | Proxied |
-| CNAME | `www` | `<project>.pages.dev` | Proxied |
+| CNAME | `gvns.ca` | (managed by CF — Worker custom domain) | Proxied |
+| CNAME | `www` | (managed by CF — Worker custom domain) | Proxied |
 
 ## Backups
 
@@ -106,10 +122,10 @@ No Cloudflare secrets needed in GitHub — deploys are handled by CF Pages nativ
 
 | Item | Monthly |
 |------|---------|
-| Cloudflare Pages | $0 |
+| Cloudflare Workers (Free tier) | $0 |
 | Domain | ~$1 (amortised) |
 | **Total** | **~$1/month** |
 
 ---
 
-*Last updated: 2026-04-25*
+*Last updated: 2026-04-26*

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -8,7 +8,7 @@
 │                                                     │
 │   gvns.ca ──────────► Workers (Static Assets + SSR) │
 │                                                     │
-│   www.gvns.ca ────────► 301 → gvns.ca (_redirects) │
+│   www.gvns.ca ────► 301 → gvns.ca (CF Redirect Rule) │
 │                                                     │
 └─────────────────────────────────────────────────────┘
 
@@ -39,7 +39,7 @@ GitHub Actions (scheduled):
 | Domain | Purpose |
 |--------|---------|
 | `gvns.ca` | Primary (apex) — bound to `gvns-ca` Worker |
-| `www.gvns.ca` | Redirects to apex via `_redirects` |
+| `www.gvns.ca` | Redirects to apex via a Cloudflare Redirect Rule (see below) |
 
 ### How Deploys Work
 
@@ -57,6 +57,20 @@ npm run build
 ```
 
 The `--config dist/server/wrangler.json` flag points wrangler at the adapter-generated config (which has the resolved `main: entry.mjs` and `assets.directory: ../client`). The root `wrangler.jsonc` intentionally omits `main` because `@cloudflare/vite-plugin` validates that path during `astro build` before the SSR bundle exists.
+
+### www → Apex Redirect
+
+Configured as a Cloudflare **Redirect Rule** (Rules → Redirect Rules), not in `_redirects`:
+
+| Field | Value |
+|---|---|
+| If: | `Hostname` equals `www.gvns.ca` |
+| Then | Static redirect, `301`, target: `concat("https://gvns.ca", http.request.uri.path)` |
+| Preserve query string | ✓ |
+
+Workers Static Assets rejects absolute URLs in `_redirects` (validation error 10021), so the previous `https://www.gvns.ca/* https://gvns.ca/:splat 301` rule could not be carried forward. A path-only `/*` rule in `_redirects` would also fire on apex requests since both hostnames route to the same Worker, breaking `gvns.ca`. Cloudflare Redirect Rules run at the edge before the Worker sees the request, which is the correct layer for hostname-based redirects.
+
+`public/_redirects` is retained for any future *path-relative* redirects.
 
 ### Security Headers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gvns-ca",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/cloudflare": "^13.2.1",
         "@astrojs/react": "^5.0.3",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
@@ -39,10 +40,38 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
-        "@inquirer/prompts": "^8.4.1"
+        "@inquirer/prompts": "^8.4.1",
+        "wrangler": "^4.85.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/cloudflare": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-13.2.1.tgz",
+      "integrity": "sha512-ggmf3eeK+jlgyMFZwlnopU8MVhljNXs9/WQ/BTYjsMJTULe50nROvC/Mc/TZ5ZIHv0b6LJDfN9/n0PUhfI3qJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/underscore-redirects": "1.0.3",
+        "@cloudflare/vite-plugin": "^1.32.3",
+        "piccolore": "^0.1.3",
+        "tinyglobby": "^0.2.15",
+        "vite": "^7.3.2"
+      },
+      "peerDependencies": {
+        "astro": "^6.0.0",
+        "wrangler": "^4.83.0"
+      }
+    },
+    "node_modules/@astrojs/cloudflare/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -200,6 +229,12 @@
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
+    },
+    "node_modules/@astrojs/underscore-redirects": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.3.tgz",
+      "integrity": "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg==",
+      "license": "MIT"
     },
     "node_modules/@atproto/api": {
       "version": "0.19.3",
@@ -577,11 +612,175 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.33.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.33.2.tgz",
+      "integrity": "sha512-XI6+XkDn8W6tlvtYUoS6C89Te7fwhyDLrhUBUbagPO1StJ6ofbR0vpqNNqNskUp9592xTRCDk5ukqcjz6xMo+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.16.1",
+        "miniflare": "4.20260424.0",
+        "unenv": "2.0.0-rc.24",
+        "wrangler": "4.85.0",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
+        "wrangler": "^4.85.0"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260424.1.tgz",
+      "integrity": "sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260424.1.tgz",
+      "integrity": "sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260424.1.tgz",
+      "integrity": "sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260424.1.tgz",
+      "integrity": "sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260424.1.tgz",
+      "integrity": "sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@codybrom/denim": {
       "name": "@jsr/codybrom__denim",
       "version": "2.0.1",
       "resolved": "https://npm.jsr.io/~/11/@jsr/codybrom__denim/2.0.1.tgz",
       "integrity": "sha512-LVbEh16+J6I4JfNYXkNdGBsPdiTInbIagxNvETudwc0pLhphKQAU9NS/eDh62kA3SXKwLi8Xn1Z9R1Mw2Xnybg=="
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
@@ -1094,7 +1293,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2052,6 +2250,32 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "license": "MIT"
     },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2510,6 +2734,24 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
@@ -3216,6 +3458,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3750,6 +3998,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-module-lexer": {
@@ -4479,6 +4736,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -5601,6 +5867,47 @@
         "mini-svg-data-uri": "cli.js"
       }
     },
+    "node_modules/miniflare": {
+      "version": "4.20260424.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260424.0.tgz",
+      "integrity": "sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260424.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5865,6 +6172,18 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -6357,7 +6676,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -6401,7 +6719,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6572,6 +6889,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/svelte": {
       "version": "5.55.0",
@@ -6864,11 +7193,29 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/unicode-segmenter": {
       "version": "0.14.5",
@@ -7318,6 +7665,60 @@
         "node": ">=4"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260424.1.tgz",
+      "integrity": "sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260424.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260424.1",
+        "@cloudflare/workerd-linux-64": "1.20260424.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260424.1",
+        "@cloudflare/workerd-windows-64": "1.20260424.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.85.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.85.0.tgz",
+      "integrity": "sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260424.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260424.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260424.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -7370,6 +7771,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     },
     "node_modules/zimmerframe": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@astrojs/cloudflare": "^13.2.1",
     "@astrojs/react": "^5.0.3",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
@@ -47,6 +48,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
-    "@inquirer/prompts": "^8.4.1"
+    "@inquirer/prompts": "^8.4.1",
+    "wrangler": "^4.85.0"
   }
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,5 @@
-# Redirect www to apex domain
-https://www.gvns.ca/* https://gvns.ca/:splat 301
+# www → apex redirect is handled by a Cloudflare Redirect Rule (dashboard:
+# Rules → Redirect Rules → "If hostname equals www.gvns.ca → 301 to
+# https://gvns.ca/$1"). Workers Static Assets rejects absolute URLs in
+# _redirects (error 10021), and a path-only `/*` rule here would also fire
+# on apex requests. Keep this file for any future path-relative redirects.

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -1,7 +1,6 @@
 ---
 import yaml from 'js-yaml';
-import fs from 'node:fs';
-import path from 'node:path';
+import timelineSource from '../data/timeline.yaml?raw';
 
 interface TimelineEntry {
   date: string;
@@ -9,10 +8,7 @@ interface TimelineEntry {
   description: string;
 }
 
-// Load timeline data from YAML
-const timelinePath = path.join(process.cwd(), 'src/data/timeline.yaml');
-const timelineContent = fs.readFileSync(timelinePath, 'utf-8');
-const entries = yaml.load(timelineContent) as TimelineEntry[];
+const entries = yaml.load(timelineSource) as TimelineEntry[];
 
 // Sort by date descending (newest first)
 const sortedEntries = entries.sort((a, b) =>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import BaseLayout from "@layouts/BaseLayout.astro";
 ---
 

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import PageLayout from '@layouts/PageLayout.astro';
 import Timeline from '@components/Timeline.astro';
 import { personSchema, breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';

--- a/src/pages/code/index.astro
+++ b/src/pages/code/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import BaseLayout from "@layouts/BaseLayout.astro";
 import ContributionHeatmap from "@components/ContributionHeatmap.astro";
 import ActivityTimeline from "@components/ActivityTimeline.astro";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import PostCard from '@components/PostCard.astro';

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from "@utils/json-ld";
 import { relativeTime, isValidMbid } from "@utils/format";

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -2,6 +2,8 @@ import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
 import { getPostSlug } from "@utils/content";
 
+export const prerender = true;
+
 export async function GET(context: APIContext) {
   const siteUrl = (context.site || "https://gvns.ca")
     .toString()

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from "@utils/json-ld";
 import CodeWidget from "@components/widgets/CodeWidget.astro";

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection, render } from 'astro:content';
 import PostLayout from '@layouts/post-layout.astro';
 import { getPostSlug } from '@utils/content';

--- a/src/pages/posts/archive.astro
+++ b/src/pages/posts/archive.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection } from "astro:content";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import TagList from "@components/TagList.astro";

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection } from "astro:content";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import PostCard from "@components/PostCard.astro";

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection } from "astro:content";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import PostCard from "@components/PostCard.astro";

--- a/src/pages/posts/tags/index.astro
+++ b/src/pages/posts/tags/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection } from "astro:content";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import PostsNav from "@components/PostsNav.astro";

--- a/src/pages/read/index.astro
+++ b/src/pages/read/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import BaseLayout from "@layouts/BaseLayout.astro";
 import BookList from "@components/BookList.astro";
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from "@utils/json-ld";

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import PageLayout from '@layouts/PageLayout.astro';
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,6 +3,8 @@ import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
 import { getPostSlug } from "@utils/content";
 
+export const prerender = true;
+
 export async function GET(context: APIContext) {
   const posts = (await getCollection("posts"))
     .filter((post) => !post.data.draft)

--- a/src/pages/sandbox/starwind.astro
+++ b/src/pages/sandbox/starwind.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import "@styles/global.css";
 import "@styles/starwind.css";
 import "@styles/sandbox-lab.css";

--- a/src/pages/watch/index.astro
+++ b/src/pages/watch/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from "@utils/json-ld";
 import { safeUrl } from "@utils/format";

--- a/src/pages/work/[project].astro
+++ b/src/pages/work/[project].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import type { CollectionEntry } from 'astro:content';
 import { getCollection, render } from 'astro:content';
 import PageLayout from '@layouts/PageLayout.astro';

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import { getCollection } from 'astro:content';
 import PageLayout from '@layouts/PageLayout.astro';
 import TagList from '@components/TagList.astro';

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "gvns-ca",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "404-page"
+  },
+  "observability": {
+    "enabled": true
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,12 @@
     "binding": "ASSETS",
     "not_found_handling": "404-page"
   },
+  "kv_namespaces": [
+    {
+      "binding": "SESSION",
+      "id": "f05bec37e34047828e00d198521206f3"
+    }
+  ],
   "observability": {
     "enabled": true
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "2026-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "directory": "./dist",
+    "directory": "./dist/client",
     "binding": "ASSETS",
     "not_found_handling": "404-page"
   },
@@ -12,3 +12,9 @@
     "enabled": true
   }
 }
+// Note: `main` is intentionally omitted from this root config.
+// The @astrojs/cloudflare adapter generates `dist/server/wrangler.json` with the
+// resolved `main: entry.mjs` and matching `assets.directory: ../client` after build.
+// Use `--config dist/server/wrangler.json` for `wrangler dev` and `wrangler deploy`.
+// Including `main` here breaks `astro build` because @cloudflare/vite-plugin validates
+// the path before the SSR bundle is emitted.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "gvns-ca",
+  "name": "gvns-ca-worker",
   "compatibility_date": "2026-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {


### PR DESCRIPTION
## **User description**
## Summary

Migrates `gvns.ca` from Cloudflare Pages to Cloudflare Workers (Static Assets + `@astrojs/cloudflare` SSR adapter). Behaviour-equivalent today; unlocks server endpoints required by #254 (contact form).

- Adopt `@astrojs/cloudflare` adapter in `output: 'server'` mode
- Mark all 19 existing pages as `prerender = true` (CDN-served, identical performance)
- Add `wrangler.jsonc` with assets binding + `nodejs_compat`
- Adapter generates `dist/server/wrangler.json` with resolved paths for `wrangler dev`/`deploy`
- `_headers` and `_redirects` retained as-is (Workers Static Assets honours both)
- Update `docs/INFRASTRUCTURE.md` and `CLAUDE.md`

**Spec:** `docs/superpowers/specs/2026-04-26-pages-to-workers-design.md` (local)
**Plan:** `docs/superpowers/plans/2026-04-26-pages-to-workers.md` (local)

## What's left after merge (Cloudflare dashboard work)

The code change here is complete; remaining steps need dashboard access:

- [x] Create a Workers Builds project in CF dashboard, point at this repo, branch `main`, build cmd `npm run build`
- [ ] Smoke test the resulting `*.workers.dev` URL
- [ ] In-place cutover: remove `gvns.ca` + `www.gvns.ca` from Pages project, add them to the Worker
- [ ] Verify post-cutover (smoke battery from plan Task 9 step 4)
- [ ] Watch for next scheduled fetch-* GH Action commit → confirm Workers Builds rebuilds
- [ ] After 2-week soak: delete the Pages project, close #249

Rollback path: rebind `gvns.ca` back to the Pages project (kept alive intentionally during soak).

## Test Plan

Local `wrangler dev` smoke battery already passed:

- [x] All routes return expected status codes (`/`, `/about/`, `/posts/`, `/code/`, `/now/`, `/rss.xml`, `/llms.txt`, `/sitemap-index.xml` all 200; bogus route 404)
- [x] Security headers present (CSP, HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy)
- [x] Pagefind assets serve (`/pagefind/pagefind.js` 200)
- [x] Hashed `_astro/*` assets ship `cache-control: public, max-age=31536000, immutable`
- [x] Clean `npm run build` produces `dist/client/` (HTML/CSS/JS) + `dist/server/entry.mjs`
- [x] Pagefind indexed 17 pages

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Switched hosting/deploy model to Cloudflare Workers (including new deployment and local dev guidance).
  * Added Worker deployment configuration and updated redirect handling to Cloudflare Redirect Rules.

* **Performance Improvements**
  * Most site routes and endpoints are now prerendered at build time for faster page loads and reduced runtime work.

* **Dependencies**
  * Added Cloudflare adapter and tooling for builds and deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Serve the site through Cloudflare Workers while keeping the current pages static

### What Changed
- Core site pages, post pages, archive pages, tags, and utility pages are now marked to build ahead of time instead of relying on runtime rendering
- The RSS feed, `llms.txt`, 404 page, and timeline content are now packaged for the new Workers setup so they continue to load correctly
- The site now uses Workers deployment settings and local development instructions instead of the old Pages-based setup
- Project docs were updated to match the new hosting and deployment flow

### Impact
`✅ Fewer runtime page failures on Cloudflare Workers`
`✅ Consistent static delivery for public pages`
`✅ Clearer local preview of the production setup` 


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=U-KyPmnnPRy-E3C26MqWo2KU4U3JQDpaIof4Ua_rNus&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
