### PR TITLE
chore(docs): sweep image schema docs (#280)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,34 +84,48 @@ src/
 ### Writing Collection Schema
 
 ```typescript
-// src/content/config.ts
+// src/content.config.ts (excerpt — see file for full source)
 import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { UPLOADS_PATH_REGEX } from './uploads-path.mjs';
+
+const uploadsPathSchema = z
+  .string()
+  .regex(UPLOADS_PATH_REGEX, 'heroImage must be an absolute /uploads/... path')
+  .optional();
 
 const posts = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    title: z.string().max(100),
-    description: z.string().max(200),
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    tags: z.array(z.string()).min(1).max(4),
-    draft: z.boolean().default(false),
-    heroImage: image().optional(),
-  }),
+  loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/posts' }),
+  // Bundle layout (ADR-015): heroImage is a bare filename validated by
+  // Astro's image() helper, relative to the post's index.md.
+  schema: ({ image }) =>
+    z.object({
+      title: z.string().max(100),
+      description: z.string().max(200),
+      pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      tags: z.array(z.string()).min(1).max(4),
+      draft: z.boolean().default(false),
+      heroImage: image().optional(),
+      heroImageAlt: z.string().max(250).optional(),
+    }),
 });
 
 const work = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    title: z.string().max(100),
-    description: z.string().max(200),
-    url: z.string().url().optional(),
-    repo: z.string().url().optional(),
-    status: z.enum(['active', 'maintained', 'archived']),
-    tags: z.array(z.string()).min(1).max(6),
-    heroImage: image().optional(),
-    featured: z.boolean().default(false),
-  }),
+  loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/work' }),
+  // Work still uses absolute /uploads/... URLs written by Sveltia.
+  schema: () =>
+    z.object({
+      title: z.string().max(100),
+      description: z.string().max(200),
+      url: z.string().url().optional(),
+      repo: z.string().url().optional(),
+      status: z.enum(['active', 'maintained', 'archived']),
+      tags: z.array(z.string()).min(1).max(6),
+      heroImage: uploadsPathSchema,
+      heroImageAlt: z.string().max(250).optional(),
+      featured: z.boolean().default(false),
+    }),
 });
 
 export const collections = { posts, work };

--- a/docs/CONTENT-SCHEMA.md
+++ b/docs/CONTENT-SCHEMA.md
@@ -23,9 +23,12 @@ pubDate: 2024-12-09
 updatedDate: 2024-12-15          # Shows "Updated" badge
 tags: ["homelab", "docker"]
 draft: true                      # Excludes from build
-heroImage: "./images/hero.jpg"   # Relative to post file
+heroImage: "cover.jpg"           # Bare filename — sits beside index.md in the post bundle
+heroImageAlt: "Short description of the hero image"
 ---
 ```
+
+> **Posts vs work:** the `posts` collection uses Astro's bundle layout — `heroImage` is a bare filename resolved relative to the post's `index.md` and validated through Astro's `image()` helper. The `work` collection still writes absolute `/uploads/...` paths (Sveltia uploads to `public/uploads/`). See ADR-014 / ADR-015 in `docs/DECISIONS.md` for rationale.
 
 ### Field Specifications
 
@@ -37,7 +40,8 @@ heroImage: "./images/hero.jpg"   # Relative to post file
 | `updatedDate` | date | | Last significant update |
 | `tags` | string[] | ✓ | 1-4 tags from taxonomy |
 | `draft` | boolean | | Default: false |
-| `heroImage` | string | | Path to hero image |
+| `heroImage` | string | | **Posts:** bare filename (e.g. `cover.jpg`) sitting next to `index.md`, validated by Astro's `image()` helper. **Work:** absolute `/uploads/...` URL written by Sveltia. |
+| `heroImageAlt` | string | | Alt text for the hero image (max 250 chars). Recommended whenever `heroImage` is set. |
 | `canonicalUrl` | string | | Canonical URL for SEO |
 | `syndication` | object[] | | Array of cross-post records |
 | `syndication[].platform` | enum | ✓ (if syndication) | One of: `bluesky`, `mastodon`, `threads`, `linkedin` |
@@ -100,24 +104,24 @@ Use **one primary tag** per post, plus 1-3 secondary tags.
 src/content/posts/
 ├── 2024/
 │   ├── 12/
-│   │   ├── my-first-post.md
-│   │   └── my-first-post/
-│   │       └── images/
-│   │           └── hero.jpg
+│   │   └── my-first-post/        # Bundle directory (== slug)
+│   │       ├── index.md          # Post body + frontmatter
+│   │       ├── cover.jpg         # heroImage (bare filename in frontmatter)
+│   │       └── diagram.png       # Inline image, referenced as ./diagram.png
 │   └── ...
 └── ...
 ```
 
 ### Naming Conventions
 
-- **Post files**: `kebab-case-title.md`
-- **Image folders**: Same name as post file (without `.md`)
-- **Images**: Descriptive kebab-case (`docker-compose-diagram.png`)
+- **Bundle directory**: `kebab-case-slug/` — the directory name becomes the URL slug.
+- **Post body**: always `index.md` inside the bundle.
+- **Images**: bare filename in frontmatter (`heroImage: cover.jpg`); inline images use entry-relative paths (`![alt](./diagram.png)`).
 
 ### URL Generation
 
-Posts generate URLs from filename:
-- `src/content/posts/2024/12/my-first-post.md` → `/posts/my-first-post/`
+Posts generate URLs from the bundle directory name (Sveltia is configured with `path: "{{year}}/{{month}}/{{slug}}/index"`):
+- `src/content/posts/2024/12/my-first-post/index.md` → `/posts/my-first-post/`
 - Date folders are for organisation only, not in URL
 
 ## Content Guidelines
@@ -184,57 +188,82 @@ Supports:
 
 ### Images
 
+**Sveltia CMS is the canonical authoring path for posts.** When you upload a hero image or drop an inline image into the editor, Sveltia writes the file into the post's bundle directory (next to `index.md`) and references it using a bare filename (hero) or an entry-relative path (inline). The `validate-image-refs.mjs` prebuild check rejects manually-authored `/uploads/...` paths in the `posts` collection — drafting frontmatter by hand with absolute paths is **not supported** for posts.
+
 ```markdown
-![Alt text describing the image](./images/screenshot.png)
+![Alt text describing the image](./diagram.png)
 ```
 
-- **Alt text**: Required, descriptive
-- **Format**: WebP preferred, PNG for screenshots, JPG for photos
-- **Size**: Max 1200px wide, optimised for web
+- **Hero image**: bare filename in frontmatter (e.g. `heroImage: cover.jpg`); the file sits next to `index.md`. Astro's `image()` helper validates it and runs the asset pipeline.
+- **Inline images**: entry-relative paths (`./filename.ext`) inside the bundle directory.
+- **Alt text**: required, descriptive. For the hero image, set `heroImageAlt` in frontmatter.
+- **Format**: WebP preferred, PNG for screenshots, JPG for photos.
+- **Size**: Max 1200px wide, optimised for web.
+
+**Why bundles?** ADR-015 (`docs/DECISIONS.md`) — Sveltia's entry-relative upload path goes with the grain of the CMS once `{{slug}}` is in the path template. ADR-014 documents the earlier `/public/uploads/` baseline and why decision #1 was superseded.
+
+The `work` collection still uses absolute `/uploads/...` URLs (validated by `UPLOADS_PATH_REGEX` in `src/uploads-path.mjs`); that flow has not migrated to bundles.
 
 ## Zod Schema Reference
 
+Excerpted from `src/content.config.ts` (the live source — check the file for the full version with `preprocess` helpers and the `glob` loader configuration).
+
 ```typescript
-// src/content/config.ts
+// src/content.config.ts
 import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { UPLOADS_PATH_REGEX } from './uploads-path.mjs';
+
+// Work-collection media: Sveltia writes absolute /uploads/... URLs.
+const uploadsPathSchema = z
+  .string()
+  .regex(UPLOADS_PATH_REGEX, 'heroImage must be an absolute /uploads/... path')
+  .optional();
 
 const posts = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    title: z.string().max(100),
-    description: z.string().max(200),
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    tags: z.array(z.string()).min(1).max(4),
-    draft: z.boolean().default(false),
-    heroImage: image().optional(),
-    canonicalUrl: z.string().url().optional(),
-    syndication: z
-      .array(
-        z.object({
-          platform: z.enum(['bluesky', 'mastodon', 'threads', 'linkedin']),
-          url: z.string().url(),
-          syndicatedAt: z.coerce.date(),
-          mediaId: z.string().optional(),
-          shortcode: z.string().optional(),
-        })
-      )
-      .optional(),
-  }),
+  loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/posts' }),
+  // Posts use the bundle layout (ADR-015): heroImage is a bare filename
+  // resolved by Astro's image() helper relative to the post's index.md.
+  schema: ({ image }) =>
+    z.object({
+      title: z.string().max(100),
+      description: z.string().max(200),
+      pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      tags: z.array(z.string()).min(1).max(4),
+      draft: z.boolean().default(false),
+      heroImage: image().optional(),
+      heroImageAlt: z.string().max(250).optional(),
+      canonicalUrl: z.string().url().optional(),
+      syndication: z
+        .array(
+          z.object({
+            platform: z.enum(['bluesky', 'mastodon', 'threads', 'linkedin']),
+            url: z.string().url(),
+            syndicatedAt: z.coerce.date(),
+            mediaId: z.string().optional(),
+            shortcode: z.string().optional(),
+          })
+        )
+        .optional(),
+    }),
 });
 
 const work = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    title: z.string().max(100),
-    description: z.string().max(200),
-    url: z.string().url().optional(),
-    repo: z.string().url().optional(),
-    status: z.enum(['active', 'maintained', 'archived']),
-    tags: z.array(z.string()).min(1).max(6),
-    heroImage: image().optional(),
-    featured: z.boolean().default(false),
-  }),
+  loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/work' }),
+  // Work entries still use absolute /uploads/... URLs written by Sveltia.
+  schema: () =>
+    z.object({
+      title: z.string().max(100),
+      description: z.string().max(200),
+      url: z.string().url().optional(),
+      repo: z.string().url().optional(),
+      status: z.enum(['active', 'maintained', 'archived']),
+      tags: z.array(z.string()).min(1).max(6),
+      heroImage: uploadsPathSchema,
+      heroImageAlt: z.string().max(250).optional(),
+      featured: z.boolean().default(false),
+    }),
 });
 
 export const collections = { posts, work };
@@ -242,4 +271,4 @@ export const collections = { posts, work };
 
 ---
 
-*Last updated: 2026-02-02*
+*Last updated: 2026-04-28*

--- a/docs/CONTENT-SCHEMA.md
+++ b/docs/CONTENT-SCHEMA.md
@@ -196,7 +196,7 @@ Supports:
 
 - **Hero image**: bare filename in frontmatter (e.g. `heroImage: cover.jpg`); the file sits next to `index.md`. Astro's `image()` helper validates it and runs the asset pipeline.
 - **Inline images**: entry-relative paths (`./filename.ext`) inside the bundle directory.
-- **Alt text**: required, descriptive. For the hero image, set `heroImageAlt` in frontmatter.
+- **Alt text**: inline `![alt](...)` markdown alt text is required and should be descriptive. For the hero image, set `heroImageAlt` in frontmatter — optional, but recommended whenever `heroImage` is set.
 - **Format**: WebP preferred, PNG for screenshots, JPG for photos.
 - **Size**: Max 1200px wide, optimised for web.
 


### PR DESCRIPTION
## **User description**
## Summary

Sweeps `docs/CONTENT-SCHEMA.md` and `docs/ARCHITECTURE.md` so they describe the schema actually shipping in `main` (post #264 / #271 / #278, codified in ADR-015):

- **Posts** use the bundle layout (`{{year}}/{{month}}/{{slug}}/index.md`); `heroImage` is a bare filename validated through Astro's `image()` helper. Frontmatter example updated from `./images/hero.jpg` to `cover.jpg`.
- **Work** entries still write absolute `/uploads/...` URLs validated by `UPLOADS_PATH_REGEX` (`src/uploads-path.mjs`). Called out separately so authors don't conflate the two flows.
- Added the `heroImageAlt` field to the table (already shipped in `src/content.config.ts`).
- Rewrote the Images section around the Sveltia bundle flow; explicitly noted that manual `/uploads/...` frontmatter is rejected by `scripts/validate-image-refs.mjs` for the posts collection.
- Refreshed the file-structure example to show the bundle directory with `index.md`.
- Replaced the Zod schema excerpts in both docs with the live shape from `src/content.config.ts` (loader-based, `uploadsPathSchema`, `image()` helper).
- Linked ADR-014 / ADR-015 in `docs/DECISIONS.md` for rationale.

Closes #280.

## Test plan

- [x] `npm run build` clean (the pre-existing "posts collection empty" warning is unrelated — content lives outside the worktree's tracked tree).
- [x] `coderabbit --prompt-only --type uncommitted` — no findings.
- [ ] Reviewer spot-check that schema excerpts match `src/content.config.ts` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the current image upload rules for posts and work entries**

### What Changed
- Updated the docs to show that post images use a bundle layout with `index.md` and a bare filename for `heroImage`
- Added guidance for `heroImageAlt`, inline images, and the new folder structure used by posts
- Clarified that posts no longer support manual `/uploads/...` image paths, while work entries still use `/uploads/...` URLs
- Replaced outdated schema examples with the current shape used in the app

### Impact
`✅ Clearer post image setup`
`✅ Fewer authoring mistakes with hero images`
`✅ Less confusion between post and work image paths`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=jkapzRzwj9IfbMbytZIbaWuIMHeE2vrspQY-GXBmRSs&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated content collection documentation with revised schema requirements and organization guidelines.
  * Documented new `heroImageAlt` field and updated image path formatting rules for content entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->