### PR TITLE
fix(contact): log stage + error message in 500 paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ src/
 
 ### Naming
 
-- **Components** (`src/components/**/*.astro`, `*.svelte`): `PascalCase` (e.g. `BookList.astro`, `ThemeToggle.svelte`). Matches Astro/Svelte community norm and Starwind UI Pro output.
-- **Pages, routes, layouts, utils, content, styles**: `kebab-case` (e.g. `src/pages/read/index.astro`, `src/utils/reading-time.ts`). Keeps URLs and import paths clean.
+- **Components and layouts** (`src/components/**/*.astro`, `*.svelte`, `src/layouts/*.astro`): `PascalCase` (e.g. `BookList.astro`, `ThemeToggle.svelte`, `BaseLayout.astro`). Matches Astro/Svelte community norm and Starwind UI Pro output; layouts are imported and consumed exactly like components.
+- **Pages, routes, utils, content, styles**: `kebab-case` (e.g. `src/pages/read/index.astro`, `src/utils/reading-time.ts`). Keeps URLs and import paths clean.
 
 See `docs/COMPONENT-CONVENTIONS.md` for full rationale and examples.
 

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -204,7 +204,7 @@ export const POST: APIRoute = async (context) => {
     }
   } catch (err: unknown) {
     const e = err as Error & { code?: string };
-    log('send_failed', `error=${e.name}`);
+    log('send_failed', `stage=ratelimit error=${e.name} message=${JSON.stringify(e.message)}`);
     return errorResponse(fmt, 500, 'Something went wrong, please try again', 'server');
   }
 
@@ -242,7 +242,7 @@ export const POST: APIRoute = async (context) => {
       log('turnstile_failed', 'error=timeout');
       return errorResponse(fmt, 504, 'Verification timed out, please try again', 'verification');
     }
-    log('send_failed', `error=${e.name}`);
+    log('send_failed', `stage=turnstile_fetch error=${e.name} message=${JSON.stringify(e.message)}`);
     return errorResponse(fmt, 500, 'Something went wrong, please try again', 'server');
   } finally {
     clearTimeout(verifyTimeout);
@@ -271,7 +271,7 @@ export const POST: APIRoute = async (context) => {
     await cfEnv.SEND_EMAIL.send(message);
   } catch (err: unknown) {
     const e = err as Error & { code?: string };
-    log('send_failed', `error=${e.name}`);
+    log('send_failed', `stage=email error=${e.name} message=${JSON.stringify(e.message)}`);
     return errorResponse(fmt, 500, 'Something went wrong, please try again', 'server');
   }
 


### PR DESCRIPTION
## **User description**
## Summary
- Tag each 500-arm in `src/pages/api/contact.ts` with `stage=ratelimit|turnstile_fetch|email` so they're distinguishable in `wrangler tail`.
- Include `JSON.stringify(e.message)` alongside `e.name` so the underlying failure reason is captured.

## Why
Diagnostic step for #295. The contact form returns 500 in production and the existing log line (`outcome=send_failed error=<Name>`) doesn't say which dependency threw or why. Need this merged to `main` before we can attribute the failure — Turnstile site key is bound to `gvns.ca` only, so preview deploy URLs can't reproduce a real submission.

## Test plan
- [ ] Merge → wait for Workers Build to deploy.
- [ ] `npx wrangler tail gvns-ca --format pretty` running locally.
- [ ] Submit https://gvns.ca/contact with a real Turnstile token.
- [ ] Confirm log line includes `stage=…` and `message=…` identifying the failing arm.

Refs #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make contact form 500 logs show which step failed and why

### What Changed
- Contact form server errors now include the failing step in logs: rate limiting, Turnstile fetch, or email sending
- Error logs now also include the failure message, not just the error name
- Timeout handling for Turnstile checks stays separate and still returns a verification timeout response

### Impact
`✅ Faster contact form debugging`
`✅ Clearer production error logs`
`✅ Easier root-cause tracing for failed submissions`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=4xcXDh7pWFhKeu3dMeFokj56z2wJhUkoJDl68VoSNEw&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
