### PR TITLE
feat(about): adopt Starwind Profile 1 (#291)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -515,6 +515,8 @@ Wrap the structure of `@starwind-pro/blog-06` (image-left, content-right) in a n
 
 Issue [#291](https://github.com/ggfevans/gvns.ca/issues/291), under epic [#290](https://github.com/ggfevans/gvns.ca/issues/290). `/about` adopts `@starwind-pro/profile-01` (centred avatar + name + role + social links + content slot) wrapped over `BaseLayout` (PageLayout dropped here to avoid double `<h1>`); the block's `Prose` import is replaced with a plain slot so our custom `.prose` rules in `src/styles/global.css` continue to style the body. Avatar reuses `/avatar.jpg` from the homepage hero; tokens bridge through `src/styles/starwind.css` (no hardcoded colours — `data-accent="p5-sky"` drives the accent). `Timeline` renders below the block, separated by a Starwind `Separator`.
 
+**Fork deltas from upstream `Profile1.astro`**: (1) `Prose` import replaced with a plain slot; (2) `Image` swapped for native `<img>`; (3) social links pass `href`/`target`/`rel` directly to `<Button>` (which polymorphs to `<a>`) instead of wrapping an inner `<a>` — fixes nested-interactive-element bug from PR #314 review.
+
 ---
 
 ## Template for New Decisions

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -508,6 +508,15 @@ Wrap the structure of `@starwind-pro/blog-06` (image-left, content-right) in a n
 
 ---
 
+## ADR-017: Adopt Starwind Pro Profile 1 (Centered Clean) on /about
+
+**Date**: 2026-04-28
+**Status**: Accepted
+
+Issue [#291](https://github.com/ggfevans/gvns.ca/issues/291), under epic [#290](https://github.com/ggfevans/gvns.ca/issues/290). `/about` adopts `@starwind-pro/profile-01` (centred avatar + name + role + social links + content slot) wrapped over `BaseLayout` (PageLayout dropped here to avoid double `<h1>`); the block's `Prose` import is replaced with a plain slot so our custom `.prose` rules in `src/styles/global.css` continue to style the body. Avatar reuses `/avatar.jpg` from the homepage hero; tokens bridge through `src/styles/starwind.css` (no hardcoded colours — `data-accent="p5-sky"` drives the accent). `Timeline` renders below the block, separated by a Starwind `Separator`.
+
+---
+
 ## Template for New Decisions
 
 ```markdown

--- a/src/components/starwind-pro/profile-01/Profile1.astro
+++ b/src/components/starwind-pro/profile-01/Profile1.astro
@@ -95,14 +95,11 @@ const {
             size="icon"
             class="size-10 rounded-full"
             aria-label={social.name}
+            href={social.href}
+            target={social.href.startsWith("mailto:") ? undefined : "_blank"}
+            rel={social.href.startsWith("mailto:") ? undefined : "noopener noreferrer"}
           >
-            <a
-              href={social.href}
-              target={social.href.startsWith("mailto:") ? undefined : "_blank"}
-              rel={social.href.startsWith("mailto:") ? undefined : "noopener noreferrer"}
-            >
-              <social.icon class="size-5" />
-            </a>
+            <social.icon class="size-5" />
           </Button>
         ))}
       </div>

--- a/src/components/starwind-pro/profile-01/Profile1.astro
+++ b/src/components/starwind-pro/profile-01/Profile1.astro
@@ -1,0 +1,121 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { tv } from "tailwind-variants";
+
+import { Badge } from "@/components/starwind/badge";
+import { Button } from "@/components/starwind/button";
+import { Separator } from "@/components/starwind/separator";
+
+/** Social link for a profile */
+export interface ProfileSocialLink {
+  /** Platform name */
+  name: string;
+  /** Icon component (SVG import) */
+  icon: any;
+  /** Link URL */
+  href: string;
+}
+
+interface Props extends HTMLAttributes<"article"> {
+  /** Person's full name */
+  name: string;
+  /** Job title or role */
+  jobTitle: string;
+  /** Short tagline or subtitle */
+  tagline?: string;
+  /** Profile photo URL */
+  image: string;
+  /** Optional badge text above the name */
+  badge?: string;
+  /** Social media links */
+  socials?: ProfileSocialLink[];
+}
+
+const sectionStyles = tv({
+  base: "@container mx-auto w-full max-w-4xl px-4 py-24",
+});
+
+const {
+  name,
+  jobTitle,
+  tagline,
+  image,
+  badge: badgeText,
+  socials = [],
+  class: className,
+  ...rest
+} = Astro.props;
+---
+
+<article class={sectionStyles({ class: className })} {...rest}>
+  <!-- Avatar -->
+  <div class="flex justify-center">
+    <div
+      class="size-36 overflow-hidden rounded-full border-4 border-white shadow-xl @xl:size-44 dark:border-white/10"
+    >
+      <img src={image} alt={name} class="size-full object-cover" loading="eager" decoding="async" />
+    </div>
+  </div>
+
+  <!-- Badge -->
+  {
+    badgeText && (
+      <div class="mt-6 flex justify-center">
+        <Badge variant="primary">{badgeText}</Badge>
+      </div>
+    )
+  }
+
+  <!-- Name -->
+  <h1
+    class="font-heading mt-5 text-center text-3xl font-bold tracking-tight @xl:text-4xl @3xl:text-5xl"
+  >
+    {name}
+  </h1>
+
+  <!-- Role -->
+  <p class="text-primary-accent mt-2 text-center text-lg font-medium">
+    {jobTitle}
+  </p>
+
+  <!-- Tagline -->
+  {
+    tagline && (
+      <p class="text-muted-foreground mx-auto mt-3 max-w-xl text-center text-pretty">{tagline}</p>
+    )
+  }
+
+  <!-- Social Links -->
+  {
+    socials.length > 0 && (
+      <div class="mt-6 flex justify-center gap-2">
+        {socials.map((social) => (
+          <Button
+            variant="outline"
+            size="icon"
+            class="size-10 rounded-full"
+            aria-label={social.name}
+          >
+            <a
+              href={social.href}
+              target={social.href.startsWith("mailto:") ? undefined : "_blank"}
+              rel={social.href.startsWith("mailto:") ? undefined : "noopener noreferrer"}
+            >
+              <social.icon class="size-5" />
+            </a>
+          </Button>
+        ))}
+      </div>
+    )
+  }
+
+  <!-- Separator -->
+  <div class="mx-auto mt-10 max-w-xs">
+    <Separator />
+  </div>
+
+  <!-- Content slot — consumer applies its own prose styling -->
+  <div class="mt-10">
+    <slot />
+  </div>
+</article>

--- a/src/components/starwind/image/Image.astro
+++ b/src/components/starwind/image/Image.astro
@@ -1,0 +1,24 @@
+---
+import type { ComponentProps } from "astro/types";
+import { Image as AstroImage } from "astro:assets";
+import { tv } from "tailwind-variants";
+
+export const image = tv({ base: "starwind-image h-auto w-full" });
+
+type Props = Partial<ComponentProps<typeof AstroImage>> & { inferSize?: boolean };
+
+const { class: className, src, alt = "", inferSize = true, ...rest } = Astro.props;
+---
+
+{
+  src && (
+    <AstroImage
+      class={image({ class: className })}
+      src={src}
+      alt={alt}
+      inferSize={inferSize}
+      {...(rest as any)}
+      data-slot="image"
+    />
+  )
+}

--- a/src/components/starwind/image/index.ts
+++ b/src/components/starwind/image/index.ts
@@ -1,0 +1,9 @@
+import Image, { image } from "./Image.astro";
+
+const ImageVariants = {
+  image,
+};
+
+export { Image, ImageVariants };
+
+export default Image;

--- a/src/components/starwind/separator/Separator.astro
+++ b/src/components/starwind/separator/Separator.astro
@@ -1,0 +1,36 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { tv } from "tailwind-variants";
+
+type Props = Omit<HTMLAttributes<"div">, "role" | "aria-orientation"> & {
+  /**
+   * The orientation of the separator.
+   * @default "horizontal"
+   */
+  orientation?: "horizontal" | "vertical";
+};
+
+export const separator = tv({
+  base: "bg-border shrink-0",
+  variants: {
+    orientation: {
+      horizontal: "h-[1px] w-full",
+      vertical: "h-full w-[1px]",
+    },
+  },
+  defaultVariants: {
+    orientation: "horizontal",
+  },
+});
+
+const { class: className, orientation = "horizontal", ...rest } = Astro.props;
+---
+
+<div
+  role="separator"
+  aria-orientation={orientation}
+  class={separator({ orientation, class: className })}
+  {...rest}
+  data-slot="separator"
+>
+</div>

--- a/src/components/starwind/separator/index.ts
+++ b/src/components/starwind/separator/index.ts
@@ -1,0 +1,7 @@
+import Separator, { separator } from "./Separator.astro";
+
+const SeparatorVariants = { separator };
+
+export { Separator, SeparatorVariants };
+
+export default Separator;

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,9 +1,16 @@
 ---
 export const prerender = true;
 
-import PageLayout from '@layouts/PageLayout.astro';
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Profile1, { type ProfileSocialLink } from '@components/starwind-pro/profile-01/Profile1.astro';
+import { Separator } from '@components/starwind/separator';
 import Timeline from '@components/Timeline.astro';
 import { personSchema, breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
+
+import IconBrandGithub from '@tabler/icons/outline/brand-github.svg';
+import IconBrandThreads from '@tabler/icons/outline/brand-threads.svg';
+import IconBrandLinkedin from '@tabler/icons/outline/brand-linkedin.svg';
+import IconRss from '@tabler/icons/outline/rss.svg';
 
 const siteUrl = normalizeSiteUrl(Astro.site);
 const personJsonLd = toJsonLd(personSchema(siteUrl));
@@ -11,9 +18,16 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
   { name: 'Home', url: siteUrl },
   { name: 'About', url: `${siteUrl}/about` },
 ]));
+
+const socials: ProfileSocialLink[] = [
+  { name: 'GitHub', icon: IconBrandGithub, href: 'https://github.com/ggfevans' },
+  { name: 'Threads', icon: IconBrandThreads, href: 'https://threads.net/@ggfevans' },
+  { name: 'LinkedIn', icon: IconBrandLinkedin, href: 'https://linkedin.com/in/ggfevans' },
+  { name: 'RSS', icon: IconRss, href: '/rss.xml' },
+];
 ---
 
-<PageLayout
+<BaseLayout
   title="About"
   description="Web developer on Vancouver Island. Writing about homelab, web development, BJJ, and whatever catches my attention."
   accent="p5-sky"
@@ -21,39 +35,67 @@ const breadcrumbJsonLd = toJsonLd(breadcrumbSchema([
 >
   <script type="application/ld+json" set:html={personJsonLd} slot="head" />
   <script type="application/ld+json" set:html={breadcrumbJsonLd} slot="head" />
-  <p>
-    Hi, I'm Gareth — a web developer based on Vancouver Island, Canada.
-  </p>
 
-  <p>
-    I build things for the web by day, and tinker with homelabs and self-hosting
-    by night. When I'm not at a keyboard, you'll find me on the mats training
-    Brazilian Jiu-Jitsu.
-  </p>
+  <main id="main-content" class="gvns-about" data-pagefind-body>
+    <Profile1
+      name="Gareth Evans"
+      jobTitle="Web developer · Vancouver Island"
+      image="/avatar.jpg"
+      socials={socials}
+    >
+      <div class="prose">
+        <p>
+          Hi, I'm Gareth — a web developer based on Vancouver Island, Canada.
+        </p>
 
-  <h2>What I Write About</h2>
+        <p>
+          I build things for the web by day, and tinker with homelabs and self-hosting
+          by night. When I'm not at a keyboard, you'll find me on the mats training
+          Brazilian Jiu-Jitsu.
+        </p>
 
-  <ul>
-    <li><strong>Homelab &amp; Self-Hosting</strong> — Docker, Linux, networking, automation</li>
-    <li><strong>Web Development</strong> — Mostly frontend, sometimes fullstack</li>
-    <li><strong>BJJ</strong> — Training logs, technique notes, competition prep</li>
-    <li><strong>Productivity</strong> — ADHD strategies, PKM workflows, tools that work</li>
-  </ul>
+        <h2>What I Write About</h2>
 
-  <h2>Elsewhere</h2>
+        <ul>
+          <li><strong>Homelab &amp; Self-Hosting</strong> — Docker, Linux, networking, automation</li>
+          <li><strong>Web Development</strong> — Mostly frontend, sometimes fullstack</li>
+          <li><strong>BJJ</strong> — Training logs, technique notes, competition prep</li>
+          <li><strong>Productivity</strong> — ADHD strategies, PKM workflows, tools that work</li>
+        </ul>
 
-  <ul>
-    <li><a href="https://github.com/ggfevans">GitHub</a> — Code and projects</li>
-  </ul>
+        <h2>Elsewhere</h2>
 
-  <h2>About This Site</h2>
+        <ul>
+          <li><a href="https://github.com/ggfevans">GitHub</a> — Code and projects</li>
+        </ul>
 
-  <p>
-    Built with <a href="https://astro.build">Astro</a>, styled with
-    <a href="https://tailwindcss.com">Tailwind CSS</a> and a custom GVNS
-    design system. Typography is Inter and JetBrains Mono. Self-hosted
-    on <a href="https://pages.cloudflare.com">Cloudflare Pages</a>.
-  </p>
+        <h2>About This Site</h2>
 
-  <Timeline />
-</PageLayout>
+        <p>
+          Built with <a href="https://astro.build">Astro</a>, styled with
+          <a href="https://tailwindcss.com">Tailwind CSS</a> and a custom GVNS
+          design system. Typography is Inter and JetBrains Mono. Self-hosted
+          on <a href="https://pages.cloudflare.com">Cloudflare Pages</a>.
+        </p>
+      </div>
+    </Profile1>
+
+    <div class="gvns-about-divider" aria-hidden="true">
+      <Separator />
+    </div>
+
+    <Timeline />
+  </main>
+</BaseLayout>
+
+<style>
+  .gvns-about {
+    max-width: var(--width-content);
+    margin: 0 auto;
+  }
+
+  .gvns-about-divider {
+    max-width: var(--width-content);
+    margin: 2rem auto;
+  }
+</style>

--- a/starwind.config.json
+++ b/starwind.config.json
@@ -35,6 +35,14 @@
     {
       "name": "badge",
       "version": "1.4.2"
+    },
+    {
+      "name": "image",
+      "version": "1.0.1"
+    },
+    {
+      "name": "separator",
+      "version": "1.0.1"
     }
   ]
 }


### PR DESCRIPTION
## **User description**
## Summary

- Refactor `/about` to use Starwind Pro **Profile 1 — Centered Clean** (`@starwind-pro/profile-01`): centred avatar + name + role + social link buttons (GitHub, Threads, LinkedIn, RSS) at the top, existing intro / "What I Write About" / "Elsewhere" / "About This Site" copy in the prose slot, `Timeline` below a Starwind `Separator`.
- Drop `PageLayout` for `/about` (block provides its own `<h1>`) and consume `BaseLayout` directly to avoid the double-h1 the issue called out.
- Wire `--colour-*` tokens through the already-existing bridge in `src/styles/starwind.css` — `data-accent="p5-sky"` drives `--primary`, no hardcoded colours.
- Reuse the homepage avatar (`/avatar.jpg` from `gvns-hero`); no new asset.
- Replace the block's `Prose` import with a plain slot so consumers apply their own prose styling — keeps our custom `.prose` rules in `src/styles/global.css:249-348` authoritative.
- Replace the block's `<Image>` (Astro `image()` pipeline) with a plain `<img>` — `/avatar.jpg` is a public asset and doesn't need the pipeline.
- Add **ADR-017** to `docs/DECISIONS.md`.

## Files

- `src/pages/about/index.astro` — refactored to wrap `Profile1` + `Separator` + `Timeline` over `BaseLayout`.
- `src/components/starwind-pro/profile-01/Profile1.astro` — installed via Starwind CLI; modified to drop the `Prose` import and use `<img>` instead of `<Image>`.
- `src/components/starwind/image/`, `src/components/starwind/separator/` — installed by the Starwind CLI run.
- `starwind.config.json` — registers the new components.
- `docs/DECISIONS.md` — ADR-017.

## Test plan

- [ ] `npm run build` succeeds (verified locally — clean).
- [ ] Visit `/about` at 320px / 768px / 1280px in light + dark mode — avatar / name / role / social buttons stack vertically on mobile.
- [ ] All four social links route correctly: GitHub, Threads, LinkedIn, RSS (`/rss.xml`).
- [ ] Single `<h1>` on the page (verified in built HTML).
- [ ] `Timeline` still renders all entries below the `Separator`.
- [ ] Person + BreadcrumbList JSON-LD inject in `<head>` (verified in built HTML).
- [ ] Accent reads from `data-accent` (no hardcoded colours in changed files).

## CodeRabbit

CodeRabbit was unavailable during this session — `coderabbit --prompt-only --type uncommitted` returned the hourly-cap error on three attempts. Self-reviewed the diff (typed props, single h1, no hardcoded colours, `gvns-` prefix on custom CSS classes, public-asset img path).

Closes #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Refresh the About page with a centered profile header and keep the existing bio content below it**

### What Changed
- The About page now starts with a centered avatar, name, role, and social links instead of the previous plain text layout
- The existing bio, topic list, and site details still appear on the page, now inside the new profile section
- A divider separates the profile content from the timeline section
- The page now uses a single main heading, avoiding the duplicated heading on About
- The avatar reuses the homepage image, and the page continues to use the site’s existing accent color setup

### Impact
`✅ Clearer About page layout`
`✅ Fewer heading conflicts on About`
`✅ Consistent profile presentation across the site`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=s2W4HT1O9Gs6G84Nw9f2Ip0SQz6RSHYOlUCoU2LwbNQ&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
