### PR TITLE
feat(home): focus homepage on posts; reorder above activity widgets (#324)

### DIFF
--- a/src/components/HorizontalPostCard.astro
+++ b/src/components/HorizontalPostCard.astro
@@ -61,7 +61,7 @@ const HeadingTag = headingLevel;
                 </li>
               ))}
             </ul>
-            <time datetime={pubDate.toISOString()} class="text-muted-foreground text-sm">
+            <time datetime={pubDate.toISOString()} class="text-muted-foreground text-sm whitespace-nowrap">
               {formatDate(pubDate)} · {readingTime} min read
             </time>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,13 +58,13 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     <section class="recent-writing" aria-label="Recent posts">
       {
         posts.length > 0 ? (
-          <div class="post-list">
+          <div class="gvns-post-list">
             {posts.map((post) => (
               <HorizontalPostCard post={post} />
             ))}
           </div>
         ) : (
-          <p class="empty-state">
+          <p class="gvns-empty-state">
             Currently drafting in private. See what I'm up to on <a href="/now">/now</a>.
           </p>
         )
@@ -75,8 +75,8 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
       <ActivityBar />
     </div>
 
-    <section class="activity-widgets" aria-label="Current activity">
-      <div class="activity-grid">
+    <section class="gvns-activity-widgets" aria-label="Current activity">
+      <div class="gvns-activity-grid">
         <ReadWidget compact />
         <ListenWidget compact />
         <WatchWidget compact />
@@ -193,21 +193,21 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   }
 
   /* Activity widget grid */
-  .activity-widgets {
+  .gvns-activity-widgets {
     padding: var(--space-8) 0;
   }
-  .activity-grid {
+  .gvns-activity-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: var(--space-4);
   }
   @media (max-width: 1024px) {
-    .activity-grid {
+    .gvns-activity-grid {
       grid-template-columns: repeat(2, 1fr);
     }
   }
   @media (max-width: 640px) {
-    .activity-grid {
+    .gvns-activity-grid {
       grid-template-columns: 1fr;
     }
   }
@@ -219,12 +219,12 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     padding: var(--space-12) 0;
     border-top: 1px solid var(--colour-border);
   }
-  .post-list {
+  .gvns-post-list {
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
   }
-  .empty-state {
+  .gvns-empty-state {
     color: var(--colour-text-secondary);
     font-style: italic;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,11 +55,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
       <StatusWidget />
     </section>
 
-    <section class="recent-writing" aria-labelledby="writing-heading">
-      <div class="section-header">
-        <h2 id="writing-heading">Writing</h2>
-        <a href="/posts" class="view-all">Explore all posts &rarr;</a>
-      </div>
+    <section class="recent-writing" aria-label="Recent posts">
       {
         posts.length > 0 ? (
           <div class="post-list">
@@ -216,33 +212,12 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     }
   }
 
-  /* Recent Writing */
+  /* Recent posts */
   .recent-writing {
     max-width: var(--width-content);
     margin: 0 auto;
     padding: var(--space-12) 0;
     border-top: 1px solid var(--colour-border);
-  }
-  .section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-bottom: var(--space-8);
-  }
-  .section-header h2 {
-    font-size: var(--text-2xl);
-    font-weight: 700;
-    letter-spacing: -0.025em;
-  }
-  .view-all {
-    color: var(--colour-accent-primary);
-    text-decoration: none;
-    font-size: var(--text-sm);
-    transition: color var(--transition-fast);
-    white-space: nowrap;
-  }
-  .view-all:hover {
-    color: var(--colour-accent-hover);
   }
   .post-list {
     display: flex;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import '@styles/widgets.css';
 const posts = (await getCollection('posts'))
   .filter((post) => (import.meta.env.PROD ? !post.data.draft : true))
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-  .slice(0, 3);
+  .slice(0, 5);
 
 const siteUrl = normalizeSiteUrl(Astro.site);
 const jsonLd = toJsonLd(websiteSchema(siteUrl));
@@ -55,6 +55,26 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
       <StatusWidget />
     </section>
 
+    <section class="recent-writing" aria-labelledby="writing-heading">
+      <div class="section-header">
+        <h2 id="writing-heading">Writing</h2>
+        <a href="/posts" class="view-all">Explore all posts &rarr;</a>
+      </div>
+      {
+        posts.length > 0 ? (
+          <div class="post-list">
+            {posts.map((post) => (
+              <HorizontalPostCard post={post} />
+            ))}
+          </div>
+        ) : (
+          <p class="empty-state">
+            Currently drafting in private. See what I'm up to on <a href="/now">/now</a>.
+          </p>
+        )
+      }
+    </section>
+
     <div class="activity-bar-wrapper">
       <ActivityBar />
     </div>
@@ -66,24 +86,6 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         <WatchWidget compact />
         <CodeWidget compact />
       </div>
-    </section>
-
-    <section class="recent-writing" aria-labelledby="writing-heading">
-      <div class="section-header">
-        <h2 id="writing-heading">Recent Posts</h2>
-        <a href="/posts" class="view-all">Explore all posts &rarr;</a>
-      </div>
-      {
-        posts.length > 0 ? (
-          <div class="post-list">
-            {posts.map((post) => (
-              <HorizontalPostCard post={post} />
-            ))}
-          </div>
-        ) : (
-          <p class="empty-state">No posts yet. Check back soon.</p>
-        )
-      }
     </section>
   </main>
 </BaseLayout>


### PR DESCRIPTION
## **User description**
## Summary

Reorders the homepage to put writing above lifestream widgets, plus a few small cleanups. Pro Hero adoption was deferred from this issue (scope reduced); current hand-rolled hero retained.

**New vertical order**: Hero → Status → **Writing** (5 posts) → ActivityBar → 4 widgets.

- `src/pages/index.astro`:
  - Slice 3 → 5
  - "Writing" section moved above ActivityBar + activity-grid
  - `<h2>Recent Posts</h2>` → `<h2>Writing</h2>` (aligns with "Explore all posts →" link copy)
  - Empty-state replaced: "Currently drafting in private. See what I'm up to on /now."
- `src/components/HorizontalPostCard.astro`:
  - `whitespace-nowrap` on the date + reading-time line to prevent narrow-card wrapping

## Test Plan

- [x] `npm run build` passes
- [x] Image validation passes
- [x] CodeRabbit review: no findings
- [ ] Manual visual check at 320 / 768 / 1024 / 1440 in light + dark (no posts in repo currently, so the empty-state branch is what renders — verifying the empty-state link to `/now` is reachable and styled)

## Notes

- Pro Hero block adoption deferred — re-open as a follow-up issue once a variant feels right (Starwind Pro catalog wasn't browsed in this session).
- Post slice 3 → 5 is a guess for a "writing-first" feel; once #250/#251 land real posts, easy to tune.

Closes #324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Fixed date and reading-time text wrapping on post cards.
  * Increased homepage to display up to 5 posts instead of 3.
  * Removed the "Recent Posts" heading and "Explore all posts" link; section now uses an accessible "Recent posts" label and updated list styling.
  * Updated empty-state messaging to a private-drafting message with a link to /now.
  * Repositioned the activity area for improved page layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Put posts before activity widgets on the homepage**

### What Changed
- Moved the Writing section above the activity bar and activity widgets so recent posts appear earlier on the homepage
- Show 5 posts instead of 3, giving visitors more writing up front
- Renamed the section from “Recent Posts” to “Writing” and changed the empty state to point people to the /now page
- Kept the post date and reading-time line on one line so post cards don’t wrap awkwardly on narrow screens

### Impact
`✅ Faster access to recent writing`
`✅ Clearer homepage focus on posts`
`✅ Cleaner post cards on small screens`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=KqARo3tMmuyxsnkpBy3HjehppWGxmfnq4LWf-lZF5b8&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
