### PR TITLE
chore: SITE_BIO + self-description drift fix

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,12 +2,13 @@
 import BaseHead from '@components/BaseHead.astro';
 import Header from '@components/Header.astro';
 import Footer from '@components/Footer.astro';
+import { SITE_BIO } from '@utils/site';
 import '@styles/global.css';
 import "@styles/starwind.css";
 
 interface Props {
   title: string;
-  description: string;
+  description?: string;
   image?: string;
   imageWidth?: number;
   imageHeight?: number;
@@ -16,7 +17,7 @@ interface Props {
   breadcrumbs?: { label: string; href?: string }[];
 }
 
-const { title, description, image, imageWidth, imageHeight, imageAlt, accent, breadcrumbs } = Astro.props;
+const { title, description = SITE_BIO, image, imageWidth, imageHeight, imageAlt, accent, breadcrumbs } = Astro.props;
 
 const SITE_SUFFIX = ' | gvns.ca';
 const fullTitle = title.endsWith(SITE_SUFFIX) ? title : `${title}${SITE_SUFFIX}`;

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -6,6 +6,7 @@ import Profile, { type ProfileSocialLink } from '@components/Profile.astro';
 import { Separator } from '@components/starwind/separator';
 import Timeline from '@components/Timeline.astro';
 import { personSchema, breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
+import { SITE_BIO } from '@utils/site';
 
 import IconBrandGithub from '@tabler/icons/outline/brand-github.svg';
 import IconBrandThreads from '@tabler/icons/outline/brand-threads.svg';
@@ -29,7 +30,7 @@ const socials: ProfileSocialLink[] = [
 
 <BaseLayout
   title="About"
-  description="Web developer on Vancouver Island. Writing about homelab, web development, BJJ, and whatever catches my attention."
+  description={SITE_BIO}
   accent="p5-sky"
   breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'About' }]}
 >
@@ -39,19 +40,20 @@ const socials: ProfileSocialLink[] = [
   <main id="main-content" class="gvns-about" data-pagefind-body>
     <Profile
       name="Gareth Evans"
-      jobTitle="Web developer · Vancouver Island"
+      jobTitle="Tech tinkerer · Qualicum Beach"
       image="/avatar.jpg"
       socials={socials}
     >
       <div class="prose">
         <p>
-          Hi, I'm Gareth — a web developer based on Vancouver Island, Canada.
+          Hi, I'm Gareth — a tech tinkerer based in Qualicum Beach, Canada. I write
+          about homelab, self-hosting, networking, and BJJ.
         </p>
 
         <p>
-          I build things for the web by day, and tinker with homelabs and self-hosting
-          by night. When I'm not at a keyboard, you'll find me on the mats training
-          Brazilian Jiu-Jitsu.
+          By day I work in IT infrastructure; by night I tinker with homelabs,
+          self-hosting, and networking gear. When I'm not at a keyboard, you'll
+          find me on the mats training Brazilian Jiu-Jitsu.
         </p>
 
         <h2>What I Write About</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import ListenWidget from '@components/widgets/ListenWidget.astro';
 import WatchWidget from '@components/widgets/WatchWidget.astro';
 import CodeWidget from '@components/widgets/CodeWidget.astro';
 import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
+import { SITE_BIO } from '@utils/site';
 import '@styles/widgets.css';
 
 const posts = (await getCollection('posts'))
@@ -24,7 +25,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
 
 <BaseLayout
   title="Gareth Evans"
-  description="Personal site for writing and shipped work. Serious work, questionable puns."
+  description={SITE_BIO}
   accent="neutral"
 >
   <script type="application/ld+json" set:html={jsonLd} slot="head" />

--- a/src/utils/json-ld.ts
+++ b/src/utils/json-ld.ts
@@ -4,6 +4,8 @@
  * @see https://developers.google.com/search/docs/appearance/structured-data
  */
 
+import { SITE_BIO } from "./site";
+
 const SITE_NAME = "gvns.ca";
 const AUTHOR_NAME = "Gareth Evans";
 const DEFAULT_SITE_URL = "https://gvns.ca";
@@ -45,8 +47,7 @@ export function websiteSchema(siteUrl?: string): object {
       "@type": "Person",
       name: AUTHOR_NAME,
     },
-    description:
-      "Personal site for writing and shipped work. Notes on homelab, web development, BJJ, and productivity.",
+    description: SITE_BIO,
   };
 }
 
@@ -61,7 +62,7 @@ export function personSchema(siteUrl?: string): object {
     "@type": "Person",
     name: AUTHOR_NAME,
     url,
-    jobTitle: "Web Developer",
+    jobTitle: "Tech tinkerer",
     knowsAbout: [
       "Web Development",
       "Homelab",

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,0 +1,1 @@
+export const SITE_BIO = "Tech tinkerer in Qualicum Beach. I write about homelab, self-hosting, networking, and BJJ.";


### PR DESCRIPTION
## Summary

Introduces canonical `SITE_BIO` constant in `src/utils/site.ts` and routes all consumers through it: `BaseLayout` default meta, homepage `description` prop, OG/Twitter cards, `/about` (`jobTitle` + lead paragraph), and JSON-LD structured data. Resolves the self-description drift across surfaces.

Closes #341
Spec: [`docs/specs/home-now-redesign-2026-04.md` §5](../blob/main/docs/specs/home-now-redesign-2026-04.md#5-self-description-drift-fix)
Tracked by epic: #340

## Changes

- `src/utils/site.ts` (new) — exports `SITE_BIO`.
- `src/layouts/BaseLayout.astro` — `description` prop now optional, defaults to `SITE_BIO`. OG/Twitter cards already read from `description` (via `BaseHead`).
- `src/pages/index.astro` — passes `description={SITE_BIO}`.
- `src/pages/about/index.astro` — `jobTitle` → "Tech tinkerer · Qualicum Beach"; description → `SITE_BIO`; lead paragraph rewritten with tech-tinkerer framing. BJJ / homelab / networking sections untouched.
- `src/utils/json-ld.ts` — `websiteSchema` description now reads from `SITE_BIO`; `personSchema` `jobTitle` updated from "Web Developer" to "Tech tinkerer". No drift remains.

## Verification

`npm run build` — clean (existing `posts` collection empty warnings unrelated; pre-existing in worktree).

`curl -s http://localhost:4322/ | tr '>' '>\n' | grep -E '(name="description"|og:description|twitter:description)'`:
```
<meta name="description" content="Tech tinkerer in Qualicum Beach. I write about homelab, self-hosting, networking, and BJJ.">
<meta property="og:description" content="Tech tinkerer in Qualicum Beach. I write about homelab, self-hosting, networking, and BJJ.">
<meta name="twitter:description" content="Tech tinkerer in Qualicum Beach. I write about homelab, self-hosting, networking, and BJJ.">
```

`grep -rin "Vancouver Island" src/pages src/layouts src/components` → no hits.
`grep -E "(Web Developer|Personal site for writing|Vancouver Island)" src/utils/json-ld.ts` → no hits.
`grep -rin "web developer" src/pages src/layouts src/components` → only `src/pages/resume/index.astro:23` (historical resume copy, intentionally retained).

## Out of scope (intentionally retained)

- `src/pages/resume/index.astro` — historical resume copy.
- `src/data/timeline.yaml` — historical "Moved to Vancouver Island" event (biographical, retain).

## Test plan

- [ ] CI build passes
- [ ] Visual diff `/about` — only lead paragraph + jobTitle change
- [ ] OG card preview (paste preview URL into Slack draft)
- [ ] Inspect `/` JSON-LD payload — `WebSite.description` and `Person.jobTitle` reflect new bio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed site profile and biography information, including updated job title and location details.
  * Standardized site description across pages and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->