### PR TITLE
feat(footer): adopt Starwind Footer 9 with gvns.ca wordmark (#293)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -508,6 +508,15 @@ Wrap the structure of `@starwind-pro/blog-06` (image-left, content-right) in a n
 
 ---
 
+## ADR-017: Adopt Starwind Pro Footer 9 (Fading Large Text) Globally
+
+**Date**: 2026-04-28
+**Status**: Accepted
+
+Replaced `src/components/Footer.astro` with the Footer 9 shell — large fading "gvns.ca" wordmark, copyright, and the existing five links (GitHub, Threads, LinkedIn, Email, RSS). Wordmark uses `--colour-text-muted` so it stays subdued in light + dark modes; link hovers use `--colour-accent-primary` so they track the per-page `data-accent`. Block source kept under `src/components/starwind-pro/footer-09/` for reference; project-flavoured copy lives in `src/components/Footer.astro` per the "shell, not skin" working principle.
+
+---
+
 ## Template for New Decisions
 
 ```markdown

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,70 +1,141 @@
 ---
+/*
+ * Footer — adopts Starwind Pro Footer 9 (Fading Large Text) shell.
+ * Block source: src/components/starwind-pro/footer-09/Footer9.astro.
+ *
+ * This is the project's customised version: links, copyright and tokens
+ * map to the site's `--colour-*` variables so the wordmark stays subdued
+ * and link hovers respect the per-page `data-accent`.
+ */
 const currentYear = new Date().getFullYear();
+const wordmark = "gvns.ca";
+
+const externalLinks = [
+    { label: "GitHub", href: "https://github.com/ggfevans" },
+    { label: "Threads", href: "https://threads.net/@ggfevans" },
+    { label: "LinkedIn", href: "https://linkedin.com/in/ggfevans" },
+];
 ---
 
-<footer class="footer">
-    <div class="footer-content">
-        <p>© {currentYear} Gareth Evans</p>
-        <ul class="footer-links">
-            <li>
-                <a
-                    href="https://github.com/ggfevans"
-                    target="_blank"
-                    rel="noopener"
-                    aria-label="GitHub (opens in new tab)">GitHub</a>
-            </li>
-            <li>
-                <a
-                    href="https://threads.net/@ggfevans"
-                    target="_blank"
-                    rel="noopener"
-                    aria-label="Threads (opens in new tab)">Threads</a>
-            </li>
-            <li>
-                <a
-                    href="https://linkedin.com/in/ggfevans"
-                    target="_blank"
-                    rel="noopener"
-                    aria-label="LinkedIn (opens in new tab)">LinkedIn</a>
-            </li>
-            <li><a href="/contact">Email</a></li>
-            <li><a href="/rss.xml" aria-label="RSS feed">RSS</a></li>
-        </ul>
+<footer class="gvns-footer">
+    <div class="gvns-footer-inner">
+        <div class="gvns-footer-bottom">
+            <p class="gvns-footer-copyright">© {currentYear} Gareth Evans</p>
+
+            <ul class="gvns-footer-links">
+                {externalLinks.map((link) => (
+                    <li>
+                        <a
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener"
+                            aria-label={`${link.label} (opens in new tab)`}
+                        >
+                            {link.label}
+                        </a>
+                    </li>
+                ))}
+                <li><a href="/contact">Email</a></li>
+                <li><a href="/rss.xml" aria-label="RSS feed">RSS</a></li>
+            </ul>
+        </div>
+
+        <div class="gvns-footer-wordmark-wrap">
+            <h2 class="gvns-footer-wordmark" aria-hidden="true">
+                {wordmark.split("").map((letter) => (
+                    <span class="gvns-footer-wordmark-letter">{letter}</span>
+                ))}
+            </h2>
+        </div>
     </div>
 </footer>
 
 <style>
-    .footer {
-        padding: var(--space-8, 2rem) var(--space-6, 1.5rem);
-        border-top: 1px solid var(--colour-border);
+    .gvns-footer {
+        position: relative;
+        width: 100%;
         margin-top: auto;
+        padding-top: var(--space-12, 3rem);
+        border-top: 1px solid var(--colour-border);
+        overflow: hidden;
+        container-type: inline-size;
     }
 
-    .footer-content {
+    .gvns-footer-inner {
         max-width: var(--width-content);
         margin: 0 auto;
+        padding: 0 var(--space-6, 1.5rem);
+    }
+
+    .gvns-footer-bottom {
         display: flex;
-        justify-content: space-between;
-        align-items: center;
+        flex-direction: column;
+        gap: var(--space-4, 1rem);
+        padding-bottom: var(--space-6, 1.5rem);
         color: var(--colour-text-secondary);
         font-size: 0.875rem;
     }
 
-    .footer-links {
+    @container (min-width: 640px) {
+        .gvns-footer-bottom {
+            flex-direction: row;
+            align-items: center;
+            justify-content: space-between;
+        }
+    }
+
+    .gvns-footer-copyright {
+        margin: 0;
+    }
+
+    .gvns-footer-links {
         display: flex;
+        flex-wrap: wrap;
         gap: var(--space-4, 1rem);
         list-style: none;
         margin: 0;
         padding: 0;
     }
 
-    .footer-links a {
+    .gvns-footer-links a {
         color: var(--colour-text-secondary);
         text-decoration: none;
-        transition: color var(--transition-fast);
+        transition: color var(--transition-fast, 150ms ease);
     }
 
-    .footer-links a:hover {
+    .gvns-footer-links a:hover,
+    .gvns-footer-links a:focus-visible {
         color: var(--colour-accent-primary);
+    }
+
+    .gvns-footer-wordmark-wrap {
+        position: relative;
+        width: 100%;
+    }
+
+    .gvns-footer-wordmark {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        margin: 0;
+        font-family: var(--font-heading, "Space Grotesk", sans-serif);
+        font-weight: 700;
+        line-height: 1;
+        text-transform: uppercase;
+        pointer-events: none;
+        user-select: none;
+    }
+
+    .gvns-footer-wordmark-letter {
+        font-size: clamp(2rem, 16cqi, 12rem);
+        background-image: linear-gradient(
+            to bottom,
+            var(--colour-text-muted) 0%,
+            transparent 80%
+        );
+        background-clip: text;
+        -webkit-background-clip: text;
+        color: transparent;
+        -webkit-text-fill-color: transparent;
     }
 </style>

--- a/src/components/starwind-pro/footer-09/Footer9.astro
+++ b/src/components/starwind-pro/footer-09/Footer9.astro
@@ -1,0 +1,174 @@
+---
+import IconBrandGithub from "@tabler/icons/filled/brand-github.svg";
+import IconBrandLinkedin from "@tabler/icons/filled/brand-linkedin.svg";
+import IconBrandX from "@tabler/icons/outline/brand-x.svg";
+import type { HTMLAttributes } from "astro/types";
+import { tv } from "tailwind-variants";
+
+export interface FooterLink {
+  label: string;
+  href: string;
+}
+
+export interface FooterColumn {
+  title: string;
+  links: FooterLink[];
+}
+
+export interface SocialLink {
+  name: string;
+  href: string;
+  icon: any;
+}
+
+interface Props extends HTMLAttributes<"footer"> {
+  /** Large fading text at the bottom */
+  largeText?: string;
+  /** Company name for copyright */
+  companyName?: string;
+  /** Array of footer link columns */
+  columns?: FooterColumn[];
+  /** Array of social media links */
+  socialLinks?: SocialLink[];
+}
+
+const footer9Styles = tv({
+  base: "dark bg-background pt-16 text-foreground @container relative w-full overflow-hidden",
+});
+
+const {
+  largeText = "STARWIND",
+  companyName = "Starwind",
+  columns = [
+    {
+      title: "Product",
+      links: [
+        { label: "Features", href: "/features" },
+        { label: "Pricing", href: "/pricing" },
+        { label: "Documentation", href: "/docs" },
+        { label: "Changelog", href: "/changelog" },
+      ],
+    },
+    {
+      title: "Company",
+      links: [
+        { label: "About", href: "/about" },
+        { label: "Blog", href: "/blog" },
+        { label: "Careers", href: "/careers" },
+        { label: "Contact", href: "/contact" },
+      ],
+    },
+    {
+      title: "Resources",
+      links: [
+        { label: "Community", href: "/community" },
+        { label: "Support", href: "/support" },
+        { label: "API", href: "/api" },
+        { label: "Status", href: "/status" },
+      ],
+    },
+    {
+      title: "Legal",
+      links: [
+        { label: "Privacy", href: "/privacy" },
+        { label: "Terms", href: "/terms" },
+        { label: "License", href: "/license" },
+        { label: "Cookies", href: "/cookies" },
+      ],
+    },
+  ],
+  socialLinks = [
+    { name: "Twitter", href: "https://twitter.com", icon: IconBrandX },
+    { name: "GitHub", href: "https://github.com", icon: IconBrandGithub },
+    { name: "LinkedIn", href: "https://linkedin.com", icon: IconBrandLinkedin },
+  ],
+  class: className,
+  ...rest
+} = Astro.props;
+
+const currentYear = new Date().getFullYear();
+---
+
+<footer class={footer9Styles({ class: className })} {...rest}>
+  <div class="mx-auto w-full max-w-7xl px-4">
+    <!-- Footer Content -->
+    <div class="relative z-10">
+      <!-- Links Grid -->
+      <div class="mb-12 grid gap-8 @md:grid-cols-2 @lg:grid-cols-4">
+        {
+          columns.map((column) => (
+            <div>
+              <h3 class="font-heading mb-4 text-sm font-semibold tracking-wide uppercase">
+                {column.title}
+              </h3>
+              <ul class="space-y-3">
+                {column.links.map((link) => (
+                  <li>
+                    <a
+                      href={link.href}
+                      class="text-muted-foreground hover:text-foreground text-sm transition-colors duration-200"
+                    >
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
+        }
+      </div>
+
+      <!-- Bottom Section -->
+      <div
+        class="border-border/50 flex flex-col gap-6 border-t py-8 @md:flex-row @md:items-center @md:justify-between"
+      >
+        <!-- Copyright -->
+        <p class="text-muted-foreground text-sm">
+          © {currentYear}
+          {companyName}. All rights reserved.
+        </p>
+
+        <!-- Social Links -->
+        <div class="flex gap-5">
+          {
+            socialLinks.map((social) => (
+              <a
+                href={social.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-muted-foreground hover:text-foreground transition-colors duration-200"
+                aria-label={social.name}
+              >
+                <social.icon class="size-5" aria-hidden="true" />
+              </a>
+            ))
+          }
+        </div>
+      </div>
+    </div>
+
+    <!-- Large Fading Text at Bottom -->
+    <div class="relative w-full">
+      <h2
+        class="font-heading pointer-events-none flex w-full justify-between select-none"
+        aria-hidden="true"
+      >
+        {
+          largeText
+            .split("")
+            .map((letter) => (
+              <span class="large-text from-muted bg-linear-to-b to-transparent to-80% bg-clip-text leading-none font-bold text-transparent uppercase">
+                {letter}
+              </span>
+            ))
+        }
+      </h2>
+    </div>
+  </div>
+</footer>
+
+<style>
+  .large-text {
+    font-size: clamp(2rem, 16cqi, 12rem);
+  }
+</style>

--- a/src/components/starwind-pro/footer-09/Footer9Demo.astro
+++ b/src/components/starwind-pro/footer-09/Footer9Demo.astro
@@ -1,0 +1,46 @@
+---
+import Footer9 from "./Footer9.astro";
+---
+
+<Footer9
+  largeText="STARWIND"
+  companyName="Starwind UI"
+  columns={[
+    {
+      title: "Product",
+      links: [
+        { label: "Components", href: "/components" },
+        { label: "Templates", href: "/templates" },
+        { label: "Documentation", href: "/docs" },
+        { label: "Changelog", href: "/changelog" },
+      ],
+    },
+    {
+      title: "Company",
+      links: [
+        { label: "About", href: "/about" },
+        { label: "Blog", href: "/blog" },
+        { label: "Careers", href: "/careers" },
+        { label: "Contact", href: "/contact" },
+      ],
+    },
+    {
+      title: "Resources",
+      links: [
+        { label: "Community", href: "/community" },
+        { label: "Support", href: "/support" },
+        { label: "API Reference", href: "/api" },
+        { label: "Status", href: "/status" },
+      ],
+    },
+    {
+      title: "Legal",
+      links: [
+        { label: "Privacy Policy", href: "/privacy" },
+        { label: "Terms of Service", href: "/terms" },
+        { label: "License", href: "/license" },
+        { label: "Cookie Policy", href: "/cookies" },
+      ],
+    },
+  ]}
+/>


### PR DESCRIPTION
## **User description**
## Summary

- Replace `src/components/Footer.astro` with the Starwind Pro Footer 9 shell — large fading "gvns.ca" wordmark + copyright + five existing links (GitHub, Threads, LinkedIn, Email, RSS).
- Wordmark uses `--colour-text-muted` so it stays subdued across light + dark modes; scales via `clamp(2rem, 16cqi, 12rem)` with a container query so the row collapses cleanly at 320px.
- Link hover uses `--colour-accent-primary` so it tracks the per-page `data-accent` (P1-P5) instead of hardcoding P5 sky.
- External links retain `target="_blank" rel="noopener"` + `aria-label`. RSS link keeps its `aria-label="RSS feed"`.
- One-line ADR-017 added to `docs/DECISIONS.md`. Vendor source kept under `src/components/starwind-pro/footer-09/` per the "shell, not skin" principle.

## Cross-page smoke-test results

`npm run build` runs clean. `gvns-footer` + `gvns-footer-wordmark` markup confirmed in:

- [x] `dist/client/index.html`
- [x] `dist/client/about/index.html`
- [x] `dist/client/now/index.html`
- [x] `dist/client/404.html`

All 7 letters of "gvns.ca" render as separate `<span class="gvns-footer-wordmark-letter">` nodes (verified in built HTML).

## CodeRabbit pass

Two iteration cycles. Findings addressed:
- **Fixed:** stray `</content>` tag at end of `Footer.astro` (copy-paste artifact).

Findings deliberately left:
- ADR-017 length — issue spec explicitly asks for a "one-line ADR".
- Adding `noreferrer` to external links — issue acceptance criteria specify `rel="noopener"` exactly; preserving the existing convention.
- `icon: any` typing in vendor `Footer9.astro` — vendor block, not on the project's hot path.

## Test plan

- [ ] Visual check on `/`, a post, `/about`, `/now`, `/404` at 320px / 768px / 1280px in light + dark mode.
- [ ] Confirm wordmark stays subdued and does not compete with content.
- [ ] Confirm link hover colour matches the page's `data-accent`.
- [ ] Tab-order through footer links is logical.
- [ ] All five links resolve.

Closes #293.


___

## **CodeAnt-AI Description**
**Adopt a new footer layout with a large gvns.ca wordmark**

### What Changed
- Replaced the old single-line footer with a footer that shows a large fading “gvns.ca” wordmark, copyright, and the same links for GitHub, Threads, LinkedIn, Email, and RSS
- External links still open in a new tab, and the RSS link keeps its feed label
- Footer link hover color now follows the page’s accent color instead of using one fixed color
- The wordmark now scales down cleanly on small screens and stays muted in both light and dark modes

### Impact
`✅ More recognizable footer branding`
`✅ Clearer link hover states across pages`
`✅ Fewer footer layout issues on small screens`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ZmsJICYF0S2ZSAKPtvGwsscVIiy-a2XN8oK71g99z1k&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
