### PR TITLE
feat: footer rewrite — gradient line + dual-licence legal

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -55,7 +55,7 @@ const links: FooterLink[] = [
 
 <footer class="gvns-footer @container w-full border-t py-12">
     <div class="mx-auto w-full max-w-7xl px-4">
-        <div class="flex flex-col items-center gap-6">
+        <div class="gvns-footer__inner">
             <ul class="gvns-footer-links flex gap-6">
                 {
                     links.map((link) => (
@@ -82,8 +82,10 @@ const links: FooterLink[] = [
                 }
             </ul>
 
-            <p class="gvns-footer-copyright text-center text-sm">
-                © {currentYear} Gareth Evans
+            <div class="gvns-footer__gradient" aria-hidden="true"></div>
+
+            <p class="gvns-footer__legal">
+                © {currentYear} Gareth Evans · code MIT · words CC BY 4.0
             </p>
         </div>
     </div>
@@ -93,6 +95,13 @@ const links: FooterLink[] = [
     .gvns-footer {
         margin-top: auto;
         border-color: var(--colour-border);
+    }
+
+    .gvns-footer__inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.875rem;
     }
 
     .gvns-footer-links {
@@ -113,8 +122,19 @@ const links: FooterLink[] = [
         color: var(--colour-accent-primary);
     }
 
-    .gvns-footer-copyright {
+    .gvns-footer__gradient {
+        width: 80px;
+        height: 2px;
+        background: var(--gvns-activity-gradient);
+    }
+
+    .gvns-footer__legal {
         margin: 0;
-        color: var(--colour-text-secondary);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--colour-text-muted);
+        letter-spacing: 0.02em;
+        text-align: center;
+        white-space: nowrap;
     }
 </style>


### PR DESCRIPTION
## Summary

Adds an 80×2px P1–P5 gradient line between the existing icon row and the legal line in `src/components/Footer.astro`, and replaces the legal copy with `© {currentYear} Gareth Evans · code MIT · words CC BY 4.0` (real U+00B7 middle dots).

The gradient line consumes `var(--gvns-activity-gradient)` (added in #350) — same gradient as the masthead stripe (#343), different scale — so the page is bookended by the same colour signature.

Icon row markup, link list, ordering, and internal/external handling are preserved verbatim.

Closes #345

## §10.5 Decision: content licence anchor

- [x] **(a) Leave "words CC BY 4.0" unlinked — spec default, ship as-is.**
- [ ] (b) Add a `/licence` page and link.
- [ ] (c) Document on `/about` and link there.

Rationale: spec default; restraint is the point. A `/licence` page or `/about` blurb can be added in a follow-up if/when desired without disturbing the footer.

## Implementation notes

- `.gvns-footer__inner`: flex column, `align-items: center`, `gap: 0.875rem`.
- `.gvns-footer__gradient`: `width: 80px; height: 2px; background: var(--gvns-activity-gradient);`, `aria-hidden="true"`.
- `.gvns-footer__legal`: `var(--font-mono)`, 11px, `var(--colour-text-muted)`, `letter-spacing: 0.02em`, `margin: 0`, `white-space: nowrap` (guarantees no wrap at 375px).
- `currentYear` already computed via `new Date().getFullYear()` at the top of the component.
- Existing outer `<footer>` container (border-top, padding, `max-w-7xl` wrapper) preserved — the inner stack centres regardless.

## Verification

- [x] `npm run build` clean (output includes `gvns-footer__gradient` div + correct legal line on every prerendered page).
- [x] Hex-verified middle dot is `c2 b7` (UTF-8 for U+00B7), not `|` or `-`.
- [x] Existing 5-icon row markup unchanged (GitHub, Threads, LinkedIn, Email→/contact, RSS).
- [x] `--gvns-activity-gradient` consumed via CSS var — no inlined duplicate gradient.
- [x] No wordmark, tagline, or swatch circles introduced.

## Outstanding (maintainer)

- [ ] Screenshots at mobile (375px) + desktop posted to PR description.
- [ ] axe-core run on a sample page.
- [ ] Visual diff vs masthead stripe (top/bottom colour rhyme) at desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the footer layout with an improved visual structure.
  * Added a decorative gradient element to the footer.
  * Updated the legal text section with expanded licensing information, clearly identifying code and content licensing terms separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->