### PR TITLE
chore(footer): align rel to sitewide "noopener noreferrer"

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -551,6 +551,7 @@ Swap the global footer to Starwind Pro **Footer 1 — Socials** (`@starwind-pro/
 - Footer 9 reference files are gone; if we ever want a wordmark variant again, we'd reinstall via the CLI.
 - The footer now has zero CLS risk from oversized type — its height is bounded by the icon row + copyright.
 - ADR-017 (Footer 9) is superseded; the original entry is left in place for history.
+- Issue #318's spec was minimal (`rel="noopener"`); a follow-up aligns Footer external links to the sitewide `rel="noopener noreferrer"` convention used by `WorkCard`, `BookCard`, `SyndicationLinks`, and `/read/index` — `noreferrer` blocks `Referer` leakage to external destinations.
 
 ---
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -67,7 +67,7 @@ const links: FooterLink[] = [
                                         : link.name
                                 }
                                 {...(link.external
-                                    ? { target: "_blank", rel: "noopener" }
+                                    ? { target: "_blank", rel: "noopener noreferrer" }
                                     : {})}
                             >
                                 <link.icon


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to PR #319 / issue #318. Footer 1 Socials shipped with `rel="noopener"` per #318's literal spec, but the rest of the site (`WorkCard`, `BookCard`, `SyndicationLinks`, `/read/index`, etc.) uses `rel="noopener noreferrer"`. This aligns the Footer to that sitewide convention.

`noreferrer` additionally blocks `Referer` header leakage to external destinations.

## Changes

- `src/components/Footer.astro` — external link `rel` now `"noopener noreferrer"`
- `docs/DECISIONS.md` — appended a Consequences bullet to ADR-018 noting the alignment

## Test plan

- [x] `npm run build` clean
- [x] `coderabbit --prompt-only --type uncommitted` — no findings
- [ ] Visual check on preview deploy: external footer icons still open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add `noreferrer` to footer social links to match the sitewide external-link behavior**

### What Changed
- Footer links that open in a new tab now also stop sending the page referrer to external sites
- The footer now follows the same external-link behavior used elsewhere across the site
- The decision record was updated to reflect this follow-up change

### Impact
`✅ Less referrer leakage to external sites`
`✅ Consistent external-link behavior in the footer`
`✅ Safer new-tab social links`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=oTwV6Ux0z8ic8XG5X0HNArvrJwGCv4HC8f0-8gBXYlo&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
