### PR TITLE
feat(homepage): adopt Starwind Blog 6 horizontal cards (#288)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Starwind Pro registry — required to install @starwind-pro/* components
+# (see ADR-016, docs/DECISIONS.md). Place the real key in `.env.local`.
+# STARWIND_LICENSE_KEY=
+
 # Future data integrations (set in GitHub Actions secrets, not CF Pages)
 # HARDCOVER_TOKEN=
 # HARDCOVER_USER_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
+# editor / IDE — Starwind init drops a snippets file here, but it's not project-specific
+.vscode/
+
 # git worktrees
 .worktree/
 .worktrees/

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -485,18 +485,22 @@ The end-to-end browser checklist is captured in the implementation PR. Critical 
 **Status**: Accepted
 
 ### Context
+
 Issues [#281](https://github.com/ggfevans/gvns.ca/issues/281) and [#288](https://github.com/ggfevans/gvns.ca/issues/288), under epic [#290](https://github.com/ggfevans/gvns.ca/issues/290). The homepage's `Recent Posts` list used the bespoke text-only `PostCard.astro`; with `heroImage` now flowing through Astro's `image()` pipeline (ADR-015), the homepage was the right surface to introduce a hero-thumb layout.
 
 ### Decision
+
 Wrap the structure of `@starwind-pro/blog-06` (image-left, content-right) in a new `src/components/HorizontalPostCard.astro` and use it on `/` only. `PostCard.astro` remains for `/posts` and `/posts/tags/[tag]` — separate decision once homepage adoption is proven.
 
 ### Rationale
-- Shell, not skin: take the Pro block's flex / @container layout; map its tokens (`--card`, `--border`, `--primary`, `--muted-foreground`) to our `--colour-*` palette via `src/styles/starwind.css` — no fork.
+
+- Shell, not skin: take the Pro block's flex / viewport-breakpoint layout; map its tokens (`--card`, `--border`, `--primary`, `--muted-foreground`) to our `--colour-*` palette via `src/styles/starwind.css` — no fork.
 - Reuse over re-implement: existing `formatDate`, `getReadingTime`, `getPostSlug`, and Starwind `Badge` / `Button` / `Card` primitives compose the body — TagList stays for other surfaces.
 - Posts without `heroImage` render a content-only row (no broken `<img>`, no layout collapse) — the homepage gracefully tolerates the optional schema.
-- Hero images use Astro `<Image>` with `widths={[320,480,640,800]}` and `loading="lazy"` (off-screen below the hero). Per-viewport srcset comes from the existing pipeline, not unpic — that's #272.
+- Hero images use Astro `<Image>` with `widths={[288, 320, 480, 640, 800]}` and `loading="lazy"` (off-screen below the hero). Per-viewport srcset comes from the existing pipeline, not unpic — that's #272.
 
 ### Consequences
+
 - Pro init is now persisted (`@starwind-pro` registry already configured at the npm/auth layer; no `pro: true` field in `starwind.config.json` because none exists).
 - `STARWIND_LICENSE_KEY` is required in `.env.local` for any Pro `add` to succeed; documented in `.env.example`.
 - `badge` (free primitive, v1.4.2) is now installed and available for #289 / #291 / #292 / #293.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -479,6 +479,31 @@ The end-to-end browser checklist is captured in the implementation PR. Critical 
 
 ---
 
+## ADR-016: Adopt Starwind Pro Blog 6 (Horizontal Cards) on the Homepage
+
+**Date**: 2026-04-28
+**Status**: Accepted
+
+### Context
+Issues [#281](https://github.com/ggfevans/gvns.ca/issues/281) and [#288](https://github.com/ggfevans/gvns.ca/issues/288), under epic [#290](https://github.com/ggfevans/gvns.ca/issues/290). The homepage's `Recent Posts` list used the bespoke text-only `PostCard.astro`; with `heroImage` now flowing through Astro's `image()` pipeline (ADR-015), the homepage was the right surface to introduce a hero-thumb layout.
+
+### Decision
+Wrap the structure of `@starwind-pro/blog-06` (image-left, content-right) in a new `src/components/HorizontalPostCard.astro` and use it on `/` only. `PostCard.astro` remains for `/posts` and `/posts/tags/[tag]` — separate decision once homepage adoption is proven.
+
+### Rationale
+- Shell, not skin: take the Pro block's flex / @container layout; map its tokens (`--card`, `--border`, `--primary`, `--muted-foreground`) to our `--colour-*` palette via `src/styles/starwind.css` — no fork.
+- Reuse over re-implement: existing `formatDate`, `getReadingTime`, `getPostSlug`, and Starwind `Badge` / `Button` / `Card` primitives compose the body — TagList stays for other surfaces.
+- Posts without `heroImage` render a content-only row (no broken `<img>`, no layout collapse) — the homepage gracefully tolerates the optional schema.
+- Hero images use Astro `<Image>` with `widths={[320,480,640,800]}` and `loading="lazy"` (off-screen below the hero). Per-viewport srcset comes from the existing pipeline, not unpic — that's #272.
+
+### Consequences
+- Pro init is now persisted (`@starwind-pro` registry already configured at the npm/auth layer; no `pro: true` field in `starwind.config.json` because none exists).
+- `STARWIND_LICENSE_KEY` is required in `.env.local` for any Pro `add` to succeed; documented in `.env.example`.
+- `badge` (free primitive, v1.4.2) is now installed and available for #289 / #291 / #292 / #293.
+- The Pro `blog-06` source files (`Blog6.astro`, `Blog6Demo.astro`) were removed after the layout intent was forked into `HorizontalPostCard.astro` — they're dead code, and re-installing via `npx starwind@latest add @starwind-pro/blog-06` is trivial if a future contributor wants to consult the original block.
+
+---
+
 ## Template for New Decisions
 
 ```markdown

--- a/src/components/HorizontalPostCard.astro
+++ b/src/components/HorizontalPostCard.astro
@@ -1,0 +1,79 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { Image } from 'astro:assets';
+import ArrowRightIcon from '@tabler/icons/outline/arrow-right.svg';
+import { formatDate } from '@utils/date';
+import { getReadingTime } from '@utils/reading-time';
+import { getPostSlug } from '@utils/content';
+import { Badge } from '@/components/starwind/badge';
+import { Button } from '@/components/starwind/button';
+import { Card } from '@/components/starwind/card';
+
+interface Props {
+  post: CollectionEntry<'posts'>;
+  headingLevel?: 'h2' | 'h3';
+}
+
+const { post, headingLevel = 'h3' } = Astro.props;
+const { title, description, pubDate, tags, heroImage, heroImageAlt } = post.data;
+const readingTime = getReadingTime(post.body ?? '');
+const slug = getPostSlug(post.id);
+const href = `/posts/${slug}`;
+const HeadingTag = headingLevel;
+---
+
+<article class="group relative isolate block">
+  <a class="absolute inset-0 z-1 rounded-xl" href={href} aria-label={title}></a>
+  <Card class="overflow-hidden py-0 transition-colors group-hover:ring-primary">
+    <div class="flex flex-col md:flex-row">
+      {heroImage && (
+        <div class="aspect-[16/9] w-full shrink-0 overflow-hidden bg-muted md:aspect-auto md:w-72 lg:w-80">
+          <Image
+            src={heroImage}
+            alt={heroImageAlt ?? ''}
+            widths={[288, 320, 480, 640, 800]}
+            sizes="(min-width: 1024px) 320px, (min-width: 768px) 288px, 100vw"
+            loading="lazy"
+            decoding="async"
+            class="size-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+          />
+        </div>
+      )}
+      <div class="flex flex-1 flex-col justify-between gap-4 p-6">
+        <div class="space-y-3">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <ul class="flex flex-wrap gap-1.5 list-none p-0 m-0">
+              {tags.map((tag) => (
+                <li>
+                  <a
+                    href={`/posts/tags/${encodeURIComponent(tag)}`}
+                    class="relative z-2 inline-block"
+                  >
+                    <Badge variant="ghost" class="rounded-md font-normal">
+                      {tag}
+                    </Badge>
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <time datetime={pubDate.toISOString()} class="text-muted-foreground text-sm">
+              {formatDate(pubDate)} · {readingTime} min read
+            </time>
+          </div>
+          <div>
+            <HeadingTag class="font-heading text-xl md:text-2xl leading-snug font-medium mb-1 group-hover:text-primary transition-colors">
+              {title}
+            </HeadingTag>
+            <p class="text-muted-foreground line-clamp-2">{description}</p>
+          </div>
+        </div>
+        <div class="flex items-center justify-end">
+          <Button variant="ghost" size="sm" class="pointer-events-none gap-2">
+            Read more
+            <ArrowRightIcon class="size-4 transition-transform group-hover:translate-x-1" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Card>
+</article>

--- a/src/components/starwind/badge/Badge.astro
+++ b/src/components/starwind/badge/Badge.astro
@@ -1,0 +1,55 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { tv, type VariantProps } from "tailwind-variants";
+
+interface Props
+  extends HTMLAttributes<"div">, Omit<HTMLAttributes<"a">, "type">, VariantProps<typeof badge> {}
+
+export const badge = tv({
+  base: [
+    "starwind-badge inline-flex items-center gap-1.5 rounded-full font-medium whitespace-nowrap",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "transition-all outline-none focus-visible:ring-3",
+    "aria-invalid:border-error aria-invalid:focus-visible:ring-error/40",
+  ],
+  variants: {
+    variant: {
+      default: "bg-foreground text-background focus-visible:ring-outline/50",
+      primary: "bg-primary text-primary-foreground focus-visible:ring-primary/50",
+      secondary: "bg-secondary text-secondary-foreground focus-visible:ring-secondary/50",
+      outline: "border-border focus-visible:border-outline focus-visible:ring-outline/50 border",
+      ghost: "bg-foreground/10 text-foreground focus-visible:ring-outline/50",
+      info: "bg-info text-info-foreground focus-visible:ring-info/50",
+      success: "bg-success text-success-foreground focus-visible:ring-success/50",
+      warning: "bg-warning text-warning-foreground focus-visible:ring-warning/50",
+      error: "bg-error text-error-foreground focus-visible:ring-error/50",
+    },
+    size: {
+      sm: "px-2.5 py-0.5 text-xs [&_svg:not([class*='size-'])]:size-3",
+      md: "px-3 py-0.5 text-sm [&_svg:not([class*='size-'])]:size-4",
+      lg: "px-4 py-1 text-base [&_svg:not([class*='size-'])]:size-4.5",
+    },
+    isLink: { true: "cursor-pointer", false: "" },
+  },
+  compoundVariants: [
+    { isLink: true, variant: "default", className: "hover:bg-foreground/80" },
+    { isLink: true, variant: "primary", className: "hover:bg-primary/80" },
+    { isLink: true, variant: "secondary", className: "hover:bg-secondary/80" },
+    { isLink: true, variant: "outline", className: "hover:border-border/80" },
+    { isLink: true, variant: "ghost", className: "hover:bg-foreground/7" },
+    { isLink: true, variant: "info", className: "hover:bg-info/80" },
+    { isLink: true, variant: "success", className: "hover:bg-success/80" },
+    { isLink: true, variant: "warning", className: "hover:bg-warning/80" },
+    { isLink: true, variant: "error", className: "hover:bg-error/80" },
+  ],
+  defaultVariants: { variant: "default", size: "md", isLink: false },
+});
+
+const { variant, size, class: className, ...rest } = Astro.props;
+const isLink = Astro.props.href ? true : false;
+const Tag = Astro.props.href ? "a" : "div";
+---
+
+<Tag class={badge({ variant, size, isLink, class: className })} data-slot="badge" {...rest}>
+  <slot />
+</Tag>

--- a/src/components/starwind/badge/Badge.astro
+++ b/src/components/starwind/badge/Badge.astro
@@ -3,11 +3,13 @@ import type { HTMLAttributes } from "astro/types";
 import { tv, type VariantProps } from "tailwind-variants";
 
 interface Props
-  extends HTMLAttributes<"div">, Omit<HTMLAttributes<"a">, "type">, VariantProps<typeof badge> {}
+  extends HTMLAttributes<"div">,
+    Omit<HTMLAttributes<"a">, "type">,
+    Omit<VariantProps<typeof badge>, "isLink"> {}
 
 export const badge = tv({
   base: [
-    "starwind-badge inline-flex items-center gap-1.5 rounded-full font-medium whitespace-nowrap",
+    "gvns-badge inline-flex items-center gap-1.5 rounded-full font-medium whitespace-nowrap",
     "[&_svg]:pointer-events-none [&_svg]:shrink-0",
     "transition-all outline-none focus-visible:ring-3",
     "aria-invalid:border-error aria-invalid:focus-visible:ring-error/40",

--- a/src/components/starwind/badge/Badge.astro
+++ b/src/components/starwind/badge/Badge.astro
@@ -47,11 +47,16 @@ export const badge = tv({
   defaultVariants: { variant: "default", size: "md", isLink: false },
 });
 
-const { variant, size, class: className, ...rest } = Astro.props;
-const isLink = Astro.props.href ? true : false;
-const Tag = Astro.props.href ? "a" : "div";
+const { variant, size, class: className, href, ...rest } = Astro.props;
+const isLink = href ? true : false;
+const Tag = isLink ? "a" : "div";
 ---
 
-<Tag class={badge({ variant, size, isLink, class: className })} data-slot="badge" {...rest}>
+<Tag
+  class={badge({ variant, size, isLink, class: className })}
+  data-slot="badge"
+  {...(isLink ? { href } : {})}
+  {...rest}
+>
   <slot />
 </Tag>

--- a/src/components/starwind/badge/index.ts
+++ b/src/components/starwind/badge/index.ts
@@ -1,0 +1,7 @@
+import Badge, { badge } from "./Badge.astro";
+
+const BadgeVariants = { badge };
+
+export { Badge, BadgeVariants };
+
+export default Badge;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,7 @@ export const prerender = true;
 
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
-import PostCard from '@components/PostCard.astro';
+import HorizontalPostCard from '@components/HorizontalPostCard.astro';
 import StatusWidget from '@components/widgets/StatusWidget.astro';
 import ActivityBar from '@components/ActivityBar.astro';
 import ReadWidget from '@components/widgets/ReadWidget.astro';
@@ -77,7 +77,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         posts.length > 0 ? (
           <div class="post-list">
             {posts.map((post) => (
-              <PostCard post={post} />
+              <HorizontalPostCard post={post} />
             ))}
           </div>
         ) : (

--- a/starwind.config.json
+++ b/starwind.config.json
@@ -31,6 +31,10 @@
     {
       "name": "label",
       "version": "1.2.1"
+    },
+    {
+      "name": "badge",
+      "version": "1.4.2"
     }
   ]
 }


### PR DESCRIPTION
## **User description**
## Summary

Wraps `@starwind-pro/blog-06` layout into a new `HorizontalPostCard` used on `/` only. `/posts` and `/posts/tags/[tag]` keep the existing `PostCard` (separate decision). Closes #288, supersedes #281.

- Image-left, content-right at md+; stacks on mobile
- Posts without `heroImage` render content-only — no broken `<img>`, no layout collapse
- Tags become Starwind `Badge`s linking to `/posts/tags/<tag>`; `TagList` stays for other surfaces
- Astro `<Image>` with `widths={[288,320,480,640,800]}` and a `sizes` attr matching the rendered card widths at md/lg
- Hero thumbs use `loading=\"lazy\"` (off-screen below the fold)

### Pro init notes

`@starwind-pro` registry was already configured at the npm/auth layer in `main` — `npx starwind@latest init --defaults --pro` confirmed this and added no new fields to `starwind.config.json` (Pro is registry-level, not config-level). The acceptance criterion \"`starwind.config.json` reflects Pro\" turned out to be a non-event in practice; documented in ADR-016.

`STARWIND_LICENSE_KEY` must be in `.env.local` to install Pro components — added to `.env.example`.

### Block source dropped

`Blog6.astro` and `Blog6Demo.astro` were forked into `HorizontalPostCard` and then deleted as dead code (CodeRabbit caught real issues in the unused source). The Pro block is one `npx starwind@latest add @starwind-pro/blog-06` away if anyone needs to consult the original.

### CodeRabbit fix worth calling out

Initial draft used `@2xl:flex-row` / `@3xl:w-80` (Tailwind container queries). The `post-list` parent has no `@container`, so the queries never fired and the row layout never activated. Switched to viewport breakpoints (`md:` / `lg:`) — caught by CodeRabbit before merge.

## Test Plan

- [x] `npm run build` succeeds (clean cache → fresh `.astro/` and `node_modules/.astro/` regenerated correctly)
- [x] Spot-checked output HTML against test fixtures: hero post renders 5 webp srcset variants; no-hero post renders content-only row
- [ ] Visual smoke test on `/` at 320 / 768 / 1024 / 1280 in light + dark mode (after merge to main; worktree has no real posts)
- [ ] Confirm tag badge links route to `/posts/tags/<tag>`
- [ ] Confirm hover states use `--colour-accent-primary` (P1 violet) via the existing token bridge in `src/styles/starwind.css`

Closes #288


___

## **CodeAnt-AI Description**
**Use horizontal post cards on the homepage**

### What Changed
- The homepage’s recent posts section now shows horizontal cards with the image on the left and post details on the right at larger screen sizes, while keeping a stacked layout on mobile.
- Posts without a featured image now render cleanly without a broken image area or layout shift.
- Tags on homepage cards now link directly to their tag pages as clickable badges, and each card shows the publish date and reading time in one line.
- Added the badge style used by the new cards, along with notes for the Starwind Pro setup and required license key.

### Impact
`✅ Clearer homepage post browsing`
`✅ Fewer broken image layouts on posts without a featured image`
`✅ Faster access to tag pages from the homepage`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=4CsJHcbC_cXPo6mvO0RCw-iYxKxYapNDrb5ykYSy7ks&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homepage "Recent Posts" now uses a horizontal card layout with images, tags, date, reading time, descriptions and a “Read more” action.
  * New configurable badge UI with multiple variants and sizes.

* **Documentation**
  * Added ADR documenting the homepage layout decision and operational notes for Starwind Pro.

* **Chores**
  * Added commented STARWIND_LICENSE_KEY to env example.
  * Ignored editor settings directory and updated component registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->