### PR TITLE
feat: navbar redesign + masthead stripe (site-wide)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -346,5 +346,3 @@ const statusOpen = status === 'open';
     pointer-events: none;
   }
 </style>
-</content>
-</invoke>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -287,7 +287,7 @@ const statusOpen = status === 'open';
   }
 
   .gvns-status-pill:hover {
-    color: var(--colour-accent-primary);
+    color: var(--colour-text-primary);
   }
 
   .gvns-status-pill__dot {
@@ -302,8 +302,8 @@ const statusOpen = status === 'open';
   @media (min-width: 768px) and (max-width: 1023px) {
     .gvns-status-pill {
       padding: 0.25rem;
-      width: 22px;
-      height: 22px;
+      width: 24px;
+      height: 24px;
       justify-content: center;
       gap: 0;
     }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,29 +16,47 @@ const navItems = [
 ];
 
 const currentPath = Astro.url.pathname;
+
+// Hardcoded for v1; will read from StatusWidget when that lands.
+const status: 'open' | 'closed' = 'open';
+const statusOpen = status === 'open';
 ---
 
 <header class="gvns-navbar">
   <!-- Desktop Navigation -->
   <nav class="gvns-navbar__nav" aria-label="Main navigation">
     <div class="gvns-navbar__start">
-      <a href="/" class="gvns-navbar__logo" aria-label="GVNS home">GVNS</a>
+      <a href="/" class="gvns-navbar__brand" aria-label="Home — Gareth Evans">
+        <picture>
+          <source srcset="/avatar.webp" type="image/webp" />
+          <img
+            src="/avatar.jpg"
+            alt=""
+            width="24"
+            height="24"
+            loading="eager"
+            decoding="async"
+            class="gvns-navbar__avatar"
+          />
+        </picture>
+        <span class="gvns-navbar__wordmark">Gareth Evans</span>
+      </a>
     </div>
 
     <div class="gvns-navbar__center">
       {breadcrumbs ? (
         <ol class="gvns-breadcrumbs" aria-label="Breadcrumb">
-            {breadcrumbs.map((item, i) => (
-              <li class="gvns-breadcrumbs__item">
-                {i > 0 && <span class="gvns-breadcrumbs__separator" aria-hidden="true">/</span>}
-                {item.href ? (
-                  <a href={item.href} class="gvns-breadcrumbs__link">{item.label}</a>
-                ) : (
-                  <span class="gvns-breadcrumbs__current" aria-current="page">{item.label}</span>
-                )}
-              </li>
-            ))}
-          </ol>
+          {breadcrumbs.map((item, i) => (
+            <li class="gvns-breadcrumbs__item">
+              {i > 0 && <span class="gvns-breadcrumbs__separator" aria-hidden="true">/</span>}
+              {item.href ? (
+                <a href={item.href} class="gvns-breadcrumbs__link">{item.label}</a>
+              ) : (
+                <span class="gvns-breadcrumbs__current" aria-current="page">{item.label}</span>
+              )}
+            </li>
+          ))}
+        </ol>
       ) : (
         <ul class="gvns-navbar__links">
           {navItems.map(({ href, label }) => {
@@ -60,6 +78,16 @@ const currentPath = Astro.url.pathname;
     </div>
 
     <div class="gvns-navbar__end">
+      {statusOpen && (
+        <a
+          class="gvns-status-pill"
+          href="/contact"
+          aria-label="Open to freelance work — contact me"
+        >
+          <span class="gvns-status-pill__dot" aria-hidden="true"></span>
+          <span class="gvns-status-pill__label">Open to freelance work</span>
+        </a>
+      )}
       <ThemeToggle client:load />
       <Search />
     </div>
@@ -67,12 +95,34 @@ const currentPath = Astro.url.pathname;
 
   <!-- Mobile Navigation -->
   <div class="gvns-navbar__mobile">
-    <a href="/" class="gvns-navbar__logo" aria-label="GVNS home">GVNS</a>
+    <a href="/" class="gvns-navbar__brand" aria-label="Home — Gareth Evans">
+      <picture>
+        <source srcset="/avatar.webp" type="image/webp" />
+        <img
+          src="/avatar.jpg"
+          alt=""
+          width="24"
+          height="24"
+          loading="eager"
+          decoding="async"
+          class="gvns-navbar__avatar"
+        />
+      </picture>
+      <span class="gvns-navbar__wordmark">Gareth Evans</span>
+    </a>
     <div class="gvns-navbar__mobile-actions">
       <Search />
-      <MobileNav client:load navItems={navItems} currentPath={currentPath} />
+      <MobileNav
+        client:load
+        navItems={navItems}
+        currentPath={currentPath}
+        statusOpen={statusOpen}
+      />
     </div>
   </div>
+
+  <!-- Masthead stripe: full-viewport-wide P1–P5 gradient -->
+  <div class="gvns-masthead-stripe" aria-hidden="true"></div>
 </header>
 
 <style>
@@ -89,6 +139,7 @@ const currentPath = Astro.url.pathname;
     display: none;
     align-items: center;
     justify-content: space-between;
+    gap: var(--space-4);
   }
 
   @media (min-width: 768px) {
@@ -97,14 +148,48 @@ const currentPath = Astro.url.pathname;
     }
   }
 
-  /* Start: Logo */
-  .gvns-navbar__logo {
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+  /* Start: Brand */
+  .gvns-navbar__start {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .gvns-navbar__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
     color: var(--colour-text-primary);
     text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .gvns-navbar__brand:hover {
+    color: var(--colour-accent-primary);
+  }
+
+  .gvns-navbar__avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 9999px;
+    object-fit: cover;
+    display: block;
     flex-shrink: 0;
+  }
+
+  .gvns-navbar__wordmark {
+    font-family: var(--font-sans, 'Inter', sans-serif);
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  /* Hide wordmark below 640px (mobile compact) */
+  @media (max-width: 639px) {
+    .gvns-navbar__wordmark {
+      display: none;
+    }
   }
 
   /* Center: Nav links or breadcrumbs */
@@ -175,12 +260,57 @@ const currentPath = Astro.url.pathname;
     white-space: nowrap;
   }
 
-  /* End: Theme toggle + Search */
+  /* End: Status pill + Theme toggle + Search */
   .gvns-navbar__end {
     display: flex;
     align-items: center;
     gap: var(--space-4);
     flex-shrink: 0;
+  }
+
+  /* Status pill */
+  .gvns-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.1875rem 0.625rem;
+    border: 1px solid var(--colour-border);
+    border-radius: 9999px;
+    background: rgb(14 165 233 / 0.06);
+    color: var(--colour-text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    line-height: 1;
+    transition:
+      color var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+
+  .gvns-status-pill:hover {
+    color: var(--colour-accent-primary);
+  }
+
+  .gvns-status-pill__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: var(--colour-p5-sky);
+    flex-shrink: 0;
+  }
+
+  /* Tablet (768–1023px): collapse pill to dot-only */
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .gvns-status-pill {
+      padding: 0.25rem;
+      width: 22px;
+      height: 22px;
+      justify-content: center;
+      gap: 0;
+    }
+
+    .gvns-status-pill__label {
+      display: none;
+    }
   }
 
   /* Mobile Navigation */
@@ -203,4 +333,18 @@ const currentPath = Astro.url.pathname;
       display: none;
     }
   }
+
+  /* Masthead stripe — edge-to-edge P1–P5 gradient */
+  .gvns-masthead-stripe {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px; /* sits over the 1px border for a clean line */
+    height: 2px;
+    width: 100%;
+    background: var(--gvns-activity-gradient);
+    pointer-events: none;
+  }
 </style>
+</content>
+</invoke>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -276,7 +276,7 @@ const statusOpen = status === 'open';
     padding: 0.1875rem 0.625rem;
     border: 1px solid var(--colour-border);
     border-radius: 9999px;
-    background: rgb(from var(--colour-p5-sky) r g b / 0.06);
+    background: var(--gvns-status-tint);
     color: var(--colour-text-secondary);
     text-decoration: none;
     font-size: var(--text-sm);

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -276,7 +276,7 @@ const statusOpen = status === 'open';
     padding: 0.1875rem 0.625rem;
     border: 1px solid var(--colour-border);
     border-radius: 9999px;
-    background: rgb(14 165 233 / 0.06);
+    background: rgb(from var(--colour-p5-sky) r g b / 0.06);
     color: var(--colour-text-secondary);
     text-decoration: none;
     font-size: var(--text-sm);

--- a/src/components/MobileNav.svelte
+++ b/src/components/MobileNav.svelte
@@ -9,9 +9,10 @@
   interface Props {
     navItems: NavItem[];
     currentPath: string;
+    statusOpen?: boolean;
   }
 
-  let { navItems, currentPath }: Props = $props();
+  let { navItems, currentPath, statusOpen = false }: Props = $props();
 
   let isOpen = $state(false);
   let menuRef = $state<HTMLElement | null>(null);
@@ -98,6 +99,17 @@
     class:open={isOpen}
     aria-hidden={!isOpen}
   >
+    {#if statusOpen}
+      <a
+        class="status-pill"
+        href="/contact"
+        aria-label="Open to freelance work — contact me"
+        onclick={close}
+      >
+        <span class="status-pill__dot" aria-hidden="true"></span>
+        <span class="status-pill__label">Open to freelance work</span>
+      </a>
+    {/if}
     <ul class="nav-links">
       {#each navItems as { href, label }}
         <li>
@@ -196,6 +208,36 @@
   .nav-link.active {
     color: var(--colour-accent-primary);
     background: var(--colour-bg-secondary);
+  }
+
+  .status-pill {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.5rem;
+    border: 1px solid var(--colour-border);
+    border-radius: 9999px;
+    background: rgb(14 165 233 / 0.06);
+    color: var(--colour-text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    transition:
+      color var(--transition-fast),
+      background-color var(--transition-fast);
+  }
+
+  .status-pill:hover {
+    color: var(--colour-accent-primary);
+  }
+
+  .status-pill__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: var(--colour-p5-sky);
+    flex-shrink: 0;
   }
 
   .menu-footer {

--- a/src/components/MobileNav.svelte
+++ b/src/components/MobileNav.svelte
@@ -219,7 +219,7 @@
     margin-bottom: 0.5rem;
     border: 1px solid var(--colour-border);
     border-radius: 9999px;
-    background: rgb(14 165 233 / 0.06);
+    background: rgb(from var(--colour-p5-sky) r g b / 0.06);
     color: var(--colour-text-secondary);
     text-decoration: none;
     font-size: var(--text-sm);

--- a/src/components/MobileNav.svelte
+++ b/src/components/MobileNav.svelte
@@ -219,7 +219,7 @@
     margin-bottom: 0.5rem;
     border: 1px solid var(--colour-border);
     border-radius: 9999px;
-    background: rgb(from var(--colour-p5-sky) r g b / 0.06);
+    background: var(--gvns-status-tint);
     color: var(--colour-text-secondary);
     text-decoration: none;
     font-size: var(--text-sm);

--- a/src/components/MobileNav.svelte
+++ b/src/components/MobileNav.svelte
@@ -229,7 +229,7 @@
   }
 
   .gvns-status-pill:hover {
-    color: var(--colour-accent-primary);
+    color: var(--colour-text-primary);
   }
 
   .gvns-status-pill__dot {

--- a/src/components/MobileNav.svelte
+++ b/src/components/MobileNav.svelte
@@ -101,13 +101,13 @@
   >
     {#if statusOpen}
       <a
-        class="status-pill"
+        class="gvns-status-pill"
         href="/contact"
         aria-label="Open to freelance work — contact me"
         onclick={close}
       >
-        <span class="status-pill__dot" aria-hidden="true"></span>
-        <span class="status-pill__label">Open to freelance work</span>
+        <span class="gvns-status-pill__dot" aria-hidden="true"></span>
+        <span class="gvns-status-pill__label">Open to freelance work</span>
       </a>
     {/if}
     <ul class="nav-links">
@@ -210,7 +210,7 @@
     background: var(--colour-bg-secondary);
   }
 
-  .status-pill {
+  .gvns-status-pill {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -228,11 +228,11 @@
       background-color var(--transition-fast);
   }
 
-  .status-pill:hover {
+  .gvns-status-pill:hover {
     color: var(--colour-accent-primary);
   }
 
-  .status-pill__dot {
+  .gvns-status-pill__dot {
     width: 6px;
     height: 6px;
     border-radius: 9999px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,6 +45,11 @@
         var(--colour-p5-sky) 80% 100%
     );
 
+    /* Status surfaces — P5 sky tinted to 0.06 alpha for the "open to work"
+       pill background (Header + MobileNav). Single source of truth so any
+       future status surface (banner, badge, etc.) reads from the same value. */
+    --gvns-status-tint: rgb(from var(--colour-p5-sky) r g b / 0.06);
+
     /* Neutral accent */
     --colour-accent-neutral: #a1a1aa;
     --colour-accent-neutral-hover: #d4d4d8;


### PR DESCRIPTION
## **User description**
Closes #343

## Summary

Rewrites `src/components/Header.astro` around a three-cluster justified layout (brand · nav · tools) and adds a 2px P1–P5 masthead stripe directly below the nav, rendered site-wide. Swaps the "GVNS" wordmark for a 24px circular avatar + "Gareth Evans" Inter 600 14px wordmark. Adds a sky status pill in the right cluster that links to `/contact`, collapses to dot-only at 768–1023px, and is suppressed entirely when status ≠ `open`.

`src/components/MobileNav.svelte` accepts a new `statusOpen` prop and renders the pill as the top item in the mobile menu when true.

## Implementation notes

- **Stripe gradient:** sources `var(--gvns-activity-gradient)` (merged in PR #350) — no duplicate gradient is inlined.
- **Edge-to-edge stripe:** the stripe is positioned absolutely inside the `<header>` (`left: 0; right: 0; bottom: -1px`) so it spans the full viewport even though the nav is constrained to `--width-content`. It sits over the existing 1px header border for a clean line.
- **Status data:** hardcoded `status: "open"` per spec §4.7. `statusOpen` is computed once and threaded into both desktop markup and `MobileNav` props.
- **Breadcrumb swap preserved:** the centre cluster still swaps to breadcrumbs whenever `Astro.props.breadcrumbs` is supplied (post pages, `/code`, `/resume`, etc.).
- **No JS island** introduced for the navbar or stripe.

## Verification

- `npm run build` — clean (build server + 14 prerendered routes, sitemap + Pagefind index generated).
- Dev server smoke-tested against `/`, `/about`, `/now`, `/contact`, `/code` (breadcrumb consumer):
  - `gvns-masthead-stripe` rendered on every page.
  - `gvns-status-pill` rendered on every page with `href="/contact"` and `aria-label="Open to freelance work — contact me"`.
  - `Gareth Evans` wordmark + avatar `<picture>` rendered in the brand cluster.
  - On `/code`, the centre cluster correctly renders `gvns-breadcrumbs` instead of nav links.
- Confirmed `var(--gvns-activity-gradient)` is the single source of truth — the stripe references the token directly.
- Toggling the hardcoded status to `"closed"` in the component suppresses both desktop and mobile pills (verified by reading the conditional; reverted before commit).

## Acceptance criteria

- [x] Three-cluster justified layout at ≥1024px using `--width-content`.
- [x] Brand cluster: avatar (24×24, webp + jpg fallback, `loading="eager"`, `decoding="async"`, `alt=""`) + "Gareth Evans" Inter 600 14px wordmark, wrapped in `<a href="/" aria-label="Home — Gareth Evans">`.
- [x] At <640px the wordmark hides; from 640px up it returns.
- [x] Status pill links to `/contact`, has accurate `aria-label`, sky dot + label, sky-tinted bg, 1px border.
- [x] At 768–1023px the pill collapses to dot-only (label hidden, padding tightened to ~22px circular).
- [x] When `status !== "open"` the pill is suppressed entirely (not rendered).
- [x] `MobileNav.svelte` accepts a `statusOpen` prop and renders the pill as the top mobile menu item when true.
- [x] On post pages, breadcrumbs continue to replace the centre cluster as today.
- [x] Masthead stripe renders below the nav on every page.
- [x] Stripe is 2px tall, full-viewport-wide, `aria-hidden="true"`, sources `var(--gvns-activity-gradient)`.
- [x] No JS island introduced for the navbar or stripe.
- [x] Keyboard tab order: brand link → nav links → status pill → theme toggle → search (matches DOM order).
- [x] `npm run build` clean.

## Note for maintainer

This was implemented in a headless agent session — **screenshots at all three breakpoints (mobile <768, tablet 768–1023, desktop ≥1024) on home + a post page should be added to this PR description before un-drafting.** Same goes for an axe-core run on `/` and `/posts/<slug>/` (no posts existed in this isolated worktree to test against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open to freelance work" status indicator on desktop and mobile; appears in mobile menu and closes the menu when selected

* **Style**
  * Header branding updated to an avatar plus “Gareth Evans” wordmark with responsive display
  * Added edge-to-edge masthead gradient stripe and refined status-pill appearance (tablet collapses label to a dot)
  * Introduced a status tint design token for consistent pill surfaces
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Redesign the site header with a new brand, status pill, and masthead stripe**

### What Changed
- Replaces the old "GVNS" home link with a round avatar and "Gareth Evans" wordmark in the header and mobile bar
- Adds an open-status pill that links to contact on desktop and mobile, and hides the label on tablet-sized screens
- Shows the status pill inside the mobile menu when the site is marked open
- Adds a thin colored masthead stripe under the header on every page
- Removes leftover stray text from the header and keeps the mobile status pill styling consistent with the site naming pattern

### Impact
`✅ Clearer site identity`
`✅ Easier contact from the header`
`✅ Consistent status display across desktop and mobile`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=xHX83lNJPMNRmjEPBhdOFHiQWvhmFB8oTMh-72F4x2E&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
