### PR TITLE
fix: address review feedback on #261 (CSP, syndication, Worker hardening)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,29 +4,10 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 
 /admin/*
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://www.githubstatus.com https://auth.gvns.ca https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com
-  X-Frame-Options: DENY
-  Referrer-Policy: strict-origin-when-cross-origin
-
-/
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
-
-/posts/*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
-
-/read/*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
-
-/listen/*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
-
-/watch/*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
-
-/status/*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-ancestors 'none'; base-uri 'self'; form-action 'self'

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -8,6 +8,13 @@ backend:
 site_url: https://gvns.ca
 display_url: https://gvns.ca
 
+# Media uploads are co-located with each post for Astro's image() pipeline.
+# media_folder_relative: true makes Sveltia compute paths relative to the
+# entry, so an upload from a post at YYYY/MM/<slug>.md lands in the sibling
+# YYYY/MM/images/ folder. The top-level public_folder is a Sveltia-required
+# placeholder (it insists on an absolute path) but is unused at runtime —
+# any future image widget MUST set its own per-field media_folder /
+# public_folder rather than rely on these defaults.
 media_folder_relative: true
 media_folder: src/content/posts/{{year}}/{{month}}/images
 public_folder: /images

--- a/scripts/fetch-comments.mjs
+++ b/scripts/fetch-comments.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Fetch Threads replies for syndicated writing posts.
+ * Fetch Threads replies for syndicated posts.
  *
- * Walks src/content/writing/ for non-draft posts with a Threads syndication
+ * Walks src/content/posts/ for non-draft posts with a Threads syndication
  * entry that includes a mediaId, fetches top-level replies via denim, and
  * writes normalised JSON to src/data/comments/{slug}.json.
  *
@@ -25,7 +25,7 @@ import matter from 'gray-matter';
 import { getReplies } from '@codybrom/denim';
 
 const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
-const WRITING_DIR = join(ROOT, 'src', 'content', 'writing');
+const POSTS_DIR = join(ROOT, 'src', 'content', 'posts');
 const COMMENTS_DIR = join(ROOT, 'src', 'data', 'comments');
 
 // Fields to request from the Threads API
@@ -91,7 +91,7 @@ async function main() {
   // Ensure the output directory exists
   await mkdir(COMMENTS_DIR, { recursive: true });
 
-  const files = await collectMarkdownFiles(WRITING_DIR);
+  const files = await collectMarkdownFiles(POSTS_DIR);
 
   // Collect qualifying posts (non-draft, has Threads syndication with mediaId)
   const qualifying = [];

--- a/scripts/syndicate.mjs
+++ b/scripts/syndicate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * POSSE syndication script — posts unsyndicated writing to Bluesky, Mastodon, and Threads.
+ * POSSE syndication script — posts unsyndicated posts to Bluesky, Mastodon, and Threads.
  *
  * Usage:
  *   node scripts/syndicate.mjs            # Post unsyndicated content
@@ -25,7 +25,7 @@ import { createRestAPIClient } from 'masto';
 import { createThreadsContainer, publishThreadsContainer } from '@codybrom/denim';
 
 const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
-const WRITING_DIR = join(ROOT, 'src', 'content', 'writing');
+const POSTS_DIR = join(ROOT, 'src', 'content', 'posts');
 const SITE_URL = (process.env.SITE_URL || 'https://gvns.ca').replace(/\/+$/, '');
 
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -79,7 +79,7 @@ function getPostUrl(frontmatter, slug) {
       // fall through to default URL
     }
   }
-  return `${SITE_URL}/write/${slug}/`;
+  return `${SITE_URL}/posts/${slug}/`;
 }
 
 /** Format post text for syndication. */
@@ -212,7 +212,7 @@ async function main() {
     console.log('🏃 DRY RUN — no posts will be published\n');
   }
 
-  const files = await collectMarkdownFiles(WRITING_DIR);
+  const files = await collectMarkdownFiles(POSTS_DIR);
   let syndicatedPlatformCount = 0;
 
   for (const filePath of files) {

--- a/workers/sveltia-auth/src/index.ts
+++ b/workers/sveltia-auth/src/index.ts
@@ -8,6 +8,8 @@ export interface Env {
 }
 
 const STATE_COOKIE = "sveltia_oauth_state";
+// Cap GitHub token-exchange to keep us comfortably under the Workers CPU limit.
+const TOKEN_EXCHANGE_TIMEOUT_MS = 8000;
 
 function parseOrigins(env: Env): string[] {
   return env.AUTH_ALLOWED_ORIGINS.split(",").map((s) => s.trim()).filter(Boolean);
@@ -23,8 +25,14 @@ function pickOrigin(referer: string | null, allowed: string[]): string | null {
   }
 }
 
+// Token-bearing HTML: never cache. SameSite/HttpOnly handled at the cookie layer.
 function htmlResponse(body: string): Response {
-  return new Response(body, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
 }
 
 function postMessageHTML(targetOrigin: string, status: "success" | "error", payload: unknown): string {
@@ -38,6 +46,23 @@ function postMessageHTML(targetOrigin: string, status: "success" | "error", payl
   </script></body></html>`;
 }
 
+// Emit an OAuth error. If we can't safely identify a target origin (e.g. the
+// allowlist is empty or the cookie was tampered with), refuse outright instead
+// of falling back to "*" — that fallback would let any popup-opener page
+// receive the postMessage.
+function originErrorResponse(targetOrigin: string | null, allowed: string[], message: string): Response {
+  if (targetOrigin && allowed.includes(targetOrigin)) {
+    return htmlResponse(postMessageHTML(targetOrigin, "error", { message }));
+  }
+  if (allowed[0]) {
+    return htmlResponse(postMessageHTML(allowed[0], "error", { message }));
+  }
+  return new Response("Origin not allowed", {
+    status: 400,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -45,6 +70,12 @@ export default {
 
     if (url.pathname === "/auth") {
       const origin = pickOrigin(request.headers.get("Referer"), allowed) ?? allowed[0];
+      if (!origin) {
+        return new Response("Origin not allowed", {
+          status: 400,
+          headers: { "Cache-Control": "no-store" },
+        });
+      }
       const state = crypto.randomUUID();
       const cookieValue = `${state}|${encodeURIComponent(origin)}`;
       const params = new URLSearchParams({
@@ -58,6 +89,7 @@ export default {
         headers: {
           Location: `https://github.com/login/oauth/authorize?${params}`,
           "Set-Cookie": `${STATE_COOKIE}=${cookieValue}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=600`,
+          "Cache-Control": "no-store",
         },
       });
     }
@@ -69,25 +101,51 @@ export default {
         .split(";").map((s) => s.trim())
         .find((c) => c.startsWith(`${STATE_COOKIE}=`))?.split("=")[1] || "";
       const [cookieState, cookieOriginEnc] = cookie.split("|");
-      const targetOrigin = decodeURIComponent(cookieOriginEnc || "");
+
+      // Malformed percent-encoding crashes decodeURIComponent. Treat any
+      // decode failure as "no valid origin" so the error path fires cleanly.
+      let targetOrigin: string | null = null;
+      try {
+        targetOrigin = decodeURIComponent(cookieOriginEnc || "");
+      } catch {
+        targetOrigin = null;
+      }
 
       if (!targetOrigin || !allowed.includes(targetOrigin)) {
-        return htmlResponse(postMessageHTML(allowed[0] || "*", "error", { message: "Origin not allowed" }));
+        return originErrorResponse(targetOrigin, allowed, "Origin not allowed");
       }
       if (!code || !state || state !== cookieState) {
         return htmlResponse(postMessageHTML(targetOrigin, "error", { message: "Invalid state" }));
       }
 
-      const tokenRes = await fetch("https://github.com/login/oauth/access_token", {
-        method: "POST",
-        headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({
-          client_id: env.GITHUB_CLIENT_ID,
-          client_secret: env.GITHUB_CLIENT_SECRET,
-          code,
-        }),
-      });
-      const data = (await tokenRes.json()) as { access_token?: string; error?: string };
+      // Robust token exchange: bound the request, check status, and treat any
+      // network/parse failure as a controlled OAuth error rather than a 500.
+      let data: { access_token?: string; error?: string } = {};
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS);
+      try {
+        const tokenRes = await fetch("https://github.com/login/oauth/access_token", {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_id: env.GITHUB_CLIENT_ID,
+            client_secret: env.GITHUB_CLIENT_SECRET,
+            code,
+          }),
+          signal: controller.signal,
+        });
+        if (!tokenRes.ok) {
+          return htmlResponse(
+            postMessageHTML(targetOrigin, "error", { message: `Token endpoint returned ${tokenRes.status}` }),
+          );
+        }
+        data = (await tokenRes.json()) as { access_token?: string; error?: string };
+      } catch {
+        return htmlResponse(postMessageHTML(targetOrigin, "error", { message: "Token exchange failed" }));
+      } finally {
+        clearTimeout(timeout);
+      }
+
       if (!data.access_token) {
         return htmlResponse(postMessageHTML(targetOrigin, "error", { message: data.error || "No token" }));
       }


### PR DESCRIPTION
## **User description**
## Summary

Resolves the open code-review findings on PR #261 (Sveltia CMS / #247).

| # | Severity | File | Fix |
|---|----------|------|-----|
| 1 | HIGH (architect) | `public/_headers` | Restore site-wide CSP on `/*`; drop duplicated per-route blocks. Previously `/about`, `/code`, `/now`, `/resume`, `/sandbox`, `/work` had no CSP. |
| 2 | HIGH (architect) | `scripts/syndicate.mjs`, `scripts/fetch-comments.mjs` | Repoint from pre-#244 `src/content/writing/` + `/write/<slug>/` to `src/content/posts/` + `/posts/<slug>/`. |
| 3 | MAJOR | `workers/sveltia-auth/src/index.ts` | Token-exchange try/catch, `tokenRes.ok` check, AbortController timeout (8s). |
| 4 | MAJOR | `workers/sveltia-auth/src/index.ts` | `decodeURIComponent` wrapped in try/catch — malformed cookie no longer crashes callback. |
| 5 | MAJOR | `workers/sveltia-auth/src/index.ts` | `Cache-Control: no-store` on all auth HTML responses (token-bearing). |
| 6 | MAJOR | `workers/sveltia-auth/src/index.ts` | Drop `"*"` postMessage fallback; refuse outright when no safe target origin exists. |
| 7 | NIT | `public/admin/config.yml` | Document the role of `public_folder: /images` (Sveltia requires it; future image widgets must override per-field). |

## Test Plan

- [x] `npm run build` clean (verified locally)
- [x] `workers/sveltia-auth` tsc clean
- [ ] After merge: redeploy auth Worker:
  ```bash
  cd workers/sveltia-auth && npm run deploy
  ```
- [ ] After Worker redeploy: smoke checks
  ```bash
  curl -sSI https://auth.gvns.ca/auth | grep -i "cache-control"           # expect: no-store
  curl -sSI "https://auth.gvns.ca/callback?code=x" --cookie 'sveltia_oauth_state=abc|%E0%80'   # malformed encoding; expect 400 (not 500)
  ```
- [ ] After site deploy: CSP coverage check
  ```bash
  for path in / /about/ /code/ /now/ /resume/ /work/ /admin/; do
    curl -sSI "https://gvns.ca${path}" | grep -i "content-security-policy"
  done
  # expect: every route returns a CSP header
  ```
- [ ] CMS: open `https://gvns.ca/admin/`, create a draft post → saves cleanly

## Already addressed in #261 (not in this PR)

- canonicalUrl regex permissiveness — pattern was removed in #261; Zod is single source of truth.
- `.mdx` slug discovery in wikilink-convert — fixed in #261.
- CDN supply-chain risk — bundle vendored to `public/admin/sveltia-cms-0.157.1.js` with SHA-384 SRI in #261.

## Deferred

- Slug normalization divergence in `scripts/wikilink-convert.mjs` — kebab-case naming convention prevents practical divergence; tracking via #264.

Refs #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved error messaging for OAuth authentication failures

* **Bug Fixes**
  * Enhanced authentication security with request timeouts and stricter origin validation
  * Optimized cache control for authentication pages
  * Updated syndicated content URLs to use `/posts/` format

* **Security**
  * Consolidated Content-Security-Policy headers globally for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix CSP coverage, auth callback handling, and syndication paths

### What Changed
- Restored the site-wide content security policy so every page gets the same protection again
- Updated syndication scripts to look in the current posts folder and generate `/posts/<slug>/` links instead of broken old paths
- Hardened the CMS login callback so bad cookie data, token exchange failures, and slow GitHub responses return a clean error instead of breaking the flow
- Prevented auth pages from being cached and removed the unsafe fallback that could send login messages to the wrong site
- Clarified the CMS image upload settings for future post images

### Impact
`✅ Fewer broken syndication runs`
`✅ Safer CMS login popups`
`✅ Fewer auth callback failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=AzVUMfZqJdHQprwoZcFB9DX-6vG2T9dooCXxnccRkP0&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
