### PR TITLE
feat(auth): switch sveltia-auth Worker to GitHub App flow (#263)

### DIFF
--- a/.github/actions/commit-via-pr/action.yml
+++ b/.github/actions/commit-via-pr/action.yml
@@ -95,5 +95,9 @@ runs:
           exit 1
         fi
 
-        gh pr merge "$BRANCH" --auto --squash --delete-branch
+        # Immediate merge: enablePullRequestAutoMerge requires a
+        # required_status_checks rule on main, which we removed (#263 — it
+        # blocked Sveltia's direct CMS commits, see docs/CMS-SETUP.md).
+        # Workers Builds runs after merge; failed builds simply don't deploy.
+        gh pr merge "$BRANCH" --squash --delete-branch
 

--- a/docs/CMS-SETUP.md
+++ b/docs/CMS-SETUP.md
@@ -4,33 +4,22 @@ Sveltia CMS is mounted at `gvns.ca/admin`. Auth is brokered by the `auth.gvns.ca
 
 ## Auth flow
 
-The Worker brokers a multi-step flow so CMS commits land as the App's bot identity (`gvns-ca-cms[bot]`) rather than as the human user. That actor distinction is what makes branch protection on `main` enforceable for CLI work without breaking the CMS.
+The Worker runs the standard GitHub web flow with the App's `client_id` / `client_secret`. The shape is identical to OAuth Apps with two differences:
 
-1. **OAuth user-flow** — `/auth` redirects to `https://github.com/login/oauth/authorize` with the App's client_id (no `scope` — App permissions are fixed at App definition). The user authorises and bounces back to `/callback` with a code.
-2. **Code → user-to-server token** — `/callback` exchanges the code for a user-to-server access_token via `client_secret`. This token represents the human, not the App.
-3. **Push-access verification** — the Worker calls `GET /user` and `GET /repos/<repo>/collaborators/<login>/permission` with the user-to-server token. Only `admin` / `maintain` / `write` proceed; anything else is rejected.
-4. **Installation token mint** — the Worker signs a short-lived RS256 JWT with the App's private key, then calls `POST /app/installations/<id>/access_tokens` to mint a ~1h **installation access token**. Commits made with this token attribute to the App's bot identity. **This** is what Sveltia receives — never the user-to-server token.
-5. **Refresh** — installation tokens aren't refreshable. The Worker hands Sveltia the user-to-server *refresh_token* (useless without our `client_secret`). On `POST /refresh`, the Worker re-exchanges that refresh_token for a fresh user-to-server token, re-runs push-access verification (catches mid-session access revocation), and mints a new installation token.
+1. **No `scope` param** on `/login/oauth/authorize` — App permissions are fixed at App definition.
+2. **Tokens expire** ("Expire user authorization tokens" enabled on the App). The Worker passes `refresh_token` and `expires_in` through to Sveltia in the success postMessage and exposes a `POST /refresh` endpoint that proxies refresh-token exchanges to GitHub. Sveltia drives the refresh client-side.
+
+The Worker uses **user-to-server** tokens only — no JWTs, no installation tokens, no private key. A user can only commit to repos where (a) the App is installed AND (b) the user has access. Both hold for `ggfevans/gvns.ca`.
 
 ### Worker secrets (`workers/sveltia-auth`)
 
 ```bash
-wrangler secret put GITHUB_CLIENT_ID         --config ./wrangler.toml  # App's Client ID (Iv23...)
-wrangler secret put GITHUB_CLIENT_SECRET     --config ./wrangler.toml  # App's Client Secret
-wrangler secret put GITHUB_APP_ID            --config ./wrangler.toml  # numeric App ID (App settings → "About")
-wrangler secret put GITHUB_APP_PRIVATE_KEY   --config ./wrangler.toml  # PEM contents (paste full key incl. headers)
-wrangler secret put GITHUB_APP_INSTALLATION_ID --config ./wrangler.toml  # numeric installation ID
-wrangler secret put GITHUB_APP_REPO          --config ./wrangler.toml  # "ggfevans/gvns.ca"
-wrangler secret put AUTH_ALLOWED_ORIGINS     --config ./wrangler.toml  # https://gvns.ca[,...]
+wrangler secret put GITHUB_CLIENT_ID         # App's Client ID (Iv23...)
+wrangler secret put GITHUB_CLIENT_SECRET     # App's Client Secret (generate from App settings)
+wrangler secret put AUTH_ALLOWED_ORIGINS     # https://gvns.ca[,https://<preview>...]
 ```
 
-The App's **Callback URL** must be `https://auth.gvns.ca/callback`.
-
-> **Why `--config`:** the repo root has `wrangler.jsonc` (the site Worker), and wrangler walks upward to find config. Pass `--config ./wrangler.toml` from `workers/sveltia-auth/` so secrets land on the right Worker.
-
-#### Finding the installation ID
-
-Visit `https://github.com/settings/installations`, click "Configure" next to the App. The numeric ID at the end of the URL (`/installations/<id>`) is `GITHUB_APP_INSTALLATION_ID`.
+The App's **Callback URL** must be `https://auth.gvns.ca/callback` (matches the route the Worker handles).
 
 ### Re-rotating from OAuth App to GitHub App
 

--- a/docs/CMS-SETUP.md
+++ b/docs/CMS-SETUP.md
@@ -1,6 +1,6 @@
 # CMS Setup
 
-Sveltia CMS is mounted at `gvns.ca/admin`. Auth is brokered by the `auth.gvns.ca` Worker, backed by a **GitHub App** (`gvns-ca-cms[bot]`). The App is the actor on every CMS commit, which keeps it distinct from the human's `git push` and lets branch protection on `main` allow CMS commits while still requiring PRs from a CLI session (#263).
+Sveltia CMS is mounted at `gvns.ca/admin`. Auth is brokered by the `auth.gvns.ca` Worker, backed by a **GitHub App** (used as the OAuth provider — see "Why a GitHub App if it's just OAuth" below).
 
 ## Auth flow
 
@@ -14,25 +14,33 @@ The Worker uses **user-to-server** tokens only — no JWTs, no installation toke
 ### Worker secrets (`workers/sveltia-auth`)
 
 ```bash
-wrangler secret put GITHUB_CLIENT_ID         # App's Client ID (Iv23...)
-wrangler secret put GITHUB_CLIENT_SECRET     # App's Client Secret (generate from App settings)
-wrangler secret put AUTH_ALLOWED_ORIGINS     # https://gvns.ca[,https://<preview>...]
+wrangler secret put GITHUB_CLIENT_ID         --config ./wrangler.toml  # App's Client ID (Iv23...)
+wrangler secret put GITHUB_CLIENT_SECRET     --config ./wrangler.toml  # App's Client Secret
+wrangler secret put AUTH_ALLOWED_ORIGINS     --config ./wrangler.toml  # https://gvns.ca[,https://<preview>...]
 ```
 
-The App's **Callback URL** must be `https://auth.gvns.ca/callback` (matches the route the Worker handles).
+The App's **Callback URL** must be `https://auth.gvns.ca/callback`.
 
-### Re-rotating from OAuth App to GitHub App
+> **Why `--config`:** the repo root has `wrangler.jsonc` (the site Worker), and wrangler walks upward to find config. Pass `--config ./wrangler.toml` from `workers/sveltia-auth/` so secrets land on the right Worker.
 
-If you ever need to rotate or replace the backing identity:
+## Why a GitHub App if it's just OAuth
 
-1. Create / update the GitHub App; install on `ggfevans/gvns.ca`.
-2. Update the three secrets above with `wrangler secret put`.
-3. Redeploy the Worker (`npm run deploy` in `workers/sveltia-auth`).
-4. Test `gvns.ca/admin` login end-to-end before flipping branch protection.
+A GitHub App is overkill for OAuth alone — an OAuth App would cover this. We tried using the App's *installation tokens* to make CMS commits attribute to the bot identity (`gvns-ca-cms[bot]`) and unlock actor-separated branch protection (#263). It doesn't work: Sveltia's GitHub backend calls `/user` after sign-in to populate the user identity, and installation tokens are server-to-server — they can't access user-scoped endpoints (HTTP 403 "Resource not accessible by integration"). Sveltia treats this as a sign-in failure.
+
+So we kept the App for the OAuth side only. If we ever switch CMSes (or Sveltia adds installation-token support), the App is already in place.
 
 ## Branch protection posture
 
-`main` is protected via a **ruleset**: PRs required, Workers Builds status check required, with the GitHub App on the **bypass list**. The CMS publishes directly to `main` (Sveltia does not support editorial workflow); the human user is *not* on the bypass list, so `git push origin main` from a CLI session is rejected and must go through a PR. See [#263](https://github.com/ggfevans/gvns.ca/issues/263) for context.
+Sveltia commits as the human user (the only path that works given the `/user` requirement above), so we *cannot* combine PR-required protection with bypass-the-CMS — the bypass would have to apply to the human, which would also bypass CLI pushes.
+
+Posture instead:
+
+- **Required status checks** on `main` (Workers Builds): blocks broken commits, supports auto-merge for fetch workflows that open PRs from a side branch.
+- **No PR-required rule.** Sveltia (and CLI) push directly; commits land if checks pass.
+
+This is "block broken builds," not "force PR review." Honest tradeoff per #263.
+
+See [#263](https://github.com/ggfevans/gvns.ca/issues/263) for the full investigation and rejected alternatives.
 
 ## Posts use the bundle layout
 

--- a/docs/CMS-SETUP.md
+++ b/docs/CMS-SETUP.md
@@ -1,6 +1,38 @@
 # CMS Setup
 
-Sveltia CMS is mounted at `gvns.ca/admin`. Auth is brokered by the `auth.gvns.ca` Worker (GitHub OAuth).
+Sveltia CMS is mounted at `gvns.ca/admin`. Auth is brokered by the `auth.gvns.ca` Worker, backed by a **GitHub App** (`gvns-ca-cms[bot]`). The App is the actor on every CMS commit, which keeps it distinct from the human's `git push` and lets branch protection on `main` allow CMS commits while still requiring PRs from a CLI session (#263).
+
+## Auth flow
+
+The Worker runs the standard GitHub web flow with the App's `client_id` / `client_secret`. The shape is identical to OAuth Apps with two differences:
+
+1. **No `scope` param** on `/login/oauth/authorize` — App permissions are fixed at App definition.
+2. **Tokens expire** ("Expire user authorization tokens" enabled on the App). The Worker passes `refresh_token` and `expires_in` through to Sveltia in the success postMessage and exposes a `POST /refresh` endpoint that proxies refresh-token exchanges to GitHub. Sveltia drives the refresh client-side.
+
+The Worker uses **user-to-server** tokens only — no JWTs, no installation tokens, no private key. A user can only commit to repos where (a) the App is installed AND (b) the user has access. Both hold for `ggfevans/gvns.ca`.
+
+### Worker secrets (`workers/sveltia-auth`)
+
+```bash
+wrangler secret put GITHUB_CLIENT_ID         # App's Client ID (Iv23...)
+wrangler secret put GITHUB_CLIENT_SECRET     # App's Client Secret (generate from App settings)
+wrangler secret put AUTH_ALLOWED_ORIGINS     # https://gvns.ca[,https://<preview>...]
+```
+
+The App's **Callback URL** must be `https://auth.gvns.ca/callback` (matches the route the Worker handles).
+
+### Re-rotating from OAuth App to GitHub App
+
+If you ever need to rotate or replace the backing identity:
+
+1. Create / update the GitHub App; install on `ggfevans/gvns.ca`.
+2. Update the three secrets above with `wrangler secret put`.
+3. Redeploy the Worker (`npm run deploy` in `workers/sveltia-auth`).
+4. Test `gvns.ca/admin` login end-to-end before flipping branch protection.
+
+## Branch protection posture
+
+`main` is protected via a **ruleset**: PRs required, Workers Builds status check required, with the GitHub App on the **bypass list**. The CMS publishes directly to `main` (Sveltia does not support editorial workflow); the human user is *not* on the bypass list, so `git push origin main` from a CLI session is rejected and must go through a PR. See [#263](https://github.com/ggfevans/gvns.ca/issues/263) for context.
 
 ## Posts use the bundle layout
 

--- a/docs/CMS-SETUP.md
+++ b/docs/CMS-SETUP.md
@@ -33,12 +33,15 @@ So we kept the App for the OAuth side only. If we ever switch CMSes (or Sveltia 
 
 Sveltia commits as the human user (the only path that works given the `/user` requirement above), so we *cannot* combine PR-required protection with bypass-the-CMS — the bypass would have to apply to the human, which would also bypass CLI pushes.
 
-Posture instead:
+Posture instead — the **`protect da goods` ruleset** on `main`:
 
-- **Required status checks** on `main` (Workers Builds): blocks broken commits, supports auto-merge for fetch workflows that open PRs from a side branch.
-- **No PR-required rule.** Sveltia (and CLI) push directly; commits land if checks pass.
+- **`deletion`** rule only: prevents accidental branch delete / force-push of an empty ref. That's it.
+- **No required status checks.** Tried; created a circular dependency: Sveltia's fresh commits don't have a passing check yet (Workers Builds runs *after* the push), so the rule rejected every CMS save.
+- **No PR-required rule.** Sveltia (and CLI) push directly.
 
-This is "block broken builds," not "force PR review." Honest tradeoff per #263.
+Workers Builds still runs on every push to `main`. A failing build just doesn't deploy — last successful build stays live. Site stays up even if a bad commit lands; the cost is a messy `git log` until the next good commit.
+
+For the watching/fetch workflows: `gh pr merge --auto` requires a `required_status_checks` rule on `main` (`enablePullRequestAutoMerge` GraphQL precondition). Since we don't have one, those workflows must use immediate merge — change `gh pr merge --auto --squash --delete-branch` to `gh pr merge --squash --delete-branch` in `.github/actions/commit-via-pr/action.yml`.
 
 See [#263](https://github.com/ggfevans/gvns.ca/issues/263) for the full investigation and rejected alternatives.
 

--- a/docs/CMS-SETUP.md
+++ b/docs/CMS-SETUP.md
@@ -4,22 +4,33 @@ Sveltia CMS is mounted at `gvns.ca/admin`. Auth is brokered by the `auth.gvns.ca
 
 ## Auth flow
 
-The Worker runs the standard GitHub web flow with the App's `client_id` / `client_secret`. The shape is identical to OAuth Apps with two differences:
+The Worker brokers a multi-step flow so CMS commits land as the App's bot identity (`gvns-ca-cms[bot]`) rather than as the human user. That actor distinction is what makes branch protection on `main` enforceable for CLI work without breaking the CMS.
 
-1. **No `scope` param** on `/login/oauth/authorize` — App permissions are fixed at App definition.
-2. **Tokens expire** ("Expire user authorization tokens" enabled on the App). The Worker passes `refresh_token` and `expires_in` through to Sveltia in the success postMessage and exposes a `POST /refresh` endpoint that proxies refresh-token exchanges to GitHub. Sveltia drives the refresh client-side.
-
-The Worker uses **user-to-server** tokens only — no JWTs, no installation tokens, no private key. A user can only commit to repos where (a) the App is installed AND (b) the user has access. Both hold for `ggfevans/gvns.ca`.
+1. **OAuth user-flow** — `/auth` redirects to `https://github.com/login/oauth/authorize` with the App's client_id (no `scope` — App permissions are fixed at App definition). The user authorises and bounces back to `/callback` with a code.
+2. **Code → user-to-server token** — `/callback` exchanges the code for a user-to-server access_token via `client_secret`. This token represents the human, not the App.
+3. **Push-access verification** — the Worker calls `GET /user` and `GET /repos/<repo>/collaborators/<login>/permission` with the user-to-server token. Only `admin` / `maintain` / `write` proceed; anything else is rejected.
+4. **Installation token mint** — the Worker signs a short-lived RS256 JWT with the App's private key, then calls `POST /app/installations/<id>/access_tokens` to mint a ~1h **installation access token**. Commits made with this token attribute to the App's bot identity. **This** is what Sveltia receives — never the user-to-server token.
+5. **Refresh** — installation tokens aren't refreshable. The Worker hands Sveltia the user-to-server *refresh_token* (useless without our `client_secret`). On `POST /refresh`, the Worker re-exchanges that refresh_token for a fresh user-to-server token, re-runs push-access verification (catches mid-session access revocation), and mints a new installation token.
 
 ### Worker secrets (`workers/sveltia-auth`)
 
 ```bash
-wrangler secret put GITHUB_CLIENT_ID         # App's Client ID (Iv23...)
-wrangler secret put GITHUB_CLIENT_SECRET     # App's Client Secret (generate from App settings)
-wrangler secret put AUTH_ALLOWED_ORIGINS     # https://gvns.ca[,https://<preview>...]
+wrangler secret put GITHUB_CLIENT_ID         --config ./wrangler.toml  # App's Client ID (Iv23...)
+wrangler secret put GITHUB_CLIENT_SECRET     --config ./wrangler.toml  # App's Client Secret
+wrangler secret put GITHUB_APP_ID            --config ./wrangler.toml  # numeric App ID (App settings → "About")
+wrangler secret put GITHUB_APP_PRIVATE_KEY   --config ./wrangler.toml  # PEM contents (paste full key incl. headers)
+wrangler secret put GITHUB_APP_INSTALLATION_ID --config ./wrangler.toml  # numeric installation ID
+wrangler secret put GITHUB_APP_REPO          --config ./wrangler.toml  # "ggfevans/gvns.ca"
+wrangler secret put AUTH_ALLOWED_ORIGINS     --config ./wrangler.toml  # https://gvns.ca[,...]
 ```
 
-The App's **Callback URL** must be `https://auth.gvns.ca/callback` (matches the route the Worker handles).
+The App's **Callback URL** must be `https://auth.gvns.ca/callback`.
+
+> **Why `--config`:** the repo root has `wrangler.jsonc` (the site Worker), and wrangler walks upward to find config. Pass `--config ./wrangler.toml` from `workers/sveltia-auth/` so secrets land on the right Worker.
+
+#### Finding the installation ID
+
+Visit `https://github.com/settings/installations`, click "Configure" next to the App. The numeric ID at the end of the URL (`/installations/<id>`) is `GITHUB_APP_INSTALLATION_ID`.
 
 ### Re-rotating from OAuth App to GitHub App
 

--- a/workers/sveltia-auth/src/index.ts
+++ b/workers/sveltia-auth/src/index.ts
@@ -1,40 +1,31 @@
 // GitHub auth proxy for Sveltia CMS.
 //
-// Backed by a GitHub App. The flow is:
+// Backed by a GitHub App (not an OAuth App). The web flow is identical —
+// /login/oauth/authorize → /login/oauth/access_token — but App tokens have
+// two differences from OAuth App tokens:
 //
-//   1. User clicks login → /auth → GitHub OAuth (App user-flow).
-//   2. /callback exchanges the code for a *user-to-server* token, then uses
-//      it to verify the user has push access to the configured repo.
-//   3. If verified, the Worker mints an *installation access token* by
-//      signing a short-lived RS256 JWT with the App's private key and
-//      exchanging it at /app/installations/{id}/access_tokens.
-//   4. The installation token is what we hand to Sveltia (NOT the
-//      user-to-server token). Commits made with installation tokens are
-//      attributed to the App's bot identity (gvns-ca-cms[bot]) — that's
-//      what enables actor separation under branch protection (#263).
+//   1. No `scope` param on /authorize. App permissions are fixed at App
+//      definition; passing `scope` is rejected.
+//   2. With "Expire user authorization tokens" enabled on the App, the
+//      token exchange returns `refresh_token` + `expires_in` alongside
+//      `access_token`. Sveltia handles refresh client-side, so we pass
+//      those through in the success postMessage and expose a /refresh
+//      endpoint for renewals.
 //
-//   5. Installation tokens last ~1 hour and aren't refreshable. We hand
-//      Sveltia the user-to-server *refresh_token* so /refresh can re-verify
-//      the user (cheap proof of identity that doesn't require re-prompting
-//      login) and mint a fresh installation token. The user-to-server
-//      access_token is never given to Sveltia — only the refresh token,
-//      which is useless without our client_secret.
+// No private key / JWT plumbing is needed here: Sveltia uses user-to-server
+// tokens, which are minted from client_id + client_secret + code. The App's
+// private key is only required for minting *installation* tokens (no human),
+// which we don't do.
 
 export interface Env {
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
-  GITHUB_APP_ID: string;
-  GITHUB_APP_PRIVATE_KEY: string; // PEM-encoded RS256 private key
-  GITHUB_APP_INSTALLATION_ID: string; // numeric installation ID
-  GITHUB_APP_REPO: string; // "owner/name" the user must have push access to
-  AUTH_ALLOWED_ORIGINS: string;
+  AUTH_ALLOWED_ORIGINS: string; // comma-separated, e.g. "https://gvns.ca,https://chore-247.gvns-ca.<account>.workers.dev"
 }
 
 const STATE_COOKIE = "sveltia_oauth_state";
+// Cap GitHub token-exchange to keep us comfortably under the Workers CPU limit.
 const TOKEN_EXCHANGE_TIMEOUT_MS = 8000;
-const APP_API_TIMEOUT_MS = 8000;
-const APP_JWT_LIFETIME_S = 540; // 9 min — GitHub allows up to 10
-const REQUIRED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
 interface TokenResponse {
   access_token?: string;
@@ -44,22 +35,6 @@ interface TokenResponse {
   token_type?: string;
   error?: string;
   error_description?: string;
-}
-
-interface InstallationTokenResponse {
-  token?: string;
-  expires_at?: string;
-  message?: string;
-}
-
-interface CollabPermissionResponse {
-  permission?: string; // "admin" | "maintain" | "write" | "triage" | "read" | "none"
-  message?: string;
-}
-
-interface UserResponse {
-  login?: string;
-  message?: string;
 }
 
 function parseOrigins(env: Env): string[] {
@@ -106,6 +81,10 @@ function postMessageHTML(targetOrigin: string, status: "success" | "error", payl
   </script></body></html>`;
 }
 
+// Emit an OAuth error. If we can't safely identify a target origin (e.g. the
+// allowlist is empty or the cookie was tampered with), refuse outright instead
+// of falling back to "*" — that fallback would let any popup-opener page
+// receive the postMessage.
 function originErrorResponse(targetOrigin: string | null, allowed: string[], message: string): Response {
   if (targetOrigin && allowed.includes(targetOrigin)) {
     return htmlResponse(postMessageHTML(targetOrigin, "error", { message }));
@@ -118,8 +97,6 @@ function originErrorResponse(targetOrigin: string | null, allowed: string[], mes
     headers: { "Cache-Control": "no-store" },
   });
 }
-
-// --- GitHub HTTP helpers ---
 
 async function exchangeWithGithub(body: Record<string, string>): Promise<TokenResponse> {
   const controller = new AbortController();
@@ -143,174 +120,6 @@ async function exchangeWithGithub(body: Record<string, string>): Promise<TokenRe
     return { error: `Token exchange failed: ${detail}` };
   } finally {
     clearTimeout(timeout);
-  }
-}
-
-// --- JWT signing for GitHub App auth ---
-
-function base64UrlEncode(bytes: ArrayBuffer | Uint8Array): string {
-  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-  let bin = "";
-  for (let i = 0; i < u8.length; i++) bin += String.fromCharCode(u8[i]);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function pemToArrayBuffer(pem: string): ArrayBuffer {
-  // Strip headers/footers and whitespace, decode base64.
-  const stripped = pem
-    .replace(/-----BEGIN [^-]+-----/g, "")
-    .replace(/-----END [^-]+-----/g, "")
-    .replace(/\s+/g, "");
-  const bin = atob(stripped);
-  const buf = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
-  return buf.buffer;
-}
-
-async function importAppPrivateKey(pem: string): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    "pkcs8",
-    pemToArrayBuffer(pem),
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-}
-
-async function mintAppJwt(env: Env): Promise<string> {
-  const now = Math.floor(Date.now() / 1000);
-  const header = base64UrlEncode(new TextEncoder().encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
-  // iat clock-skew safety: GitHub rejects iat in the future. Subtract 60s.
-  const payload = base64UrlEncode(
-    new TextEncoder().encode(
-      JSON.stringify({
-        iat: now - 60,
-        exp: now + APP_JWT_LIFETIME_S,
-        iss: env.GITHUB_APP_ID,
-      }),
-    ),
-  );
-  const signingInput = `${header}.${payload}`;
-  const key = await importAppPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
-  const sig = await crypto.subtle.sign(
-    { name: "RSASSA-PKCS1-v1_5" },
-    key,
-    new TextEncoder().encode(signingInput),
-  );
-  return `${signingInput}.${base64UrlEncode(sig)}`;
-}
-
-// --- Installation-token / user-verification helpers ---
-
-async function fetchWithTimeout(input: string, init: RequestInit, ms: number): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), ms);
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function mintInstallationToken(env: Env): Promise<{ token?: string; error?: string }> {
-  let appJwt: string;
-  try {
-    appJwt = await mintAppJwt(env);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    return { error: `App JWT signing failed: ${detail}` };
-  }
-
-  try {
-    const res = await fetchWithTimeout(
-      `https://api.github.com/app/installations/${encodeURIComponent(env.GITHUB_APP_INSTALLATION_ID)}/access_tokens`,
-      {
-        method: "POST",
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${appJwt}`,
-          "User-Agent": "sveltia-auth-worker",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      },
-      APP_API_TIMEOUT_MS,
-    );
-    const data = (await res.json()) as InstallationTokenResponse;
-    if (!res.ok || !data.token) {
-      return { error: data.message || `Installation token endpoint returned ${res.status}` };
-    }
-    return { token: data.token };
-  } catch (err) {
-    if (err instanceof Error && err.name === "AbortError") {
-      return { error: "Installation token request aborted (timeout)" };
-    }
-    const detail = err instanceof Error ? err.message : String(err);
-    return { error: `Installation token request failed: ${detail}` };
-  }
-}
-
-async function verifyUserHasPushAccess(env: Env, userToServerToken: string): Promise<{ login?: string; error?: string }> {
-  // 1. Resolve the authenticated user's login.
-  let login: string;
-  try {
-    const res = await fetchWithTimeout(
-      "https://api.github.com/user",
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${userToServerToken}`,
-          "User-Agent": "sveltia-auth-worker",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      },
-      APP_API_TIMEOUT_MS,
-    );
-    const data = (await res.json()) as UserResponse;
-    if (!res.ok || !data.login) {
-      return { error: data.message || `/user returned ${res.status}` };
-    }
-    login = data.login;
-  } catch (err) {
-    if (err instanceof Error && err.name === "AbortError") {
-      return { error: "/user request aborted (timeout)" };
-    }
-    const detail = err instanceof Error ? err.message : String(err);
-    return { error: `/user request failed: ${detail}` };
-  }
-
-  // 2. Verify the user has push (write/maintain/admin) access to the repo.
-  const [repoOwner, repoName] = env.GITHUB_APP_REPO.split("/");
-  if (!repoOwner || !repoName) {
-    return { error: `GITHUB_APP_REPO is not in 'owner/name' form: ${env.GITHUB_APP_REPO}` };
-  }
-  const repoPath = `${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}`;
-  try {
-    const res = await fetchWithTimeout(
-      `https://api.github.com/repos/${repoPath}/collaborators/${encodeURIComponent(login)}/permission`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${userToServerToken}`,
-          "User-Agent": "sveltia-auth-worker",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      },
-      APP_API_TIMEOUT_MS,
-    );
-    const data = (await res.json()) as CollabPermissionResponse;
-    if (!res.ok) {
-      return { error: data.message || `permission check returned ${res.status}` };
-    }
-    if (!data.permission || !REQUIRED_PERMISSIONS.has(data.permission)) {
-      return { error: `User ${login} lacks push access (permission: ${data.permission ?? "unknown"})` };
-    }
-    return { login };
-  } catch (err) {
-    if (err instanceof Error && err.name === "AbortError") {
-      return { error: "permission check aborted (timeout)" };
-    }
-    const detail = err instanceof Error ? err.message : String(err);
-    return { error: `permission check failed: ${detail}` };
   }
 }
 
@@ -353,6 +162,8 @@ export default {
         .find((c) => c.startsWith(`${STATE_COOKIE}=`))?.split("=")[1] || "";
       const [cookieState, cookieOriginEnc] = cookie.split("|");
 
+      // Malformed percent-encoding crashes decodeURIComponent. Treat any
+      // decode failure as "no valid origin" so the error path fires cleanly.
       let targetOrigin: string | null = null;
       try {
         targetOrigin = decodeURIComponent(cookieOriginEnc || "");
@@ -367,55 +178,39 @@ export default {
         return htmlResponse(postMessageHTML(targetOrigin, "error", { message: "Invalid state" }));
       }
 
-      // 1. Exchange code → user-to-server token.
-      const oauth = await exchangeWithGithub({
+      const data = await exchangeWithGithub({
         client_id: env.GITHUB_CLIENT_ID,
         client_secret: env.GITHUB_CLIENT_SECRET,
         redirect_uri: `${url.origin}/callback`,
         code,
       });
-      if (!oauth.access_token) {
+
+      if (!data.access_token) {
         return htmlResponse(
           postMessageHTML(targetOrigin, "error", {
-            message: oauth.error_description || oauth.error || "No token",
+            message: data.error_description || data.error || "No token",
           }),
         );
       }
 
-      // 2. Verify the human has push access to the configured repo.
-      const verify = await verifyUserHasPushAccess(env, oauth.access_token);
-      if (verify.error || !verify.login) {
-        return htmlResponse(
-          postMessageHTML(targetOrigin, "error", { message: verify.error ?? "User verification failed" }),
-        );
-      }
-
-      // 3. Mint an installation access token. This is what Sveltia uses.
-      const inst = await mintInstallationToken(env);
-      if (!inst.token) {
-        return htmlResponse(
-          postMessageHTML(targetOrigin, "error", { message: inst.error ?? "Installation token failed" }),
-        );
-      }
-
-      // 4. Hand Sveltia the installation token (so commits attribute to the
-      //    App bot) AND the user's refresh_token (so /refresh can re-verify
-      //    the user without re-prompting login). Never expose the
-      //    user-to-server access_token itself.
+      // Pass through refresh_token + expiries so Sveltia can refresh
+      // user-to-server tokens client-side (App "Expire tokens" enabled).
       const successPayload: Record<string, unknown> = {
-        token: inst.token,
+        token: data.access_token,
         provider: "github",
-        // Installation tokens last ~1 hour. Tell Sveltia conservatively.
-        expires_in: 3300,
       };
-      if (oauth.refresh_token) successPayload.refresh_token = oauth.refresh_token;
-      if (typeof oauth.refresh_token_expires_in === "number") {
-        successPayload.refresh_token_expires_in = oauth.refresh_token_expires_in;
+      if (data.refresh_token) successPayload.refresh_token = data.refresh_token;
+      if (typeof data.expires_in === "number") successPayload.expires_in = data.expires_in;
+      if (typeof data.refresh_token_expires_in === "number") {
+        successPayload.refresh_token_expires_in = data.refresh_token_expires_in;
       }
+      if (data.token_type) successPayload.token_type = data.token_type;
 
       return htmlResponse(postMessageHTML(targetOrigin, "success", successPayload));
     }
 
+    // Refresh endpoint: Sveltia POSTs the refresh_token here when the
+    // access_token nears expiry. We forward to GitHub's token endpoint.
     if (url.pathname === "/refresh") {
       const origin = request.headers.get("Origin");
       const originOk = origin !== null && allowed.includes(origin);
@@ -439,6 +234,7 @@ export default {
       if (!originOk) {
         return jsonResponse({ error: "Origin not allowed" }, { status: 403 });
       }
+      // After the originOk guard above, `origin` is guaranteed non-null.
       const allowedOrigin: string = origin;
 
       let body: { refresh_token?: unknown };
@@ -447,52 +243,36 @@ export default {
       } catch {
         return jsonResponse({ error: "Invalid JSON" }, { status: 400, origin: allowedOrigin });
       }
+
       if (typeof body.refresh_token !== "string" || !body.refresh_token) {
         return jsonResponse({ error: "Missing refresh_token" }, { status: 400, origin: allowedOrigin });
       }
 
-      // 1. Re-exchange refresh_token for a new user-to-server access_token
-      //    (and a fresh refresh_token).
-      const oauth = await exchangeWithGithub({
+      const data = await exchangeWithGithub({
         client_id: env.GITHUB_CLIENT_ID,
         client_secret: env.GITHUB_CLIENT_SECRET,
         grant_type: "refresh_token",
         refresh_token: body.refresh_token,
       });
-      if (oauth.error || !oauth.access_token) {
+
+      if (data.error || !data.access_token) {
         return jsonResponse(
-          { error: oauth.error_description || oauth.error || "No token" },
+          { error: data.error_description || data.error || "No token" },
           { status: 400, origin: allowedOrigin },
         );
       }
 
-      // 2. Re-verify the user still has push access. This catches access
-      //    revocation between sessions.
-      const verify = await verifyUserHasPushAccess(env, oauth.access_token);
-      if (verify.error || !verify.login) {
-        return jsonResponse(
-          { error: verify.error ?? "User verification failed" },
-          { status: 403, origin: allowedOrigin },
-        );
-      }
-
-      // 3. Mint a fresh installation access token.
-      const inst = await mintInstallationToken(env);
-      if (!inst.token) {
-        return jsonResponse(
-          { error: inst.error ?? "Installation token failed" },
-          { status: 502, origin: allowedOrigin },
-        );
-      }
-
+      // Mirror the /callback payload shape — only include optional fields
+      // when GitHub returned them.
       const refreshPayload: Record<string, unknown> = {
-        access_token: inst.token,
-        expires_in: 3300,
+        access_token: data.access_token,
       };
-      if (oauth.refresh_token) refreshPayload.refresh_token = oauth.refresh_token;
-      if (typeof oauth.refresh_token_expires_in === "number") {
-        refreshPayload.refresh_token_expires_in = oauth.refresh_token_expires_in;
+      if (data.refresh_token) refreshPayload.refresh_token = data.refresh_token;
+      if (typeof data.expires_in === "number") refreshPayload.expires_in = data.expires_in;
+      if (typeof data.refresh_token_expires_in === "number") {
+        refreshPayload.refresh_token_expires_in = data.refresh_token_expires_in;
       }
+      if (data.token_type) refreshPayload.token_type = data.token_type;
 
       return jsonResponse(refreshPayload, { origin: allowedOrigin });
     }

--- a/workers/sveltia-auth/src/index.ts
+++ b/workers/sveltia-auth/src/index.ts
@@ -1,31 +1,40 @@
 // GitHub auth proxy for Sveltia CMS.
 //
-// Backed by a GitHub App (not an OAuth App). The web flow is identical —
-// /login/oauth/authorize → /login/oauth/access_token — but App tokens have
-// two differences from OAuth App tokens:
+// Backed by a GitHub App. The flow is:
 //
-//   1. No `scope` param on /authorize. App permissions are fixed at App
-//      definition; passing `scope` is rejected.
-//   2. With "Expire user authorization tokens" enabled on the App, the
-//      token exchange returns `refresh_token` + `expires_in` alongside
-//      `access_token`. Sveltia handles refresh client-side, so we pass
-//      those through in the success postMessage and expose a /refresh
-//      endpoint for renewals.
+//   1. User clicks login → /auth → GitHub OAuth (App user-flow).
+//   2. /callback exchanges the code for a *user-to-server* token, then uses
+//      it to verify the user has push access to the configured repo.
+//   3. If verified, the Worker mints an *installation access token* by
+//      signing a short-lived RS256 JWT with the App's private key and
+//      exchanging it at /app/installations/{id}/access_tokens.
+//   4. The installation token is what we hand to Sveltia (NOT the
+//      user-to-server token). Commits made with installation tokens are
+//      attributed to the App's bot identity (gvns-ca-cms[bot]) — that's
+//      what enables actor separation under branch protection (#263).
 //
-// No private key / JWT plumbing is needed here: Sveltia uses user-to-server
-// tokens, which are minted from client_id + client_secret + code. The App's
-// private key is only required for minting *installation* tokens (no human),
-// which we don't do.
+//   5. Installation tokens last ~1 hour and aren't refreshable. We hand
+//      Sveltia the user-to-server *refresh_token* so /refresh can re-verify
+//      the user (cheap proof of identity that doesn't require re-prompting
+//      login) and mint a fresh installation token. The user-to-server
+//      access_token is never given to Sveltia — only the refresh token,
+//      which is useless without our client_secret.
 
 export interface Env {
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
-  AUTH_ALLOWED_ORIGINS: string; // comma-separated, e.g. "https://gvns.ca,https://chore-247.gvns-ca.<account>.workers.dev"
+  GITHUB_APP_ID: string;
+  GITHUB_APP_PRIVATE_KEY: string; // PEM-encoded RS256 private key
+  GITHUB_APP_INSTALLATION_ID: string; // numeric installation ID
+  GITHUB_APP_REPO: string; // "owner/name" the user must have push access to
+  AUTH_ALLOWED_ORIGINS: string;
 }
 
 const STATE_COOKIE = "sveltia_oauth_state";
-// Cap GitHub token-exchange to keep us comfortably under the Workers CPU limit.
 const TOKEN_EXCHANGE_TIMEOUT_MS = 8000;
+const APP_API_TIMEOUT_MS = 8000;
+const APP_JWT_LIFETIME_S = 540; // 9 min — GitHub allows up to 10
+const REQUIRED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
 interface TokenResponse {
   access_token?: string;
@@ -35,6 +44,22 @@ interface TokenResponse {
   token_type?: string;
   error?: string;
   error_description?: string;
+}
+
+interface InstallationTokenResponse {
+  token?: string;
+  expires_at?: string;
+  message?: string;
+}
+
+interface CollabPermissionResponse {
+  permission?: string; // "admin" | "maintain" | "write" | "triage" | "read" | "none"
+  message?: string;
+}
+
+interface UserResponse {
+  login?: string;
+  message?: string;
 }
 
 function parseOrigins(env: Env): string[] {
@@ -81,10 +106,6 @@ function postMessageHTML(targetOrigin: string, status: "success" | "error", payl
   </script></body></html>`;
 }
 
-// Emit an OAuth error. If we can't safely identify a target origin (e.g. the
-// allowlist is empty or the cookie was tampered with), refuse outright instead
-// of falling back to "*" — that fallback would let any popup-opener page
-// receive the postMessage.
 function originErrorResponse(targetOrigin: string | null, allowed: string[], message: string): Response {
   if (targetOrigin && allowed.includes(targetOrigin)) {
     return htmlResponse(postMessageHTML(targetOrigin, "error", { message }));
@@ -97,6 +118,8 @@ function originErrorResponse(targetOrigin: string | null, allowed: string[], mes
     headers: { "Cache-Control": "no-store" },
   });
 }
+
+// --- GitHub HTTP helpers ---
 
 async function exchangeWithGithub(body: Record<string, string>): Promise<TokenResponse> {
   const controller = new AbortController();
@@ -120,6 +143,174 @@ async function exchangeWithGithub(body: Record<string, string>): Promise<TokenRe
     return { error: `Token exchange failed: ${detail}` };
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+// --- JWT signing for GitHub App auth ---
+
+function base64UrlEncode(bytes: ArrayBuffer | Uint8Array): string {
+  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let bin = "";
+  for (let i = 0; i < u8.length; i++) bin += String.fromCharCode(u8[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  // Strip headers/footers and whitespace, decode base64.
+  const stripped = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  const bin = atob(stripped);
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+  return buf.buffer;
+}
+
+async function importAppPrivateKey(pem: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "pkcs8",
+    pemToArrayBuffer(pem),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+async function mintAppJwt(env: Env): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64UrlEncode(new TextEncoder().encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
+  // iat clock-skew safety: GitHub rejects iat in the future. Subtract 60s.
+  const payload = base64UrlEncode(
+    new TextEncoder().encode(
+      JSON.stringify({
+        iat: now - 60,
+        exp: now + APP_JWT_LIFETIME_S,
+        iss: env.GITHUB_APP_ID,
+      }),
+    ),
+  );
+  const signingInput = `${header}.${payload}`;
+  const key = await importAppPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
+  const sig = await crypto.subtle.sign(
+    { name: "RSASSA-PKCS1-v1_5" },
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${base64UrlEncode(sig)}`;
+}
+
+// --- Installation-token / user-verification helpers ---
+
+async function fetchWithTimeout(input: string, init: RequestInit, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function mintInstallationToken(env: Env): Promise<{ token?: string; error?: string }> {
+  let appJwt: string;
+  try {
+    appJwt = await mintAppJwt(env);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { error: `App JWT signing failed: ${detail}` };
+  }
+
+  try {
+    const res = await fetchWithTimeout(
+      `https://api.github.com/app/installations/${encodeURIComponent(env.GITHUB_APP_INSTALLATION_ID)}/access_tokens`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${appJwt}`,
+          "User-Agent": "sveltia-auth-worker",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+      APP_API_TIMEOUT_MS,
+    );
+    const data = (await res.json()) as InstallationTokenResponse;
+    if (!res.ok || !data.token) {
+      return { error: data.message || `Installation token endpoint returned ${res.status}` };
+    }
+    return { token: data.token };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: "Installation token request aborted (timeout)" };
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    return { error: `Installation token request failed: ${detail}` };
+  }
+}
+
+async function verifyUserHasPushAccess(env: Env, userToServerToken: string): Promise<{ login?: string; error?: string }> {
+  // 1. Resolve the authenticated user's login.
+  let login: string;
+  try {
+    const res = await fetchWithTimeout(
+      "https://api.github.com/user",
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${userToServerToken}`,
+          "User-Agent": "sveltia-auth-worker",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+      APP_API_TIMEOUT_MS,
+    );
+    const data = (await res.json()) as UserResponse;
+    if (!res.ok || !data.login) {
+      return { error: data.message || `/user returned ${res.status}` };
+    }
+    login = data.login;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: "/user request aborted (timeout)" };
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    return { error: `/user request failed: ${detail}` };
+  }
+
+  // 2. Verify the user has push (write/maintain/admin) access to the repo.
+  const [repoOwner, repoName] = env.GITHUB_APP_REPO.split("/");
+  if (!repoOwner || !repoName) {
+    return { error: `GITHUB_APP_REPO is not in 'owner/name' form: ${env.GITHUB_APP_REPO}` };
+  }
+  const repoPath = `${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}`;
+  try {
+    const res = await fetchWithTimeout(
+      `https://api.github.com/repos/${repoPath}/collaborators/${encodeURIComponent(login)}/permission`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${userToServerToken}`,
+          "User-Agent": "sveltia-auth-worker",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+      APP_API_TIMEOUT_MS,
+    );
+    const data = (await res.json()) as CollabPermissionResponse;
+    if (!res.ok) {
+      return { error: data.message || `permission check returned ${res.status}` };
+    }
+    if (!data.permission || !REQUIRED_PERMISSIONS.has(data.permission)) {
+      return { error: `User ${login} lacks push access (permission: ${data.permission ?? "unknown"})` };
+    }
+    return { login };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: "permission check aborted (timeout)" };
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    return { error: `permission check failed: ${detail}` };
   }
 }
 
@@ -162,8 +353,6 @@ export default {
         .find((c) => c.startsWith(`${STATE_COOKIE}=`))?.split("=")[1] || "";
       const [cookieState, cookieOriginEnc] = cookie.split("|");
 
-      // Malformed percent-encoding crashes decodeURIComponent. Treat any
-      // decode failure as "no valid origin" so the error path fires cleanly.
       let targetOrigin: string | null = null;
       try {
         targetOrigin = decodeURIComponent(cookieOriginEnc || "");
@@ -178,39 +367,55 @@ export default {
         return htmlResponse(postMessageHTML(targetOrigin, "error", { message: "Invalid state" }));
       }
 
-      const data = await exchangeWithGithub({
+      // 1. Exchange code → user-to-server token.
+      const oauth = await exchangeWithGithub({
         client_id: env.GITHUB_CLIENT_ID,
         client_secret: env.GITHUB_CLIENT_SECRET,
         redirect_uri: `${url.origin}/callback`,
         code,
       });
-
-      if (!data.access_token) {
+      if (!oauth.access_token) {
         return htmlResponse(
           postMessageHTML(targetOrigin, "error", {
-            message: data.error_description || data.error || "No token",
+            message: oauth.error_description || oauth.error || "No token",
           }),
         );
       }
 
-      // Pass through refresh_token + expiries so Sveltia can refresh
-      // user-to-server tokens client-side (App "Expire tokens" enabled).
-      const successPayload: Record<string, unknown> = {
-        token: data.access_token,
-        provider: "github",
-      };
-      if (data.refresh_token) successPayload.refresh_token = data.refresh_token;
-      if (typeof data.expires_in === "number") successPayload.expires_in = data.expires_in;
-      if (typeof data.refresh_token_expires_in === "number") {
-        successPayload.refresh_token_expires_in = data.refresh_token_expires_in;
+      // 2. Verify the human has push access to the configured repo.
+      const verify = await verifyUserHasPushAccess(env, oauth.access_token);
+      if (verify.error || !verify.login) {
+        return htmlResponse(
+          postMessageHTML(targetOrigin, "error", { message: verify.error ?? "User verification failed" }),
+        );
       }
-      if (data.token_type) successPayload.token_type = data.token_type;
+
+      // 3. Mint an installation access token. This is what Sveltia uses.
+      const inst = await mintInstallationToken(env);
+      if (!inst.token) {
+        return htmlResponse(
+          postMessageHTML(targetOrigin, "error", { message: inst.error ?? "Installation token failed" }),
+        );
+      }
+
+      // 4. Hand Sveltia the installation token (so commits attribute to the
+      //    App bot) AND the user's refresh_token (so /refresh can re-verify
+      //    the user without re-prompting login). Never expose the
+      //    user-to-server access_token itself.
+      const successPayload: Record<string, unknown> = {
+        token: inst.token,
+        provider: "github",
+        // Installation tokens last ~1 hour. Tell Sveltia conservatively.
+        expires_in: 3300,
+      };
+      if (oauth.refresh_token) successPayload.refresh_token = oauth.refresh_token;
+      if (typeof oauth.refresh_token_expires_in === "number") {
+        successPayload.refresh_token_expires_in = oauth.refresh_token_expires_in;
+      }
 
       return htmlResponse(postMessageHTML(targetOrigin, "success", successPayload));
     }
 
-    // Refresh endpoint: Sveltia POSTs the refresh_token here when the
-    // access_token nears expiry. We forward to GitHub's token endpoint.
     if (url.pathname === "/refresh") {
       const origin = request.headers.get("Origin");
       const originOk = origin !== null && allowed.includes(origin);
@@ -234,7 +439,6 @@ export default {
       if (!originOk) {
         return jsonResponse({ error: "Origin not allowed" }, { status: 403 });
       }
-      // After the originOk guard above, `origin` is guaranteed non-null.
       const allowedOrigin: string = origin;
 
       let body: { refresh_token?: unknown };
@@ -243,36 +447,52 @@ export default {
       } catch {
         return jsonResponse({ error: "Invalid JSON" }, { status: 400, origin: allowedOrigin });
       }
-
       if (typeof body.refresh_token !== "string" || !body.refresh_token) {
         return jsonResponse({ error: "Missing refresh_token" }, { status: 400, origin: allowedOrigin });
       }
 
-      const data = await exchangeWithGithub({
+      // 1. Re-exchange refresh_token for a new user-to-server access_token
+      //    (and a fresh refresh_token).
+      const oauth = await exchangeWithGithub({
         client_id: env.GITHUB_CLIENT_ID,
         client_secret: env.GITHUB_CLIENT_SECRET,
         grant_type: "refresh_token",
         refresh_token: body.refresh_token,
       });
-
-      if (data.error || !data.access_token) {
+      if (oauth.error || !oauth.access_token) {
         return jsonResponse(
-          { error: data.error_description || data.error || "No token" },
+          { error: oauth.error_description || oauth.error || "No token" },
           { status: 400, origin: allowedOrigin },
         );
       }
 
-      // Mirror the /callback payload shape — only include optional fields
-      // when GitHub returned them.
-      const refreshPayload: Record<string, unknown> = {
-        access_token: data.access_token,
-      };
-      if (data.refresh_token) refreshPayload.refresh_token = data.refresh_token;
-      if (typeof data.expires_in === "number") refreshPayload.expires_in = data.expires_in;
-      if (typeof data.refresh_token_expires_in === "number") {
-        refreshPayload.refresh_token_expires_in = data.refresh_token_expires_in;
+      // 2. Re-verify the user still has push access. This catches access
+      //    revocation between sessions.
+      const verify = await verifyUserHasPushAccess(env, oauth.access_token);
+      if (verify.error || !verify.login) {
+        return jsonResponse(
+          { error: verify.error ?? "User verification failed" },
+          { status: 403, origin: allowedOrigin },
+        );
       }
-      if (data.token_type) refreshPayload.token_type = data.token_type;
+
+      // 3. Mint a fresh installation access token.
+      const inst = await mintInstallationToken(env);
+      if (!inst.token) {
+        return jsonResponse(
+          { error: inst.error ?? "Installation token failed" },
+          { status: 502, origin: allowedOrigin },
+        );
+      }
+
+      const refreshPayload: Record<string, unknown> = {
+        access_token: inst.token,
+        expires_in: 3300,
+      };
+      if (oauth.refresh_token) refreshPayload.refresh_token = oauth.refresh_token;
+      if (typeof oauth.refresh_token_expires_in === "number") {
+        refreshPayload.refresh_token_expires_in = oauth.refresh_token_expires_in;
+      }
 
       return jsonResponse(refreshPayload, { origin: allowedOrigin });
     }

--- a/workers/sveltia-auth/src/index.ts
+++ b/workers/sveltia-auth/src/index.ts
@@ -1,5 +1,21 @@
-// GitHub OAuth proxy for Sveltia CMS.
-// Compatible with Decap CMS / Sveltia CMS auth flow.
+// GitHub auth proxy for Sveltia CMS.
+//
+// Backed by a GitHub App (not an OAuth App). The web flow is identical —
+// /login/oauth/authorize → /login/oauth/access_token — but App tokens have
+// two differences from OAuth App tokens:
+//
+//   1. No `scope` param on /authorize. App permissions are fixed at App
+//      definition; passing `scope` is rejected.
+//   2. With "Expire user authorization tokens" enabled on the App, the
+//      token exchange returns `refresh_token` + `expires_in` alongside
+//      `access_token`. Sveltia handles refresh client-side, so we pass
+//      those through in the success postMessage and expose a /refresh
+//      endpoint for renewals.
+//
+// No private key / JWT plumbing is needed here: Sveltia uses user-to-server
+// tokens, which are minted from client_id + client_secret + code. The App's
+// private key is only required for minting *installation* tokens (no human),
+// which we don't do.
 
 export interface Env {
   GITHUB_CLIENT_ID: string;
@@ -10,6 +26,16 @@ export interface Env {
 const STATE_COOKIE = "sveltia_oauth_state";
 // Cap GitHub token-exchange to keep us comfortably under the Workers CPU limit.
 const TOKEN_EXCHANGE_TIMEOUT_MS = 8000;
+
+interface TokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  refresh_token_expires_in?: number;
+  token_type?: string;
+  error?: string;
+  error_description?: string;
+}
 
 function parseOrigins(env: Env): string[] {
   return env.AUTH_ALLOWED_ORIGINS.split(",").map((s) => s.trim()).filter(Boolean);
@@ -33,6 +59,15 @@ function htmlResponse(body: string): Response {
       "Cache-Control": "no-store",
     },
   });
+}
+
+function jsonResponse(body: unknown, init: { status?: number; origin?: string } = {}): Response {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+  };
+  if (init.origin) headers["Access-Control-Allow-Origin"] = init.origin;
+  return new Response(JSON.stringify(body), { status: init.status ?? 200, headers });
 }
 
 function postMessageHTML(targetOrigin: string, status: "success" | "error", payload: unknown): string {
@@ -63,6 +98,31 @@ function originErrorResponse(targetOrigin: string | null, allowed: string[], mes
   });
 }
 
+async function exchangeWithGithub(body: Record<string, string>): Promise<TokenResponse> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS);
+  try {
+    const res = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      return { error: `Token endpoint returned ${res.status}` };
+    }
+    return (await res.json()) as TokenResponse;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: "Token exchange aborted (timeout)" };
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    return { error: `Token exchange failed: ${detail}` };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -78,10 +138,10 @@ export default {
       }
       const state = crypto.randomUUID();
       const cookieValue = `${state}|${encodeURIComponent(origin)}`;
+      // GitHub Apps: no `scope` — permissions are baked into the App definition.
       const params = new URLSearchParams({
         client_id: env.GITHUB_CLIENT_ID,
         redirect_uri: `${url.origin}/callback`,
-        scope: "public_repo,user",
         state,
       });
       return new Response(null, {
@@ -118,38 +178,103 @@ export default {
         return htmlResponse(postMessageHTML(targetOrigin, "error", { message: "Invalid state" }));
       }
 
-      // Robust token exchange: bound the request, check status, and treat any
-      // network/parse failure as a controlled OAuth error rather than a 500.
-      let data: { access_token?: string; error?: string } = {};
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS);
-      try {
-        const tokenRes = await fetch("https://github.com/login/oauth/access_token", {
-          method: "POST",
-          headers: { Accept: "application/json", "Content-Type": "application/json" },
-          body: JSON.stringify({
-            client_id: env.GITHUB_CLIENT_ID,
-            client_secret: env.GITHUB_CLIENT_SECRET,
-            code,
-          }),
-          signal: controller.signal,
-        });
-        if (!tokenRes.ok) {
-          return htmlResponse(
-            postMessageHTML(targetOrigin, "error", { message: `Token endpoint returned ${tokenRes.status}` }),
-          );
-        }
-        data = (await tokenRes.json()) as { access_token?: string; error?: string };
-      } catch {
-        return htmlResponse(postMessageHTML(targetOrigin, "error", { message: "Token exchange failed" }));
-      } finally {
-        clearTimeout(timeout);
-      }
+      const data = await exchangeWithGithub({
+        client_id: env.GITHUB_CLIENT_ID,
+        client_secret: env.GITHUB_CLIENT_SECRET,
+        redirect_uri: `${url.origin}/callback`,
+        code,
+      });
 
       if (!data.access_token) {
-        return htmlResponse(postMessageHTML(targetOrigin, "error", { message: data.error || "No token" }));
+        return htmlResponse(
+          postMessageHTML(targetOrigin, "error", {
+            message: data.error_description || data.error || "No token",
+          }),
+        );
       }
-      return htmlResponse(postMessageHTML(targetOrigin, "success", { token: data.access_token, provider: "github" }));
+
+      // Pass through refresh_token + expiries so Sveltia can refresh
+      // user-to-server tokens client-side (App "Expire tokens" enabled).
+      const successPayload: Record<string, unknown> = {
+        token: data.access_token,
+        provider: "github",
+      };
+      if (data.refresh_token) successPayload.refresh_token = data.refresh_token;
+      if (typeof data.expires_in === "number") successPayload.expires_in = data.expires_in;
+      if (typeof data.refresh_token_expires_in === "number") {
+        successPayload.refresh_token_expires_in = data.refresh_token_expires_in;
+      }
+      if (data.token_type) successPayload.token_type = data.token_type;
+
+      return htmlResponse(postMessageHTML(targetOrigin, "success", successPayload));
+    }
+
+    // Refresh endpoint: Sveltia POSTs the refresh_token here when the
+    // access_token nears expiry. We forward to GitHub's token endpoint.
+    if (url.pathname === "/refresh") {
+      const origin = request.headers.get("Origin");
+      const originOk = origin !== null && allowed.includes(origin);
+
+      if (request.method === "OPTIONS") {
+        if (!originOk) return new Response(null, { status: 403 });
+        return new Response(null, {
+          status: 204,
+          headers: {
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type",
+            "Access-Control-Max-Age": "86400",
+          },
+        });
+      }
+
+      if (request.method !== "POST") {
+        return new Response("Method not allowed", { status: 405 });
+      }
+      if (!originOk) {
+        return jsonResponse({ error: "Origin not allowed" }, { status: 403 });
+      }
+      // After the originOk guard above, `origin` is guaranteed non-null.
+      const allowedOrigin: string = origin;
+
+      let body: { refresh_token?: unknown };
+      try {
+        body = (await request.json()) as { refresh_token?: unknown };
+      } catch {
+        return jsonResponse({ error: "Invalid JSON" }, { status: 400, origin: allowedOrigin });
+      }
+
+      if (typeof body.refresh_token !== "string" || !body.refresh_token) {
+        return jsonResponse({ error: "Missing refresh_token" }, { status: 400, origin: allowedOrigin });
+      }
+
+      const data = await exchangeWithGithub({
+        client_id: env.GITHUB_CLIENT_ID,
+        client_secret: env.GITHUB_CLIENT_SECRET,
+        grant_type: "refresh_token",
+        refresh_token: body.refresh_token,
+      });
+
+      if (data.error || !data.access_token) {
+        return jsonResponse(
+          { error: data.error_description || data.error || "No token" },
+          { status: 400, origin: allowedOrigin },
+        );
+      }
+
+      // Mirror the /callback payload shape — only include optional fields
+      // when GitHub returned them.
+      const refreshPayload: Record<string, unknown> = {
+        access_token: data.access_token,
+      };
+      if (data.refresh_token) refreshPayload.refresh_token = data.refresh_token;
+      if (typeof data.expires_in === "number") refreshPayload.expires_in = data.expires_in;
+      if (typeof data.refresh_token_expires_in === "number") {
+        refreshPayload.refresh_token_expires_in = data.refresh_token_expires_in;
+      }
+      if (data.token_type) refreshPayload.token_type = data.token_type;
+
+      return jsonResponse(refreshPayload, { origin: allowedOrigin });
     }
 
     return new Response("Not found", { status: 404 });


### PR DESCRIPTION
## **User description**
## Summary

- Switch `auth.gvns.ca` Worker from OAuth App to **GitHub App** auth flow so CMS commits land as a distinct bot identity (`gvns-ca-cms[bot]`) — separate from the human's `git push`.
- Drop `scope` param on `/auth` (Apps reject it; permissions baked into App definition).
- Pass through `refresh_token` / `expires_in` / `refresh_token_expires_in` / `token_type` on `/callback` so Sveltia can refresh client-side (App "Expire user authorization tokens" is on).
- New `POST /refresh` endpoint with origin allowlist + CORS preflight, proxying `grant_type=refresh_token` to GitHub.
- `docs/CMS-SETUP.md` updated with the App-backed flow, secret list, and intended branch-protection posture.

No private key / JWT — Sveltia uses user-to-server tokens only.

## Deployment runbook (in order)

1. In `workers/sveltia-auth/`: `wrangler secret put GITHUB_CLIENT_ID` (App's `Iv23…` client ID)
2. `wrangler secret put GITHUB_CLIENT_SECRET` (regenerate from App settings if needed)
3. Confirm `AUTH_ALLOWED_ORIGINS` is still set
4. Merge this PR (Workers Builds redeploys auto on `main` push? — confirm; otherwise `npm run deploy` from the worker dir)
5. Test `gvns.ca/admin` login; confirm a CMS edit commits as the `[bot]` identity
6. **Only after CMS works**: re-enable branch protection on `main` (ruleset, App on bypass list, Workers Builds check required)
7. Manually merge stuck PR #327; re-run watching workflow to verify auto-merge succeeds

## Test plan

- [ ] Worker deploys cleanly (`tsc --noEmit` already green locally)
- [ ] CMS login at `/admin` → popup completes → token postMessage delivered
- [ ] Make a CMS edit → commit author is `gvns-ca-cms[bot]`
- [ ] Wait past `expires_in` (8h with default settings); confirm Sveltia refreshes via `/refresh` without re-prompting login
- [ ] After branch protection re-enabled: `git push origin main` from CLI is rejected; CMS commit still lands

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Switch CMS auth to GitHub App tokens and add token refresh support**

### What Changed
- CMS logins now use the GitHub App flow, so commits are made by the `gvns-ca-cms[bot]` account instead of the human user
- The login flow no longer sends a `scope` setting, which matches how GitHub Apps work
- Successful logins now pass back token expiry details and refresh tokens so Sveltia can renew access without forcing a new login
- A new `POST /refresh` endpoint lets the CMS refresh expired tokens from the browser, with origin checks and CORS support
- Setup docs now explain the GitHub App flow, required secrets, and the intended branch protection setup

### Impact
`✅ CMS commits show up under a separate bot identity`
`✅ Fewer repeated logins when tokens expire`
`✅ Safer direct publishing to main`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=63jekIvIGFX93LAFIZKT2YU2W89n8ncD7mJpQ3p2reI&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub App–based authentication for CMS commits (requires App installation plus user access)
  * Token refresh endpoint to renew user access without re-authentication; supports expiring user tokens and client-driven refresh

* **Documentation**
  * Updated CMS setup guide with new auth flow details, worker configuration, callback URL, token lifecycle, CORS expectations, and branch-protection guidance

* **Chores**
  * PR merge behavior changed to immediate squash merge (auto-merge avoided due to required-status-checks constraint)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->