### PR TITLE
fix(headers): detach inherited /* CSP on /admin/* (Sveltia load fix)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -10,4 +10,5 @@
   Cache-Control: public, max-age=31536000, immutable
 
 /admin/*
+  ! Content-Security-Policy
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://www.githubstatus.com https://auth.gvns.ca https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com

--- a/scripts/verify-csp.mjs
+++ b/scripts/verify-csp.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Post-deploy CSP coverage check.
+//
+// Why this exists: setting CSP via Cloudflare _headers is order-sensitive in
+// a non-obvious way — when both /* and a more-specific rule (like /admin/*)
+// match a request, BOTH Content-Security-Policy headers are emitted, and
+// browsers enforce each policy independently (W3C CSP3, "combined policy is
+// the conjunction of all individual policies"). Effective CSP is the
+// intersection (strictest wins), so a "looser" override on /admin/* doesn't
+// loosen anything unless the inherited /* CSP is detached first via
+// `! Content-Security-Policy`.
+//
+// We've shipped that bug twice. This script catches it before the third.
+//
+// Usage:  node scripts/verify-csp.mjs [origin]
+//         origin defaults to https://gvns.ca
+
+const ORIGIN = process.argv[2] || "https://gvns.ca";
+
+// Routes we expect to have a CSP, and the marker substring that proves which
+// CSP arrived. The marker is the connect-src value because it's the
+// directive that actually broke /admin/.
+const expectations = [
+  { path: "/",       marker: "connect-src 'self' https://analytics.gvns.ca",    label: "site"  },
+  { path: "/about/", marker: "connect-src 'self' https://analytics.gvns.ca",    label: "site"  },
+  { path: "/code/",  marker: "connect-src 'self' https://analytics.gvns.ca",    label: "site"  },
+  { path: "/now/",   marker: "connect-src 'self' https://analytics.gvns.ca",    label: "site"  },
+  { path: "/work/",  marker: "connect-src 'self' https://analytics.gvns.ca",    label: "site"  },
+  { path: "/admin/", marker: "https://api.github.com",                          label: "admin" },
+];
+
+let failures = 0;
+
+// Node's fetch Headers collapses duplicates by joining values with ", ".
+// CSP directives use ";" internally — never ",". So if the joined header
+// value contains ", " between two directive-bearing chunks, multiple
+// policies were sent. We detect by counting "default-src" occurrences.
+function countPolicies(cspHeaderValue) {
+  if (!cspHeaderValue) return 0;
+  const matches = cspHeaderValue.match(/(^|[,\s])default-src/g);
+  return matches ? matches.length : 0;
+}
+
+for (const { path, marker, label } of expectations) {
+  const res = await fetch(ORIGIN + path, { method: "HEAD", redirect: "manual" });
+  const csp = res.headers.get("content-security-policy");
+
+  if (!csp) {
+    console.error(`FAIL ${path}: no Content-Security-Policy header (label: ${label})`);
+    failures++;
+    continue;
+  }
+  const policyCount = countPolicies(csp);
+  if (policyCount > 1) {
+    console.error(`FAIL ${path}: ${policyCount} CSP policies sent — browsers intersect them (strictest wins, label: ${label})`);
+    console.error(`  joined: ${csp.slice(0, 300)}…`);
+    failures++;
+    continue;
+  }
+  if (!csp.includes(marker)) {
+    console.error(`FAIL ${path}: CSP doesn't contain expected '${label}' marker "${marker}"`);
+    console.error(`  got: ${csp.slice(0, 200)}…`);
+    failures++;
+    continue;
+  }
+  console.log(`OK   ${path}  (${label})`);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} route(s) failed CSP verification.`);
+  process.exit(1);
+}
+console.log("\nAll routes have exactly one CSP header with the expected scope.");


### PR DESCRIPTION
## **User description**
## Root cause

\`curl -sSI https://gvns.ca/admin/\` returns **two** \`Content-Security-Policy\` headers — one from the \`/*\` rule (strict site CSP), one from \`/admin/*\` (loose admin CSP). Per [W3C CSP3](https://www.w3.org/TR/CSP3/#multiple-policies), each policy is enforced independently — effectively the **intersection** (strictest wins). The site CSP forbids \`fonts.googleapis.com\` and \`api.github.com\`, so Sveltia stayed blocked despite the admin override.

This corrects a bad assumption on my part during #265 — Cloudflare \`_headers\` does NOT pick the most-specific rule; it concatenates matching rules into multiple response headers.

## Fix

Per [Cloudflare's official docs](https://developers.cloudflare.com/workers/static-assets/headers/#detach-a-header), prepend \`! Content-Security-Policy\` on \`/admin/*\` to detach the inherited \`/*\` CSP, then re-assert the loose admin CSP:

\`\`\`
/admin/*
  ! Content-Security-Policy
  Content-Security-Policy: <admin loose CSP>
\`\`\`

Result: single CSP header on \`/admin/\`, no intersection.

## Regression prevention

Adds \`scripts/verify-csp.mjs\`. Fails if any monitored route returns zero CSP headers OR more than one CSP policy in the joined header value. Run post-deploy:

\`\`\`bash
node scripts/verify-csp.mjs https://gvns.ca
\`\`\`

Currently fails against prod (correctly detects the existing bug):

\`\`\`
OK   /  (site)
OK   /about/  (site)
...
FAIL /admin/: 2 CSP policies sent — browsers intersect them (strictest wins, label: admin)
\`\`\`

After this PR merges and deploys, all routes should pass.

## Test plan

- [x] Local build clean
- [x] Verifier detects the current broken state on prod
- [ ] After merge: \`node scripts/verify-csp.mjs https://gvns.ca\` → all OK
- [ ] After merge: open \`https://gvns.ca/admin/\`, sign in via GitHub — Sveltia loads, fonts render, OAuth completes

Refs #247 #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Content Security Policy configuration for admin routes
  * Added post-deployment verification for Content Security Policy headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Stop the admin area from inheriting the site’s strict content rules

### What Changed
- The admin page now uses its own content rules instead of combining them with the site-wide rules, which fixes blocked admin features like Sveltia, GitHub sign-in, and Google Fonts
- Added a check that fails if any key page is missing a content security policy or sends more than one policy, so this issue is caught before deployment

### Impact
`✅ Admin sign-in works again`
`✅ Fewer blocked fonts and scripts in /admin`
`✅ Earlier detection of broken security headers`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=NpajjzXpvnDdWpw-F7_scwkXLx_ZSu8sHeFVCixRz2s&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
