### PR TITLE
feat: /now prose intro from now-intro.md

### DIFF
--- a/src/data/now-intro.md
+++ b/src/data/now-intro.md
@@ -1,0 +1,7 @@
+---
+lastUpdated: 2026-05-02
+---
+
+This is placeholder copy that Gareth will rewrite. The first paragraph sits in primary text and is meant to capture what's actively in flight right now — current projects, the work that's pulling focus this week, and anything new that's recently landed on the bench worth flagging.
+
+The second paragraph drops to secondary colour and covers the slower-burn stuff: what's resting on the back burner, the books on the nightstand, the album on repeat, and any longer-running thread that hasn't been retired but isn't getting daily attention either.

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -9,8 +9,18 @@ import ListenWidget from "@components/widgets/ListenWidget.astro";
 import WatchWidget from "@components/widgets/WatchWidget.astro";
 import WriteWidget from "@components/widgets/WriteWidget.astro";
 import StatusWidget from "@components/widgets/StatusWidget.astro";
+import { Content as NowIntroContent, frontmatter as nowIntroFrontmatter } from "../../data/now-intro.md";
 
 const siteUrl = normalizeSiteUrl(Astro.site);
+
+const lastUpdatedDate = new Date(nowIntroFrontmatter.lastUpdated);
+const lastUpdatedFormatted = new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+}).format(lastUpdatedDate);
+const lastUpdatedISO = lastUpdatedDate.toISOString().slice(0, 10);
 const breadcrumbJsonLd = toJsonLd(
     breadcrumbSchema([
         { name: "Home", url: siteUrl },
@@ -34,8 +44,18 @@ const breadcrumbJsonLd = toJsonLd(
     <main id="main-content" class="gvns-now" data-pagefind-body>
         <div class="gvns-now__container">
             <header class="gvns-now__header">
-                <h1>Now</h1>
-                <p class="gvns-now__subtitle">What I'm up to right now.</p>
+                <div class="gvns-now__heading-row">
+                    <h1>Now</h1>
+                    <time
+                        class="gvns-now__updated"
+                        datetime={lastUpdatedISO}
+                    >
+                        Updated {lastUpdatedFormatted}
+                    </time>
+                </div>
+                <div class="gvns-now__intro">
+                    <NowIntroContent />
+                </div>
             </header>
 
             <div class="gvns-now__bento">
@@ -73,18 +93,43 @@ const breadcrumbJsonLd = toJsonLd(
         margin-bottom: var(--space-10);
     }
 
+    .gvns-now__heading-row {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+        margin-bottom: var(--space-6);
+    }
+
     .gvns-now__header h1 {
-        font-size: var(--text-4xl);
+        font-family: var(--font-display, "Space Grotesk"), sans-serif;
+        font-size: 32px;
         font-weight: 700;
         letter-spacing: -0.02em;
         line-height: 1.1;
-        margin-bottom: var(--space-2);
+        margin: 0;
     }
 
-    .gvns-now__subtitle {
-        font-size: var(--text-lg);
+    .gvns-now__updated {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
         color: var(--colour-text-secondary);
-        margin: 0;
+    }
+
+    .gvns-now__intro :global(p) {
+        font-size: var(--text-base);
+        line-height: 1.6;
+        margin: 0 0 var(--space-4) 0;
+        color: var(--colour-text-primary);
+    }
+
+    .gvns-now__intro :global(p:last-child) {
+        margin-bottom: 0;
+    }
+
+    .gvns-now__intro :global(p:nth-of-type(2)) {
+        color: var(--colour-text-secondary);
     }
 
     /*


### PR DESCRIPTION
## Summary

Adds a heading row + 2-paragraph prose intro above the existing bento on `/now`, sourced from a new `src/data/now-intro.md`. The `lastUpdated` frontmatter feeds the freshness date in the heading row. Bento grid markup below is unchanged.

Closes #344

## Implementation notes

- **Markdown-import approach**: direct ESM import of the markdown file from `src/pages/now/index.astro` — `import { Content, frontmatter } from \"../../data/now-intro.md\"`. Astro 6 natively supports importing markdown files outside content collections; the import returns an `<Content />` component for the rendered body and a `frontmatter` object for the YAML.
- **Date format**: `Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' })` → e.g. `2 May 2026`. The existing `formatDate` util in `src/utils/date.ts` returns US-style \"December 9, 2024\" so it wasn't reused for this surface.
- **Frontmatter quirk**: Astro's YAML parser turns `lastUpdated: 2026-05-02` into an ISO datetime *string* (`2026-05-02T00:00:00.000Z`) rather than a Date. Passing that string straight to `new Date(...)` works correctly; previous template-literal concatenation produced an invalid date.
- **Two-paragraph colour split**: handled in CSS via `.gvns-now__intro :global(p:nth-of-type(2))` → `var(--colour-text-secondary)`. First paragraph stays in primary colour.
- **Mobile**: heading row uses `flex-wrap: wrap` so title + date drop to two lines gracefully when they can't share a baseline.
- **Mono surface**: `.gvns-now__updated` uses `var(--font-mono)` + `var(--text-sm)` with no custom letter-spacing/feature-settings — matches the widget mono surface (`.gvns-widget__time`) used elsewhere on the page. Site-wide mono audit (status of issue #344's AC) is the broader task.

## Verification

```
npm run build  →  Complete!
grep \"Updated 2 May 2026\" dist/client/now/index.html  →  match
grep -c gvns-now__bento dist/client/now/index.html  →  1  (bento markup preserved)
```

Date-update test: temporarily changed `lastUpdated` to `2025-12-25`, rebuilt, confirmed render `Updated 25 December 2025`, then reverted.

## Test plan

- [ ] Screenshots at mobile + desktop posted to PR description (pending — running in headless worktree).
- [ ] Manual visual check on dev server.
- [ ] Confirm bento grid below renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a last updated timestamp displayed on the Now page to show when content was most recently refreshed.

* **Style**
  * Reorganized the Now page header layout with a new design combining the page title and timestamp display. Updated typography, margins, and spacing throughout for improved readability and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->