### PR TITLE
docs: ADR-014 Sveltia image-handling survey (#282)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -373,6 +373,52 @@ Fetch Threads replies at build time via the Graph API using the denim library. C
 
 ---
 
+## ADR-014: Sveltia CMS Image Handling — Survey & Status Quo
+
+**Date**: 2026-04-27
+**Status**: Accepted
+
+### Context
+After landing the `/public/uploads/` workaround for #264 (broken `heroImage` resolution under our nested `path: "{{year}}/{{month}}/{{slug}}"` template), we needed to know whether the Astro+Sveltia community had already solved the same problems before committing to the inline-image spike (#278) or the validation work (#279). Survey was time-boxed to 90 minutes (issue #282).
+
+Eight repos surveyed plus the Sveltia upstream issue tracker. Key data:
+
+| Repo | path template | media_folder | slugify_filename | transformations | image() pipeline |
+|---|---|---|---|---|---|
+| ggfevans/gvns.ca (us) | `{{year}}/{{month}}/{{slug}}` | `public/uploads` (abs) | not set | WebP/q85/2048 | bypassed |
+| thiagopaixao/astro_sveltia | flat | `public/uploads` (abs) | **true** | not set | bypassed |
+| Snugug/sveltia-cms-astro-demo | flat | `public/media` (abs) | not set | not set | bypassed |
+| majesticostudio/astro-sveltia-cms | flat | `@assets/images/post` (alias) | not set | not set | attempted (underbaked) |
+| MattFM/giveback-guide | flat | `public/images/blog` (abs) + Cloudinary | **true** | not set (Cloudinary) | bypassed |
+| shiomiyan/blog | `{{slug}}/index` (bundle) | `public/media` (abs) | not set | not set | bypassed |
+| makmonty/makmonty.com | flat | `public/images/cms` (abs) | not set; uses top-level `slug.encoding: ascii` | not set | bypassed |
+| yacosta738/astro-cms | `{{year}}/{{month}}/{{day}}/{{slug}}` | `src/assets/images` | not set; uses top-level `slug.encoding: ascii` | not set | **used** (Sharp on `src/assets/`) |
+
+**Upstream finding (most consequential):** the #264 symptom is a known regression — Sveltia issue [#672](https://github.com/sveltia/sveltia-cms/issues/672), introduced in v0.140.4, fixed in **v0.146.7**. We're pinned at **v0.157.1** (`public/admin/sveltia-cms-0.157.1.js`), so the bug should already be resolved in our setup. Sveltia's recommended pattern for nested-path collections is entry-relative bundles: `media_folder: ""` + `public_folder: ""`, which co-locates uploads with the entry and auto-deletes them on entry removal. `slugify_filename` defaults to `false` in Sveltia (diverges from Decap).
+
+### Decision
+1. **Keep the current `/public/uploads/` absolute pattern** as the baseline. The spike (#278) should still validate the entry-relative bundle approach now that v0.157.1 has the #672 fix, but we don't pre-emptively switch — the absolute pattern is stable, predictable, and officially supported.
+2. **Add `media_libraries.default.config.slugify_filename: true`** in a small standalone PR before #278. This eliminates URL-encoded filenames (e.g. `No%20Ragrets...png`) at upload time and is independent of any inline-image architecture choice.
+3. **Defer the `@assets/`-alias / Astro `image()` pipeline approach** (yacosta738's pattern) to #278's evaluation. It's the only surveyed pattern that keeps `image()` benefits with a nested path, but adoption requires schema, Vite alias, and CMS-preview plumbing changes that are out of scope for a one-line config tweak.
+
+### Rationale
+- We're not the first to hit nested-path media bugs; we're the first to keep the nested path AND the absolute-uploads workaround. Two of three real-world blogs sidestep nested paths entirely (date-in-filename or `{{slug}}/index` bundles); only yacosta738 keeps deep nesting and pairs it with `src/assets/`-rooted media.
+- Our `media_libraries.transformations` (WebP/q85/2048) is ahead of every surveyed config — no prior art for gotchas, but no cautionary tales either.
+- `slugify_filename: true` is the canonical fix per upstream (#422) and is already in production use in two surveyed repos (thiagopaixao, MattFM). Low blast radius: only affects new uploads with non-ASCII / spaced names.
+- The upstream maintainer (kyoshino) is responsive on regressions (#666 was fixed within a day), so re-testing entry-relative on v0.157.1 in #278 is cheap and de-risked.
+
+### Consequences
+- A small follow-up PR adds `slugify_filename: true` under `media_libraries.default.config` in `public/admin/config.yml`. New uploads with spaces or accents will arrive on disk slugified; existing files unchanged.
+- #278 spike scope expands to include a re-test of entry-relative (`media_folder: ""`) on v0.157.1. If it works cleanly, #278 may produce a follow-up ADR that supersedes this one.
+- #279 (validation) is unaffected — Zod schema work is orthogonal to the media-folder decision.
+- #277 (tracking) is partially mitigated: `slugify_filename: true` removes one class of bug, narrowing what tracking needs to surface.
+- We deliberately do NOT adopt the alias-based `@assets/...` pattern. yacosta738/astro-cms is the only surveyed repo using it under a nested path, and the surveyed config did not include the matching Vite/tsconfig alias plumbing — suggests the pattern is fragile in practice.
+
+### Survey artefacts
+Raw findings and per-repo notes captured in this ADR; no separate research file. Sveltia upstream issues referenced: [#672](https://github.com/sveltia/sveltia-cms/issues/672), [#666](https://github.com/sveltia/sveltia-cms/issues/666), [#422](https://github.com/sveltia/sveltia-cms/issues/422), [#728](https://github.com/sveltia/sveltia-cms/issues/728), [#735](https://github.com/sveltia/sveltia-cms/issues/735).
+
+---
+
 ## Template for New Decisions
 
 ```markdown
@@ -396,4 +442,4 @@ Fetch Threads replies at build time via the Graph API using the denim library. C
 
 ---
 
-*Last updated: 2026-04-25*
+*Last updated: 2026-04-27*


### PR DESCRIPTION
## **User description**
## Summary
- Surveys 8 Astro+Sveltia repos and the upstream issue tracker for prior art on heroImage / inline-image handling
- Adds **ADR-014** to `docs/DECISIONS.md` with a comparison table and decision
- Headline: #264's symptom matches Sveltia regression [#672](https://github.com/sveltia/sveltia-cms/issues/672), fixed in v0.146.7 — we're already on v0.157.1, so re-testing entry-relative is cheap follow-up for #278
- Decision: keep `/public/uploads/` baseline, plan a separate small PR for `slugify_filename: true`, let #278 evaluate entry-relative

## Out of scope
- The `slugify_filename: true` config tweak (separate small PR, per ADR)
- Re-testing entry-relative `media_folder: ""` on v0.157.1 (folded into #278's spike scope)

## Test plan
- [ ] Markdown renders correctly in `docs/DECISIONS.md` (ADR-014 visible, table formatted)
- [ ] No code or runtime changes — docs-only
- [ ] Linked Sveltia issue numbers resolve

Closes #282
Informs #278, #279, #277


___

## **CodeAnt-AI Description**
**Document the Sveltia image-handling survey and decision**

### What Changed
- Adds ADR-014 to `docs/DECISIONS.md` with the survey findings for Sveltia image handling
- Records that the current `/public/uploads/` setup stays in place for now, while entry-relative uploads are left for a later check
- Notes a follow-up change to slugify uploaded filenames so new files with spaces or accents are stored cleanly
- Updates the decision log date

### Impact
`✅ Clearer media handling guidance`
`✅ Fewer URL-encoded upload filenames`
`✅ Faster follow-up on nested-path image checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5OAcpMtTqaG9-wUZ2mBUCfVdsc9apy1BQ0vOOFoDLTI&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision documentation for image handling in Sveltia CMS, formalizing the current uploads approach and establishing a timeline for configuration adjustments. Deferred evaluation of alternative image processing approaches for future assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->