### PR TITLE
chore: extract --gvns-activity-gradient + commit LICENSE (MIT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gareth Evans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,17 @@
     --colour-p5-sky: #0ea5e9; /* sky-500 — status */
     --colour-p5-sky-hover: #38bdf8; /* sky-400 */
 
+    /* Activity gradient — 5-stop hard-stop linear gradient using P1–P5.
+       Single source of truth for masthead stripe (PR 3) and footer line (PR 5). */
+    --gvns-activity-gradient: linear-gradient(
+        90deg,
+        var(--colour-p1-violet) 0% 20%,
+        var(--colour-p2-rose) 20% 40%,
+        var(--colour-p3-emerald) 40% 60%,
+        var(--colour-p4-amber) 60% 80%,
+        var(--colour-p5-sky) 80% 100%
+    );
+
     /* Neutral accent */
     --colour-accent-neutral: #a1a1aa;
     --colour-accent-neutral-hover: #d4d4d8;


### PR DESCRIPTION
## Summary

Foundational PR for the home/now redesign. Adds a single source-of-truth gradient variable and commits the project's MIT licence.

- **`src/styles/global.css`**: New `--gvns-activity-gradient` in `:root` — a 5-stop `linear-gradient(90deg, …)` with hard stops at 20/40/60/80%, referencing the existing P1–P5 tokens (`--colour-p1-violet`, `--colour-p2-rose`, `--colour-p3-emerald`, `--colour-p4-amber`, `--colour-p5-sky`). No new colour values.
- **`LICENSE`**: Standard SPDX MIT text, `Copyright (c) 2026 Gareth Evans`. Makes the footer's "code MIT · words CC BY 4.0" claim accurate when PR 5 lands.

## Drift note (intentional)

Per the issue's drift note, **`ActivityBar.astro` is NOT modified**. The current component renders 5 discrete colour segments with 4px gaps — not a `linear-gradient` — so there is no existing gradient to "extract". This PR creates a fresh token consumed only by PR 3 (masthead stripe) and PR 5 (footer line). `ActivityBar` keeps its segmented look unchanged; no visual regression risk.

## Verification

```
$ grep "gvns-activity-gradient" src/styles/global.css
    --gvns-activity-gradient: linear-gradient(

$ head -3 LICENSE
MIT License

Copyright (c) 2026 Gareth Evans

$ npm run build
… [build] Complete!
```

Closes #342

## Test plan

- [ ] CI build green
- [ ] `ActivityBar` renders pixel-identical before/after (untouched)
- [ ] After merge, GitHub sidebar shows "MIT License"
- [ ] PR 3 (masthead stripe) and PR 5 (footer line) can consume `var(--gvns-activity-gradient)` without further changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT License

* **Style**
  * Added new activity gradient styling using the accent colour palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->