### PR TITLE
fix(infra): drop assets.not_found_handling so SSR routes resolve

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,8 +5,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "directory": "./dist/client",
-    "binding": "ASSETS",
-    "not_found_handling": "404-page"
+    "binding": "ASSETS"
   },
   "kv_namespaces": [
     {


### PR DESCRIPTION
## **User description**
## Problem

`/contact` (and any other `prerender = false` route) returns the static `404.html` content with HTTP 200, even though the SSR worker exists and routes correctly:

\`\`\`
$ curl -sI https://gvns.ca/contact | head -2
HTTP/2 200
content-type: text/html
\`\`\`

The body is `dist/client/404.html`.

## Root cause

\`wrangler.jsonc\` had:

\`\`\`jsonc
\"assets\": {
  ...
  \"not_found_handling\": \"404-page\"
}
\`\`\`

That setting tells **Workers Static Assets** to serve the nearest `404.html` for any unmatched asset path — *before* invoking the worker. With `output: 'server'` and SSR routes (`/contact`, `/api/contact`, etc.), there's no static asset to match, so Cloudflare short-circuits to the 404 page and the SSR worker never runs.

It's the right setting for pure-static sites; it's wrong as soon as any route is `prerender = false`.

## Fix

Remove the line. Default behavior is **assets-first → worker fallback**, which is exactly what `@astrojs/cloudflare` is designed around.

Astro's `src/pages/404.astro` still gets prerendered to `dist/client/404.html`, and the adapter falls back to it via the assets binding when no SSR route matches — the user-visible 404 experience is unchanged.

## Why not `run_worker_first`?

Could have set `run_worker_first: ["/contact", "/api/*"]` to selectively route SSR paths, but that requires maintaining an enumeration every time a non-prerendered route is added. Default fallthrough handles it implicitly.

## Test plan

- [ ] Workers Builds preview deploy URL: `curl -sI <preview>/contact` returns HTTP 200 with the actual contact-form HTML (not 404 markup)
- [ ] `curl -sI <preview>/about/` still returns HTTP 200 with the prerendered about page
- [ ] `curl -sI <preview>/nonexistent-page` returns HTTP 404 with the custom 404 page (Astro's `404.astro` content)
- [ ] Submit the contact form on the preview → email arrives at `hi@gvns.ca`
- [ ] Run `node scripts/verify-csp.mjs <preview-origin>` → all paths pass

## Refs

- [Astro Cloudflare adapter docs](https://docs.astro.build/en/guides/integrations-guide/cloudflare/) — assets-first with worker fallback is the documented default
- [Workers Static Assets routing](https://developers.cloudflare.com/workers/static-assets/routing/worker-script/) — `not_found_handling` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated asset handling configuration; custom 404 error page handling has been removed while maintaining asset directory functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix SSR routes from showing the static 404 page**

### What Changed
- Removed the Cloudflare setting that was forcing unmatched routes to return the static 404 page before the app could handle them
- SSR pages like `/contact` now resolve through the app instead of being served the 404 page with a 200 response
- The custom 404 page still appears for real missing pages

### Impact
`✅ SSR pages load correctly`
`✅ Fewer false 404 pages on valid routes`
`✅ Clearer handling for missing pages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=wtXV3tPRlNUGpVN5QkTAkuh-DGOUymZiQNDMi3H_bZc&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
