### PR TITLE
fix(contact): rename honeypot field to avoid browser autofill

### DIFF
--- a/src/components/ContactForm.svelte
+++ b/src/components/ContactForm.svelte
@@ -83,13 +83,15 @@
     onsubmit={handleSubmit}
     class="space-y-5"
   >
-    <!-- Honeypot: off-screen, not display:none so bots still interact with it -->
+    <!-- Honeypot: off-screen, not display:none so bots still interact with it.
+         Field name is intentionally non-semantic so browser autofill (notably
+         Firefox) doesn't populate it for real users. -->
     <div class="absolute left-[-9999px] w-px h-px overflow-hidden" aria-hidden="true">
-      <label for="contact-website">Leave this empty</label>
+      <label for="contact-hp-field">Leave this empty</label>
       <input
         type="text"
-        id="contact-website"
-        name="website"
+        id="contact-hp-field"
+        name="hp_field"
         tabindex="-1"
         autocomplete="off"
       />

--- a/src/lib/contact-schema.ts
+++ b/src/lib/contact-schema.ts
@@ -34,11 +34,12 @@ export const contactSchema = z.object({
     .max(5000, 'Message must be 5000 characters or fewer'),
 
   // Honeypot — must be absent or empty; bots fill this in.
-  website: z
+  // Field is named hp_field (not "website") to avoid browser autofill.
+  hp_field: z
     .string()
     .optional()
     .refine((val) => !val || val === '', {
-      message: 'website: must be empty',
+      message: 'hp_field: must be empty',
     }),
 
   'cf-turnstile-response': z.string().min(1, 'Turnstile token is required'),

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -188,7 +188,7 @@ export const POST: APIRoute = async (context) => {
   }
 
   // 6. Honeypot check
-  const honeypot = typeof fields.website === 'string' ? fields.website : '';
+  const honeypot = typeof fields.hp_field === 'string' ? fields.hp_field : '';
   if (honeypot !== '') {
     log('honeypot');
     // Return fake success — do NOT call rate limiter or send email


### PR DESCRIPTION
## **User description**
## Summary
- Rename the contact form's hidden honeypot field from \`website\` → \`hp_field\` on the Svelte form, Zod schema, and API handler.
- \`autocomplete="off"\` is widely ignored by Firefox on non-password fields; renaming to a non-semantic identifier removes the autofill trigger.

## Why
After #297 fixed the Reply-To 500, a real form submission returned 200 but no email arrived. \`wrangler tail\` showed \`outcome=honeypot ip=…\` — the handler short-circuits when the hidden field is non-empty, and Firefox had auto-filled it because \`name="website"\` matches a common autofill heuristic.

## Test plan
- [ ] Merge → wait for Workers Build to deploy.
- [ ] Submit https://gvns.ca/contact in Firefox (most aggressive autofill).
- [ ] Confirm \`outcome=ok\` in tail and email arrives at hi@gvns.ca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent browser autofill from filling the contact form honeypot**

### What Changed
- Renamed the hidden contact form field from `website` to `hp_field` so browser autofill is less likely to fill it for real users.
- Updated the form, validation, and API check to use the new honeypot field name.
- Kept the honeypot behavior the same: if the hidden field is filled, the submission is still treated as spam and not sent.

### Impact
`✅ Fewer contact form submissions blocked by autofill`
`✅ More reliable email delivery from the contact form`
`✅ Fewer false spam detections`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Sbng3ibpt0neqqu0oIpphitc-IT5KUq02VgzjjBet0Y&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
