### PR TITLE
chore(seo): standardise page title format (#268)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,12 +16,15 @@ interface Props {
 }
 
 const { title, description, image, imageWidth, imageHeight, accent, breadcrumbs } = Astro.props;
+
+const SITE_SUFFIX = ' | gvns.ca';
+const fullTitle = title.endsWith(SITE_SUFFIX) ? title : `${title}${SITE_SUFFIX}`;
 ---
 
 <!doctype html>
 <html lang="en" data-accent={accent}>
   <head>
-    <BaseHead title={title} description={description} image={image} imageWidth={imageWidth} imageHeight={imageHeight} />
+    <BaseHead title={fullTitle} description={description} image={image} imageWidth={imageWidth} imageHeight={imageHeight} />
     <slot name="head" />
     <script is:inline>
       // Initialize theme before page renders to prevent flash

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -18,7 +18,7 @@ const { title, description, accent, breadcrumbs } = Astro.props;
 ---
 
 <BaseLayout
-    title={`${title} | gvns.ca`}
+    title={title}
     description={description || title}
     accent={accent}
     breadcrumbs={breadcrumbs}

--- a/src/layouts/post-layout.astro
+++ b/src/layouts/post-layout.astro
@@ -53,7 +53,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title={`${title} | gvns.ca`}
+    title={title}
     description={description}
     image={heroImageUrl}
     imageWidth={heroImageWidth}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import BaseLayout from "@layouts/BaseLayout.astro";
 ---
 
 <BaseLayout
-    title="Page Not Found | gvns.ca"
+    title="Page Not Found"
     description="The page you're looking for doesn't exist."
     accent="p5-sky"
 >

--- a/src/pages/code/index.astro
+++ b/src/pages/code/index.astro
@@ -37,7 +37,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Code | gvns.ca"
+    title="Code"
     description="Building in public on GitHub. Recent commits, active repositories, and coding activity."
     accent="p1-violet"
     breadcrumbs={[

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
 ---
 
 <BaseLayout
-  title="Gareth Evans — GVNS"
+  title="Gareth Evans"
   description="Personal site for writing and shipped work. Serious work, questionable puns."
   accent="neutral"
 >

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -122,7 +122,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Listen | gvns.ca"
+    title="Listen"
     description="Tracking my music via ListenBrainz."
     accent="p3-emerald"
     breadcrumbs={[

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -20,7 +20,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Now | gvns.ca"
+    title="Now"
     description="What I'm up to right now — code, reading, music, and more."
     accent="p5-sky"
     breadcrumbs={[{ label: "Home", href: "/" }, { label: "Now" }]}

--- a/src/pages/posts/archive.astro
+++ b/src/pages/posts/archive.astro
@@ -36,7 +36,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Archive | Posts"
+    title="Posts archive"
     description="Browse all posts by date."
     accent="p4-amber"
     breadcrumbs={[

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -21,7 +21,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Posts | gvns.ca"
+    title="Posts"
     description="Thoughts on homelab, web development, BJJ, and productivity."
     accent="p4-amber"
     breadcrumbs={[{ label: "Home", href: "/" }, { label: "Posts" }]}

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -51,7 +51,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title={`Posts tagged "${tag}" | gvns.ca`}
+    title={`Posts tagged "${tag}"`}
     description={`All writing posts tagged with ${tag}.`}
     accent="p4-amber"
     breadcrumbs={[

--- a/src/pages/posts/tags/index.astro
+++ b/src/pages/posts/tags/index.astro
@@ -34,7 +34,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Tags | gvns.ca"
+    title="Tags"
     description="Browse all post tags."
     accent="p4-amber"
     breadcrumbs={[

--- a/src/pages/read/index.astro
+++ b/src/pages/read/index.astro
@@ -73,7 +73,7 @@ if (readingData.lastUpdated) {
 ---
 
 <BaseLayout
-    title="Read | gvns.ca"
+    title="Read"
     description="Tracking my reading via Hardcover. Currently reading, finished, and want to read."
     accent="p2-rose"
     breadcrumbs={[

--- a/src/pages/watch/index.astro
+++ b/src/pages/watch/index.astro
@@ -45,7 +45,7 @@ const breadcrumbJsonLd = toJsonLd(
 ---
 
 <BaseLayout
-    title="Watch | gvns.ca"
+    title="Watch"
     description="Movies and shows I've been watching."
     accent="p4-amber"
     breadcrumbs={[


### PR DESCRIPTION
## **User description**
## Summary
- Move the ` | gvns.ca` suffix into `BaseLayout` as the single source of truth for `<title>`, `og:title`, and `twitter:title`.
- Pass bare titles from `PageLayout`, `post-layout`, and every page; suffix is appended idempotently so pages can opt in/out without breaking.
- Homepage now renders `Gareth Evans | gvns.ca` (was `Gareth Evans — GVNS`).
- Tag index, archive, and other index pages all flow through the same path; `og:title` / `twitter:title` mirror the `<title>` (suffix included) — documented in code via `SITE_SUFFIX`.

## Test Plan
- [x] `npm run build` succeeds
- [x] Spot-checked rendered `<title>` in `dist/client/`:
  - `/` → `Gareth Evans | gvns.ca`
  - `/posts/` → `Posts | gvns.ca`
  - `/read/` → `Read | gvns.ca`
  - `/about/` → `About | gvns.ca`
  - `/404.html` → `Page Not Found | gvns.ca`
  - `/posts/testy/` → `testy | gvns.ca`
- [x] Grepped `src/pages/` for hardcoded ` | gvns.ca` — none remain

Closes #268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized page title formatting across all pages to consistently display the site suffix in browser tabs and document metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Standardize page titles so site names are added consistently across pages and social cards

### What Changed
- Page titles now get the site suffix from one shared place, so pages can pass plain titles without adding `| gvns.ca` themselves
- Home, 404, posts, tags, archive, and now-related pages now use a cleaner title format before the suffix is added
- Post pages also use the same shared title path, so `<title>`, Open Graph, and Twitter titles stay aligned

### Impact
`✅ Consistent page titles across the site`
`✅ Clearer social share cards`
`✅ Fewer title formatting mismatches`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=I5th85K7GaSielaHFQMsvSqiYM7M5j_2zOY_ANqPUrg&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
