### PR TITLE
fix(contact): swap Cloudflare send_email binding for Resend HTTP API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "gray-matter": "^4.0.3",
         "image-size": "^2.0.2",
         "masto": "^7.10.2",
-        "mimetext": "^3.0.28",
         "pagefind": "^1.3.0",
         "react": "^19.2.4",
         "react-activity-calendar": "^3.1.2",
@@ -537,27 +536,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
-      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.48.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3748,17 +3726,6 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
-    "node_modules/core-js-pure": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4906,12 +4873,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6096,43 +6057,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimetext": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
-      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@babel/runtime-corejs3": "^7.26.0",
-        "js-base64": "^3.7.7",
-        "mime-types": "^2.1.35"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/muratgozel"
-      }
     },
     "node_modules/mini-svg-data-uri": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gray-matter": "^4.0.3",
     "image-size": "^2.0.2",
     "masto": "^7.10.2",
-    "mimetext": "^3.0.28",
     "pagefind": "^1.3.0",
     "react": "^19.2.4",
     "react-activity-calendar": "^3.1.2",

--- a/src/lib/contact-email.ts
+++ b/src/lib/contact-email.ts
@@ -1,4 +1,3 @@
-import { createMimeMessage, Mailbox } from 'mimetext';
 import type { ContactInput } from './contact-schema';
 
 const FROM_ADDRESS = 'noreply@gvns.ca';
@@ -6,19 +5,21 @@ const FROM_NAME = 'gvns.ca contact';
 const TO_ADDRESS = 'hi@gvns.ca';
 const SUBJECT_PREFIX = '[contact]';
 
-export function buildContactEmail(input: ContactInput): {
+export interface ResendPayload {
   from: string;
-  to: string;
-  raw: string;
-} {
-  const msg = createMimeMessage();
+  to: string[];
+  reply_to: string;
+  subject: string;
+  text: string;
+}
 
-  msg.setSender({ name: FROM_NAME, addr: FROM_ADDRESS });
-  msg.setTo(TO_ADDRESS);
-  msg.setHeader('Reply-To', new Mailbox({ addr: input.email, name: input.name }));
-  msg.setSubject(`${SUBJECT_PREFIX} ${input.subject}`);
+function quoteDisplayName(name: string): string {
+  if (/[",<>@]/.test(name)) return `"${name.replace(/(["\\])/g, '\\$1')}"`;
+  return name;
+}
 
-  const body = [
+export function buildResendPayload(input: ContactInput): ResendPayload {
+  const text = [
     `From: ${input.name} <${input.email}>`,
     `Subject: ${input.subject}`,
     '',
@@ -27,15 +28,11 @@ export function buildContactEmail(input: ContactInput): {
     input.message,
   ].join('\n');
 
-  msg.addMessage({
-    contentType: 'text/plain',
-    charset: 'utf-8',
-    data: body,
-  });
-
   return {
-    from: FROM_ADDRESS,
-    to: TO_ADDRESS,
-    raw: msg.asRaw(),
+    from: `${quoteDisplayName(FROM_NAME)} <${FROM_ADDRESS}>`,
+    to: [TO_ADDRESS],
+    reply_to: `${quoteDisplayName(input.name)} <${input.email}>`,
+    subject: `${SUBJECT_PREFIX} ${input.subject}`,
+    text,
   };
 }

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -2,12 +2,9 @@ import type { APIRoute } from 'astro';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — cloudflare:workers is a Cloudflare runtime module, not a Node module
 import { env } from 'cloudflare:workers';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — cloudflare:email is a Cloudflare runtime module, not a Node module
-import { EmailMessage } from 'cloudflare:email';
 
 import { contactSchema } from '../../lib/contact-schema';
-import { buildContactEmail } from '../../lib/contact-email';
+import { buildResendPayload } from '../../lib/contact-email';
 
 export const prerender = false;
 
@@ -20,11 +17,9 @@ interface RateLimiter {
 }
 
 interface CloudflareEnv {
-  SEND_EMAIL: {
-    send: (message: unknown) => Promise<void>;
-  };
   RATE_LIMITER: RateLimiter;
   TURNSTILE_SECRET_KEY: string;
+  RESEND_API_KEY: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -35,6 +30,8 @@ const BODY_SIZE_LIMIT = 10240; // 10 KB
 
 const TURNSTILE_VERIFY_URL =
   'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+const RESEND_SEND_URL = 'https://api.resend.com/emails';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -262,17 +259,38 @@ export const POST: APIRoute = async (context) => {
 
   const input = parsed.data;
 
-  // 10. Build MIME
-  const { from, to, raw } = buildContactEmail(input);
+  // 10. Build payload
+  const payload = buildResendPayload(input);
 
-  // 11. Send
+  // 11. Send via Resend
+  const sendController = new AbortController();
+  const sendTimeout = setTimeout(() => sendController.abort(), 10000);
   try {
-    const message = new EmailMessage(from, to, raw);
-    await cfEnv.SEND_EMAIL.send(message);
+    const sendRes = await fetch(RESEND_SEND_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${cfEnv.RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: sendController.signal,
+    });
+
+    if (!sendRes.ok) {
+      const errText = await sendRes.text().catch(() => '');
+      log('send_failed', `stage=email status=${sendRes.status} body=${JSON.stringify(errText.slice(0, 500))}`);
+      return errorResponse(fmt, 500, 'Something went wrong, please try again', 'server');
+    }
   } catch (err: unknown) {
     const e = err as Error & { code?: string };
+    if (e.name === 'AbortError') {
+      log('send_failed', 'stage=email error=timeout');
+      return errorResponse(fmt, 504, 'Sending timed out, please try again', 'server');
+    }
     log('send_failed', `stage=email error=${e.name} message=${JSON.stringify(e.message)}`);
     return errorResponse(fmt, 500, 'Something went wrong, please try again', 'server');
+  } finally {
+    clearTimeout(sendTimeout);
   }
 
   log('ok');

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,9 +16,6 @@
   "observability": {
     "enabled": true
   },
-  "send_email": [
-    { "name": "SEND_EMAIL", "destination_address": "hi@gvns.ca" }
-  ],
   "ratelimits": [
     {
       // namespace_id is any positive integer unique within this account.


### PR DESCRIPTION
## **User description**
## Summary
The Cloudflare \`send_email\` binding architecture assumes Cloudflare owns MX on the sending zone (Email Routing). gvns.ca's MX is at iCloud — out of scope to migrate. Even with everything else configured, sends were rejected with \`destination address is not a verified address\` because routed aliases on the same zone aren't valid account-level destinations.

This PR swaps the transport to **Resend** (HTTP API), which only requires DKIM/SPF TXT records on the zone and coexists with iCloud MX. Domain is already verified.

## Changes
- \`src/lib/contact-email.ts\` — rewrote \`buildContactEmail\` (MIMEMessage) → \`buildResendPayload\` (plain JSON: \`from\`, \`to\`, \`reply_to\`, \`subject\`, \`text\`). Display-name quoting handled inline.
- \`src/pages/api/contact.ts\` — replaced \`SEND_EMAIL.send()\` with \`fetch('https://api.resend.com/emails', ...)\`. 10s abort timeout. Logs Resend status + truncated body on 4xx/5xx; returns 504 on timeout.
- \`wrangler.jsonc\` — dropped \`send_email\` block.
- \`package.json\` — dropped \`mimetext\` dependency.
- \`CloudflareEnv\` interface gains \`RESEND_API_KEY\`, drops \`SEND_EMAIL\`.

Net diff: +47 / −112.

## Required infra
- Resend account: ✅ done (domain verified)
- \`RESEND_API_KEY\` Worker secret: ✅ set via \`wrangler secret put\`
- DNS (DKIM + SPF) on gvns.ca: ✅ added by Resend's CF integration

## Test plan
- [ ] Merge → wait for Workers Build to deploy.
- [ ] \`npx wrangler tail gvns-ca --format pretty\` running locally.
- [ ] Submit https://gvns.ca/contact with a real Turnstile token.
- [ ] Confirm \`outcome=ok\` in tail and email arrives in iCloud at hi@gvns.ca with the visitor's name in the Reply-To.
- [ ] Force a 4xx (e.g. temporarily revoke the API key) to confirm the new error logging surfaces \`status=\` and \`body=\`.

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email delivery infrastructure to use Resend service
  * Removed deprecated email dependency from project configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Contact form messages now send through Resend and no longer depend on Cloudflare Email Routing**

### What Changed
- Contact form submissions now use Resend to deliver email, so messages can be sent with the existing iCloud MX setup
- If sending takes too long, the form now stops waiting and returns a timeout message
- If Resend rejects a message, the site now returns a clear failure response instead of a silent send error
- The outgoing message still includes the visitor’s name, email, subject, and message in the reply details

### Impact
`✅ Fewer contact form send failures`
`✅ Clearer contact form error messages`
`✅ Fewer email setup conflicts on iCloud MX`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=VqKyf7HiAbBI1PV_0usBwfKYnJCgpDHP3Ih9bIgoYn4&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
