### PR TITLE
docs: add CONTACT-FORM.md runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,5 +105,6 @@ Detailed specs in `/docs/`:
 - `INFRASTRUCTURE.md` - Server config, CI/CD
 - `DECISIONS.md` - Architecture Decision Records
 - `CMS-SETUP.md` - Sveltia CMS at `gvns.ca/admin` + `auth.gvns.ca` Worker
+- `CONTACT-FORM.md` - `/contact` → Turnstile + rate limit + Resend HTTP API; debug recipe and known failure modes
 - `OBSIDIAN-SETUP.md` - Optional drafting in Obsidian → `npm run wikilinks` → paste into CMS
 - `ROADMAP.md` - Phases 6–10, what's done vs not

--- a/docs/CONTACT-FORM.md
+++ b/docs/CONTACT-FORM.md
@@ -1,0 +1,89 @@
+# Contact Form
+
+The `/contact` page submits to `POST /api/contact` (server-rendered Astro endpoint, deployed as part of the gvns-ca Worker). Submissions are validated, gated by Cloudflare Turnstile, rate-limited, and sent as email via the Resend HTTP API.
+
+## Architecture
+
+```
+Browser                  Worker (gvns-ca)                   External
+─────────                ─────────────────                  ────────
+ContactForm.svelte       src/pages/api/contact.ts
+   │                            │
+   │  POST /api/contact          │
+   │  ─────────────────────────▶│
+   │                            ├─▶ Origin / CT / size checks
+   │                            ├─▶ Honeypot (hp_field)
+   │                            ├─▶ RATE_LIMITER binding (5/60s per IP)
+   │                            ├─▶ POST challenges.cloudflare.com/turnstile/v0/siteverify
+   │                            │       (TURNSTILE_SECRET_KEY)
+   │                            ├─▶ Zod validate (contact-schema.ts)
+   │                            ├─▶ buildResendPayload (contact-email.ts)
+   │                            └─▶ POST api.resend.com/emails  ─────────▶  Resend
+   │  200 {ok:true}             │       (RESEND_API_KEY)                        │
+   │ ◀──────────────────────────│                                               ▼
+                                                                          DKIM-signed
+                                                                          email delivered
+                                                                          to hi@gvns.ca
+                                                                          (iCloud MX)
+```
+
+Cloudflare **does not own MX** on gvns.ca — iCloud does. We do not use `cloudflare:email` / `send_email` bindings. Resend is the transport because it only needs DKIM/SPF TXT records on the zone and coexists with iCloud receiving.
+
+## Files
+
+| File | Role |
+|---|---|
+| `src/components/ContactForm.svelte` | Client island; collects fields, renders Turnstile, POSTs as `application/x-www-form-urlencoded`. |
+| `src/pages/contact.astro` | Page wrapper; loads `https://challenges.cloudflare.com/turnstile/v0/api.js`; sets CSP. |
+| `src/pages/api/contact.ts` | Server endpoint; gating + Turnstile verify + Resend send. |
+| `src/lib/contact-schema.ts` | Zod schema (name/email/subject/message + honeypot + Turnstile token). |
+| `src/lib/contact-email.ts` | `buildResendPayload(input)` — returns plain JSON for Resend. |
+
+## Required infra
+
+| Item | Where | Notes |
+|---|---|---|
+| `TURNSTILE_SECRET_KEY` | Worker secret | `wrangler secret put TURNSTILE_SECRET_KEY --name gvns-ca` |
+| `PUBLIC_TURNSTILE_SITE_KEY` | Build-time env (Cloudflare Workers Builds → Variables) | Locked to `gvns.ca`. Preview deploy URLs cannot pass Turnstile. |
+| `RESEND_API_KEY` | Worker secret | `wrangler secret put RESEND_API_KEY --name gvns-ca` |
+| `RATE_LIMITER` binding | `wrangler.jsonc` `ratelimits` block | 5 requests / 60s per CF-Connecting-IP. |
+| Resend domain verification | resend.com → Domains → gvns.ca | Provides DKIM TXT record(s) and an SPF include to merge with iCloud's. |
+| DNS on gvns.ca | Cloudflare DNS | DKIM TXT (Resend), SPF TXT merged: `v=spf1 include:icloud.com include:_spf.resend.com ~all`. **MX stays at iCloud.** |
+
+## Outcomes (logged via `wrangler tail`)
+
+`[contact] outcome=<state> ip=<ip> [extra]`
+
+| outcome | meaning |
+|---|---|
+| `ok` | Email accepted by Resend; 200 to client. |
+| `origin_blocked` | Origin/Referer not gvns.ca or localhost. |
+| `unsupported_media_type` | Content-Type not JSON or form-urlencoded. |
+| `payload_too_large` | Body > 10 KB. |
+| `bad_request` | Body parse failed. |
+| `honeypot` | Hidden `hp_field` was non-empty. Returns fake 200 to client. |
+| `rate_limited` | RATE_LIMITER said no. 429 to client. |
+| `turnstile_failed` | Turnstile siteverify returned `success: false` or timed out. |
+| `validation_failed` | Zod parse failed. 400 with field errors. |
+| `send_failed` | Downstream throw. Tagged with `stage=ratelimit\|turnstile_fetch\|email`, plus `error=` and `message=` (or `status=`/`body=` for Resend 4xx/5xx). |
+
+## Debug recipe
+
+1. **Tail.** `npx wrangler tail gvns-ca --format pretty` from this repo. Submit the form on the live site — preview URLs cannot pass Turnstile because the site key is locked to `gvns.ca`.
+2. **Look at outcome.** The `[contact] outcome=...` line tells you which gate fired. Anything other than `ok` short-circuits before send.
+3. **`outcome=send_failed`?** The `stage=` and `message=`/`status=`/`body=` tell you which dependency threw. For `stage=email status=4xx`, the `body=` field is Resend's JSON error.
+4. **Cross-check Resend.** Resend dashboard → Logs lists every send attempt with payload + delivery state. If `outcome=ok` but no email arrives, the issue is post-Resend (deliverability, iCloud filtering).
+5. **Confirm secrets exist.** `npx wrangler secret list --name gvns-ca` should include `RESEND_API_KEY` and `TURNSTILE_SECRET_KEY`.
+
+## Known failure modes from history (#295)
+
+| Symptom | Root cause | Reference |
+|---|---|---|
+| 500 with no useful log | Catch arms only logged `error.name`; rate-limit / Turnstile-fetch / send-fail were indistinguishable | #296 added `stage=` + `message=` |
+| `MIMETEXT_INVALID_HEADER_VALUE` for Reply-To | mimetext rejects bare strings for address-list headers | #297 + #301 (since superseded by #302 dropping mimetext entirely) |
+| `outcome=honeypot` on real submissions | Hidden field was named `website` — Firefox autofill targets it. `autocomplete="off"` is widely ignored on non-password fields | #298 renamed to `hp_field` |
+| `destination address is not a verified address` | Cloudflare `send_email` binding requires the target to be an account-level Destination (an external verified mailbox). Routed aliases on the same zone (`hi@gvns.ca`) cannot be Destinations. | #302 dropped the binding entirely; switched to Resend HTTP API |
+
+## Local dev
+
+The Turnstile site key falls back to Cloudflare's always-pass test key (`1x00000000000000000000AA`) when `PUBLIC_TURNSTILE_SITE_KEY` is unset and `import.meta.env.DEV` is true. To smoke-test the send path locally, you'd also need `RESEND_API_KEY` available to the Worker dev runtime — easiest is to skip and verify in production.


### PR DESCRIPTION
## **User description**
## Summary
Adds `docs/CONTACT-FORM.md` capturing the final state of the contact form after #295 was resolved by #302:

- ASCII data-flow diagram (browser → Worker → Resend → iCloud MX).
- File map (`ContactForm.svelte` / `contact.astro` / `contact.ts` / `contact-schema.ts` / `contact-email.ts`).
- Required infra (Worker secrets, build-time vars, ratelimits binding, Resend domain verification, DNS — explicit note that **MX stays at iCloud**).
- Outcome log dictionary (`ok` / `origin_blocked` / `honeypot` / `rate_limited` / `turnstile_failed` / `validation_failed` / `send_failed` with `stage=…`).
- 5-step debug recipe.
- Known failure modes table cross-referencing the four real issues we hit (#296, #297/#301, #298, #302).
- Local dev note about the Turnstile test key fallback.

Also adds the doc to the index in CLAUDE.md.

## Test plan
- [ ] Read it. Make sure it'd unstick a future you (or me).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add a runbook for the contact form flow and troubleshooting**

### What Changed
- Adds a runbook for `/contact`, covering how submissions move through Turnstile, rate limiting, and Resend before reaching the mailbox.
- Documents the required setup, including secrets, DNS records, and the note that iCloud remains the MX provider.
- Adds a step-by-step debug guide plus the real failure modes seen during earlier fixes.
- Updates the docs index so the new contact form guide is easy to find.

### Impact
`✅ Faster contact form debugging`
`✅ Fewer setup mistakes for email delivery`
`✅ Clearer recovery from contact form failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=3bjATDyDJmF61mQPHXIVahYH91cWxydxIj86ffDoX6M&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contact form documentation covering validation processes, email delivery setup, and troubleshooting guidelines for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->