### PR TITLE
docs(infra): document branch-aware Workers Builds deploy (#262)

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -32,7 +32,7 @@ GitHub Actions (scheduled):
 | **Worker config (deploy)** | `dist/server/wrangler.json` — adapter-generated, includes resolved `main` |
 | **Node version** | 20 (via `.nvmrc`) |
 | **Production branch** | `main` |
-| **Preview deploys** | Enabled (auto on PRs via Workers Builds) |
+| **Preview deploys** | Non-`main` branches deploy via `wrangler versions upload` (versioned URL, no prod promotion) |
 
 ### Custom Domains
 
@@ -43,9 +43,26 @@ GitHub Actions (scheduled):
 
 ### How Deploys Work
 
-1. Push to `main` → Workers Builds auto-builds and deploys.
-2. PR opened → Workers Builds creates a preview deploy on a unique URL.
-3. Scheduled GH Actions fetch external data → commit JSON → push → triggers Workers Builds rebuild (same model as the previous Pages setup).
+Workers Builds runs a branch-aware deploy command — `main` promotes to production, every other branch produces a versioned preview URL without touching `gvns.ca`.
+
+The command is set in **Cloudflare → Workers & Pages → gvns-ca → Builds → Build settings**:
+
+```bash
+if [ "$WORKERS_CI_BRANCH" = "main" ]; then
+  npx wrangler deploy --config dist/server/wrangler.json
+else
+  npx wrangler versions upload --config dist/server/wrangler.json
+fi
+```
+
+> **Why `if/else` instead of `A && B || C`:** the short-circuit form silently falls through to the preview command if `wrangler deploy` fails on `main`, masking production failures. The explicit conditional propagates the exit code correctly.
+
+- **Push to `main`** → `wrangler deploy` promotes the build to the live `gvns-ca` Worker (`gvns.ca`).
+- **Push to any other branch** → `wrangler versions upload` returns a versioned preview URL of the form `<hash>-gvns-ca.<account>.workers.dev`. Production is unaffected.
+- **PR check** surfaces the preview URL in the Workers Builds log.
+- **Scheduled GH Actions** fetch external data → commit JSON → push to `main` → triggers a normal production build.
+
+Before this change, every branch ran `wrangler deploy` and overwrote production — discovered during #247 (CMS adoption). See #262 for context.
 
 No deploy workflow needed in `.github/workflows/`. No Cloudflare secrets in GitHub — Workers Builds uses the native git integration.
 
@@ -142,4 +159,4 @@ No Cloudflare secrets needed in GitHub — deploys are handled by Workers Builds
 
 ---
 
-*Last updated: 2026-04-26*
+*Last updated: 2026-04-27*

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -43,26 +43,24 @@ GitHub Actions (scheduled):
 
 ### How Deploys Work
 
-Workers Builds runs a branch-aware deploy command — `main` promotes to production, every other branch produces a versioned preview URL without touching `gvns.ca`.
+Workers Builds runs a different deploy command for the production branch (`main`) than for every other branch. `main` promotes to production; other branches produce a versioned preview URL without touching `gvns.ca`.
 
-The command is set in **Cloudflare → Workers & Pages → gvns-ca → Builds → Build settings**:
+Configured in **Cloudflare → Workers & Pages → gvns-ca → Builds → Build configuration**:
 
-```bash
-if [ "$WORKERS_CI_BRANCH" = "main" ]; then
-  npx wrangler deploy --config dist/server/wrangler.json
-else
-  npx wrangler versions upload --config dist/server/wrangler.json
-fi
-```
-
-> **Why `if/else` instead of `A && B || C`:** the short-circuit form silently falls through to the preview command if `wrangler deploy` fails on `main`, masking production failures. The explicit conditional propagates the exit code correctly.
+| Field | Value |
+|-------|-------|
+| Build command | `npm run build` |
+| Deploy command (production branch only) | `npx wrangler deploy --config dist/server/wrangler.json` |
+| Non-production branch deploy command | `npx wrangler versions upload --config dist/server/wrangler.json` |
+| Path | `/` |
+| Production branch | `main` |
 
 - **Push to `main`** → `wrangler deploy` promotes the build to the live `gvns-ca` Worker (`gvns.ca`).
 - **Push to any other branch** → `wrangler versions upload` returns a versioned preview URL of the form `<hash>-gvns-ca.<account>.workers.dev`. Production is unaffected.
 - **PR check** surfaces the preview URL in the Workers Builds log.
 - **Scheduled GH Actions** fetch external data → commit JSON → push to `main` → triggers a normal production build.
 
-Before this change, every branch ran `wrangler deploy` and overwrote production — discovered during #247 (CMS adoption). See #262 for context.
+Before this change, the non-production deploy command was also `wrangler deploy`, so every branch overwrote production — discovered during #247 (CMS adoption). See #262 for context.
 
 No deploy workflow needed in `.github/workflows/`. No Cloudflare secrets in GitHub — Workers Builds uses the native git integration.
 


### PR DESCRIPTION
## Summary

Documents the dashboard config change for #262 in `docs/INFRASTRUCTURE.md`. Workers Builds has dedicated fields for production vs non-production deploy commands, so the fix is two distinct commands — no shell conditional needed.

## Companion change (must be applied in Cloudflare dashboard)

**Workers & Pages → gvns-ca → Builds → Build configuration:**

| Field | Value |
|-------|-------|
| Build command | `npm run build` |
| Deploy command | `npx wrangler deploy --config dist/server/wrangler.json` |
| **Non-production branch deploy command** | `npx wrangler versions upload --config dist/server/wrangler.json` |
| Path | `/` |
| Production branch | `main` |

Only the **Non-production branch deploy command** field changes. Previously it was set to `wrangler deploy` (same as prod), which is why every branch was promoting to `gvns.ca`. `wrangler versions upload` produces a versioned preview URL with no production impact.

This PR is doc-only; the actual behaviour change is the dashboard config update.

## Test Plan

- [ ] Apply the dashboard config above (just the non-prod field)
- [ ] Push a commit to this branch (`docs/262-preview-deploys`) → Workers Builds log shows `versions upload`, returns `<hash>-gvns-ca.<account>.workers.dev`
- [ ] Confirm `gvns.ca` ETag/headers unchanged
- [ ] Merge to main → Workers Builds runs `wrangler deploy`, prod updates

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified branch-aware Workers Builds deploy process: production now promotes live Worker while non-main branches generate versioned preview URLs.
  * Rewrote "How Deploys Work" with explicit build configuration, commands and expected preview URL behaviour visible in Workers Builds logs.
  * Updated historical note and "Last updated" timestamp to 2026-04-27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->