### PR TITLE
fix(contact): set CSP from worker for SSR /contact route

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -13,6 +13,3 @@
   ! Content-Security-Policy
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://www.githubstatus.com https://auth.gvns.ca https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com
 
-/contact*
-  ! Content-Security-Policy
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com https://challenges.cloudflare.com 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://analytics.gvns.ca; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -13,6 +13,23 @@ const errorMessages: Record<string, string> = {
   server: 'Something went wrong on our end. Please try again.',
   bad_request: "That request couldn't be processed.",
 };
+
+// public/_headers only attaches CSP to static asset responses; this page is
+// SSR (prerender = false) so we set the header from the worker. Mirrors the
+// site CSP and adds Turnstile origins for script-src and frame-src.
+Astro.response.headers.set(
+  'Content-Security-Policy',
+  "default-src 'self'; " +
+    "script-src 'self' https://analytics.gvns.ca https://static.cloudflareinsights.com https://challenges.cloudflare.com 'unsafe-inline' 'wasm-unsafe-eval'; " +
+    "style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' https: data:; " +
+    "font-src 'self' data:; " +
+    "connect-src 'self' https://analytics.gvns.ca; " +
+    'frame-src https://challenges.cloudflare.com; ' +
+    "frame-ancestors 'none'; " +
+    "base-uri 'self'; " +
+    "form-action 'self'",
+);
 ---
 
 <PageLayout


### PR DESCRIPTION
## Problem

\`verify-csp.mjs\` reports:
\`\`\`
FAIL /contact: no Content-Security-Policy header (label: contact)
\`\`\`

\`public/_headers\` only attaches headers to **static asset responses**. The \`/contact*\` block I added in #275 looked correct in isolation, but \`/contact\` is now \`prerender = false\` (it reads \`Astro.url.searchParams\` for the success/error banner) so it's served from the SSR worker. The Cloudflare assets system never sees the request, and the rule never fires.

## Fix

Set the CSP from the worker via \`Astro.response.headers.set(...)\` in \`src/pages/contact.astro\`. The header now lives next to the route that needs it, and applies regardless of how the response is served.

Removes the dead \`/contact*\` block from \`public/_headers\` to keep one source of truth.

## Why this approach over middleware

Currently the only HTML route that needs a non-default CSP from the worker is \`/contact\`. Inline is the smallest change. If more SSR HTML routes appear that need custom CSPs, refactoring to a middleware that mirrors the static-route CSP for SSR HTML responses is the natural next step. Not yet.

## Test plan

- [ ] Workers Builds preview: \`curl -sI <preview>/contact | grep -i content-security-policy\` returns the policy with \`https://challenges.cloudflare.com\` in both \`script-src\` and \`frame-src\`
- [ ] \`node scripts/verify-csp.mjs <preview-origin>\` reports \`OK /contact (contact)\`
- [ ] Submit the contact form on the preview → no CSP violations in browser console; email arrives
- [ ] Other site routes (/, /about/, /admin/) still pass verify-csp

🤖 Generated with [Claude Code](https://claude.com/claude-code)