### PR TITLE
feat(post-layout): adopt Starwind Blog Post 2 sticky TOC (#289)

### DIFF
--- a/src/components/starwind/image/Image.astro
+++ b/src/components/starwind/image/Image.astro
@@ -1,0 +1,24 @@
+---
+import type { ComponentProps } from "astro/types";
+import { Image as AstroImage } from "astro:assets";
+import { tv } from "tailwind-variants";
+
+export const image = tv({ base: "starwind-image h-auto w-full" });
+
+type Props = Partial<ComponentProps<typeof AstroImage>> & { inferSize?: boolean };
+
+const { class: className, src, alt = "", inferSize = true, ...rest } = Astro.props;
+---
+
+{
+  src && (
+    <AstroImage
+      class={image({ class: className })}
+      src={src}
+      alt={alt}
+      inferSize={inferSize}
+      {...(rest as any)}
+      data-slot="image"
+    />
+  )
+}

--- a/src/components/starwind/image/index.ts
+++ b/src/components/starwind/image/index.ts
@@ -1,0 +1,9 @@
+import Image, { image } from "./Image.astro";
+
+const ImageVariants = {
+  image,
+};
+
+export { Image, ImageVariants };
+
+export default Image;

--- a/src/components/starwind/separator/Separator.astro
+++ b/src/components/starwind/separator/Separator.astro
@@ -1,0 +1,36 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { tv } from "tailwind-variants";
+
+type Props = Omit<HTMLAttributes<"div">, "role" | "aria-orientation"> & {
+  /**
+   * The orientation of the separator.
+   * @default "horizontal"
+   */
+  orientation?: "horizontal" | "vertical";
+};
+
+export const separator = tv({
+  base: "bg-border shrink-0",
+  variants: {
+    orientation: {
+      horizontal: "h-[1px] w-full",
+      vertical: "h-full w-[1px]",
+    },
+  },
+  defaultVariants: {
+    orientation: "horizontal",
+  },
+});
+
+const { class: className, orientation = "horizontal", ...rest } = Astro.props;
+---
+
+<div
+  role="separator"
+  aria-orientation={orientation}
+  class={separator({ orientation, class: className })}
+  {...rest}
+  data-slot="separator"
+>
+</div>

--- a/src/components/starwind/separator/index.ts
+++ b/src/components/starwind/separator/index.ts
@@ -1,0 +1,7 @@
+import Separator, { separator } from "./Separator.astro";
+
+const SeparatorVariants = { separator };
+
+export { Separator, SeparatorVariants };
+
+export default Separator;

--- a/src/layouts/post-layout.astro
+++ b/src/layouts/post-layout.astro
@@ -186,10 +186,14 @@ const breadcrumbJsonLd = toJsonLd(
     .gvns-post-shell {
         display: grid;
         grid-template-columns: minmax(0, 1fr);
+        grid-template-areas:
+            "sidebar"
+            "content";
         gap: 2rem;
     }
 
     .gvns-post-content {
+        grid-area: content;
         min-width: 0;
         max-width: var(--width-content);
         margin-inline: auto;
@@ -197,12 +201,14 @@ const breadcrumbJsonLd = toJsonLd(
     }
 
     .gvns-post-sidebar {
+        grid-area: sidebar;
         min-width: 0;
     }
 
     @media (min-width: 1024px) {
         .gvns-post-shell {
             grid-template-columns: minmax(0, 1fr) 240px;
+            grid-template-areas: "content sidebar";
             gap: 3rem;
             align-items: start;
         }

--- a/src/layouts/post-layout.astro
+++ b/src/layouts/post-layout.astro
@@ -70,9 +70,9 @@ const breadcrumbJsonLd = toJsonLd(
     />
     <ReadingProgress client:idle />
     <main id="main-content" data-pagefind-body>
-        <article class="post">
+        <article class="gvns-post">
             {heroImage && (
-                <figure class="hero">
+                <figure class="gvns-post-hero">
                     <Image
                         src={heroImage}
                         alt={heroImageAlt ?? ''}
@@ -83,15 +83,15 @@ const breadcrumbJsonLd = toJsonLd(
                     />
                 </figure>
             )}
-            <header class="post-header">
+            <header class="gvns-post-header">
                 <h1>{title}</h1>
-                <div class="post-meta">
+                <div class="gvns-post-meta">
                     <time datetime={pubDate.toISOString()}>
                         {formatDate(pubDate)}
                     </time>
                     {
                         updatedDate && (
-                            <span class="updated">
+                            <span class="gvns-post-updated">
                                 (Updated:{" "}
                                 <time datetime={updatedDate.toISOString()}>
                                     {formatDate(updatedDate)}
@@ -100,61 +100,71 @@ const breadcrumbJsonLd = toJsonLd(
                             </span>
                         )
                     }
-                    <span class="reading-time">{readingTime} min read</span>
+                    <span class="gvns-post-reading-time">{readingTime} min read</span>
                 </div>
                 <TagList tags={tags} />
             </header>
 
-            <TableOfContents client:idle />
-
-            <div class="prose">
-                <slot />
+            <div class="gvns-post-shell">
+                <div class="gvns-post-content">
+                    <div class="prose">
+                        <slot />
+                    </div>
+                    <CopyCodeInit />
+                    <SyndicationLinks
+                        syndication={syndication}
+                        postUrl={canonicalUrl}
+                        postTitle={title}
+                    />
+                    <Comments post={post} />
+                    <footer class="gvns-post-footer">
+                        <a href="/posts">&larr; Back to posts</a>
+                    </footer>
+                </div>
+                <aside class="gvns-post-sidebar" aria-label="Article navigation">
+                    <div class="gvns-post-sidebar-sticky">
+                        <TableOfContents client:idle />
+                    </div>
+                </aside>
             </div>
-            <CopyCodeInit />
-            <SyndicationLinks
-                syndication={syndication}
-                postUrl={canonicalUrl}
-                postTitle={title}
-            />
-            <Comments post={post} />
-            <footer class="post-footer">
-                <a href="/posts">&larr; Back to posts</a>
-            </footer>
         </article>
     </main>
 </BaseLayout>
 
 <style>
-    .post {
-        max-width: var(--width-content);
+    /* Outer wrapper allows wide grid; inner columns enforce 65ch reading. */
+    .gvns-post {
+        max-width: var(--width-wide, 80rem);
         margin: 0 auto;
     }
 
-    .hero {
-        margin: 0 0 2rem;
+    .gvns-post-hero {
+        margin: 0 auto 2rem;
+        max-width: var(--width-content);
     }
 
-    .hero img {
+    .gvns-post-hero img {
         width: 100%;
         height: auto;
         display: block;
         border-radius: var(--radius-lg);
     }
 
-    .post-header {
-        margin-bottom: 2rem;
+    .gvns-post-header {
+        margin: 0 auto 2rem;
         padding-bottom: 1.5rem;
         border-bottom: 1px solid var(--colour-border);
+        max-width: var(--width-content);
     }
 
-    .post-header h1 {
+    .gvns-post-header h1 {
         font-size: var(--text-4xl);
         line-height: 1.2;
         letter-spacing: -0.01em;
         margin-bottom: 0.75rem;
     }
 
-    .post-meta {
+    .gvns-post-meta {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem 1rem;
@@ -163,28 +173,66 @@ const breadcrumbJsonLd = toJsonLd(
         margin-bottom: 1rem;
     }
 
-    .reading-time::before {
+    .gvns-post-reading-time::before {
         content: "·";
         margin-right: 1rem;
     }
 
-    .updated {
+    .gvns-post-updated {
         font-style: italic;
     }
 
-    .post-footer {
+    /* Shell: single column < 1024px, content + sticky sidebar at >= 1024px */
+    .gvns-post-shell {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 2rem;
+    }
+
+    .gvns-post-content {
+        min-width: 0;
+        max-width: var(--width-content);
+        margin-inline: auto;
+        width: 100%;
+    }
+
+    .gvns-post-sidebar {
+        min-width: 0;
+    }
+
+    @media (min-width: 1024px) {
+        .gvns-post-shell {
+            grid-template-columns: minmax(0, 1fr) 240px;
+            gap: 3rem;
+            align-items: start;
+        }
+
+        /* Content stays anchored inside its grid column; 65ch cap holds. */
+        .gvns-post-content {
+            margin-inline: 0;
+        }
+
+        .gvns-post-sidebar-sticky {
+            position: sticky;
+            top: 5rem;
+            max-height: calc(100vh - 6rem);
+            overflow-y: auto;
+        }
+    }
+
+    .gvns-post-footer {
         margin-top: 3rem;
         padding-top: 1.5rem;
         border-top: 1px solid var(--colour-border);
     }
 
-    .post-footer a {
+    .gvns-post-footer a {
         color: var(--colour-accent-primary);
         text-decoration: none;
         transition: color var(--transition-fast);
     }
 
-    .post-footer a:hover {
+    .gvns-post-footer a:hover {
         color: var(--colour-accent-hover);
     }
 </style>

--- a/starwind.config.json
+++ b/starwind.config.json
@@ -35,6 +35,14 @@
     {
       "name": "badge",
       "version": "1.4.2"
+    },
+    {
+      "name": "image",
+      "version": "1.0.1"
+    },
+    {
+      "name": "separator",
+      "version": "1.0.1"
     }
   ]
 }


### PR DESCRIPTION
## **User description**
## Summary

- Restructures `src/layouts/post-layout.astro` into a 2-column shell: 65ch reading column + sticky right rail (>=1024px) hosting the existing `TableOfContents.svelte`.
- Cherry-picks the grid + sticky pattern from `@starwind-pro/blog-post-02` only — discards its internal TOC, Avatar, and Prose imports per the epic's "shell, not skin" rule.
- Below 1024px the sidebar collapses above prose, preserving the TOC component's own mobile-collapsible UX.
- Adds `image` and `separator` Starwind primitives (installed alongside the Pro block) for completeness.
- Keeps the hero `<Image>` contract from #276 (`loading="eager"`, `fetchpriority="high"`, `alt={heroImageAlt ?? ''}`).
- Preserves CopyCodeInit, SyndicationLinks, Comments, post-footer, JSON-LD head slot, breadcrumbs, and accent-aware theming.
- Custom CSS classes carry the `gvns-` prefix per `CLAUDE.md`.

## Notes

- The Pro block's `BlogPost2.astro` / `BlogPost2Demo.astro` files were deleted because they import `@/components/starwind/avatar` and `@/components/starwind/prose`, both explicitly out of scope (single-author site + custom `.prose` rules in `global.css:249-348`).
- `prose` and `badge` (already installed via #288) and `avatar` were intentionally skipped during `npx starwind add`.

## Test plan

- [x] `npm run build` clean (verified locally with a temporary fixture under `src/content/posts/2026/04/zztest/`, then removed before commit).
- [x] CodeRabbit `--prompt-only --type uncommitted` — only finding was the temp fixture (now deleted) and a vendor nitpick on the auto-generated `starwind/image/Image.astro` (left as-is, not a project rule violation).
- [ ] Visual check on a long post at 320px / 768px / 1024px / 1440px in light + dark mode.
- [ ] Visual check on a short post (<3 headings) — sidebar should appear empty (TOC component returns nothing).
- [ ] Visual check on a post with no `heroImage` — fallback path holds.
- [ ] TOC active-heading highlight tracks scroll (intersection observer intact).
- [ ] Smooth-scroll on TOC link click respects `prefers-reduced-motion`.
- [ ] No CLS regression on a long post with hero image.

Closes #289


___

## **CodeAnt-AI Description**
**Add a sticky table of contents sidebar to blog posts**

### What Changed
- Blog posts now use a two-column layout on wide screens, with the article on the left and a sticky table of contents on the right
- On smaller screens, the table of contents moves above the article content and keeps its mobile-friendly collapse behavior
- The post page keeps the hero image, post meta, code-copy setup, syndication links, comments, and back-to-posts footer
- The image and separator building blocks are now included for the post layout setup

### Impact
`✅ Easier navigation on long posts`
`✅ Faster jumping between sections on desktop`
`✅ Cleaner reading experience on mobile`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=NWeymkgwQ5QYp41NmYV4fqMWCyUgDRfRmkLvVOAeCTU&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Image component with responsive styling and optional size inference
  * Added Separator component with configurable horizontal and vertical orientations

* **Style**
  * Refactored post layout to a grid-based design with updated class names and footer styling
  * Moved Table of Contents into a sticky right-hand sidebar on desktop to improve navigation and reading flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->