### PR TITLE
feat: FeaturedPostCard — brutalist top-stripe + excerpt utility

### DIFF
--- a/scripts/test-excerpt.mjs
+++ b/scripts/test-excerpt.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// Scratch test runner for src/utils/excerpt.ts.
+// Run via: npx tsx scripts/test-excerpt.mjs
+// Exits non-zero on any failed assertion.
+
+import { getExcerpt } from '../src/utils/excerpt.ts';
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function assert(cond, msg) {
+  if (cond) {
+    passed += 1;
+  } else {
+    failed += 1;
+    failures.push(msg);
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+function test(name, fn) {
+  console.log(`\n• ${name}`);
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    failures.push(`${name}: threw ${err.message}`);
+    console.error(`  THREW: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('short input returns full plain text untouched', () => {
+  const md = 'Hello world.';
+  const out = getExcerpt(md, 500);
+  assert(out === 'Hello world.', `expected "Hello world.", got "${out}"`);
+});
+
+test('strips YAML frontmatter', () => {
+  const md = `---\ntitle: Example\npubDate: 2024-01-01\n---\n\nBody starts here.`;
+  const out = getExcerpt(md, 500);
+  assert(!out.includes('title:'), 'frontmatter leaked into output');
+  assert(out.startsWith('Body starts here'), `got: ${out}`);
+});
+
+test('strips headings, keeps text', () => {
+  const md = `# Heading One\n\nSome paragraph text after.`;
+  const out = getExcerpt(md, 500);
+  assert(!out.includes('#'), 'hash leaked');
+  assert(out.includes('Heading One'), 'heading text dropped');
+  assert(out.includes('Some paragraph text after.'), 'body dropped');
+});
+
+test('drops fenced code blocks entirely', () => {
+  const md = `Intro paragraph.\n\n\`\`\`js\nconst secret = 42;\n\`\`\`\n\nAfter code.`;
+  const out = getExcerpt(md, 500);
+  assert(!out.includes('secret'), `code leaked: ${out}`);
+  assert(out.includes('Intro paragraph.'), 'intro dropped');
+  assert(out.includes('After code.'), 'post-code dropped');
+});
+
+test('keeps link label, drops URL', () => {
+  const md = `See [the docs](https://example.com/path) for more.`;
+  const out = getExcerpt(md, 500);
+  assert(out.includes('the docs'), 'label dropped');
+  assert(!out.includes('https://'), `url leaked: ${out}`);
+  assert(!out.includes('example.com'), `url leaked: ${out}`);
+});
+
+test('strips bold/italic/strikethrough markers', () => {
+  const md = `This is **bold** and _italic_ and ~~struck~~ text.`;
+  const out = getExcerpt(md, 500);
+  assert(out === 'This is bold and italic and struck text.', `got: ${out}`);
+});
+
+test('paragraph boundary truncation', () => {
+  const p1 = 'A'.repeat(200) + '.';
+  const p2 = 'B'.repeat(200) + '.';
+  const p3 = 'C'.repeat(400) + '.';
+  const md = `${p1}\n\n${p2}\n\n${p3}`;
+  const out = getExcerpt(md, 500);
+  // Should clamp at the second paragraph break (after p2).
+  assert(out.endsWith('.'), `expected to end on full sentence; got tail: ${out.slice(-20)}`);
+  assert(!out.includes('C'), 'p3 should not appear');
+  assert(out.length <= 500, `length ${out.length} > 500`);
+});
+
+test('sentence boundary fallback when no good paragraph break', () => {
+  // One long paragraph of moderate sentences — multiple sentence breaks
+  // within the maxChars window, no double newlines.
+  const sentence = 'This sentence is exactly forty-eight chars long. ';
+  const long = sentence.repeat(20); // ~960 chars
+  const out = getExcerpt(long, 500);
+  assert(out.length <= 500, `length ${out.length} > 500`);
+  assert(/[.!?]$/.test(out), `should end at sentence punctuation; got tail: ${out.slice(-30)}`);
+});
+
+test('word boundary fallback when no sentence break in window', () => {
+  // No periods at all in first 500 chars — only spaces.
+  const words = Array(200).fill('word').join(' '); // ~999 chars
+  const out = getExcerpt(words, 500);
+  assert(out.length <= 500, `length ${out.length} > 500`);
+  // Must end on a complete "word" (no partial).
+  assert(/word…?$/.test(out), `should end on complete word + optional ellipsis; got tail: ${out.slice(-15)}`);
+});
+
+test('never truncates mid-word', () => {
+  // Build a string where char #500 lands in the middle of a word.
+  const filler = 'x'.repeat(495); // 495 chars
+  const md = `${filler} supercalifragilisticexpialidocious tail`;
+  const out = getExcerpt(md, 500);
+  assert(out.length <= 500, `length ${out.length} > 500`);
+  // Must not end with a partial slice of "supercalifragilistic..."
+  assert(
+    !/super[a-z]+$/.test(out.replace(/…$/, '')),
+    `mid-word cut detected: tail "${out.slice(-30)}"`
+  );
+});
+
+test('output never exceeds maxChars (excluding optional ellipsis)', () => {
+  const longUnbroken = 'lorem ipsum dolor sit amet '.repeat(100); // ~2700
+  const out = getExcerpt(longUnbroken, 500);
+  // We allow trailing … so strip it for the length check.
+  const stripped = out.replace(/…$/, '');
+  assert(stripped.length <= 500, `stripped length ${stripped.length} > 500`);
+});
+
+test('handles full post with frontmatter + headings + code + links', () => {
+  const md = `---
+title: A real post
+pubDate: 2025-01-01
+tags: [code]
+---
+
+# Title here
+
+This is the **opening paragraph** with a [link](https://example.com).
+
+\`\`\`ts
+const leaked = "should not appear";
+\`\`\`
+
+## Section two
+
+More body text follows here, and should still be readable.`;
+  const out = getExcerpt(md, 500);
+  assert(!out.includes('---'), 'frontmatter delimiter leaked');
+  assert(!out.includes('leaked'), 'code content leaked');
+  assert(!out.includes('https://'), 'url leaked');
+  assert(out.includes('Title here'), 'heading text missing');
+  assert(out.includes('opening paragraph'), 'bold inner text missing');
+  assert(out.includes('link'), 'link label missing');
+});
+
+test('respects custom maxChars', () => {
+  const md = 'a '.repeat(200);
+  const out = getExcerpt(md, 50);
+  assert(out.replace(/…$/, '').length <= 50, `length ${out.length} > 50`);
+});
+
+test('handles empty input', () => {
+  assert(getExcerpt('', 500) === '', 'empty input should yield empty');
+});
+
+test('handles input with only frontmatter', () => {
+  const md = `---\ntitle: x\n---\n`;
+  const out = getExcerpt(md, 500);
+  assert(out === '', `expected empty, got "${out}"`);
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  console.error('\nFailures:');
+  failures.forEach((f) => console.error(`  - ${f}`));
+  process.exit(1);
+}

--- a/src/components/FeaturedPostCard.astro
+++ b/src/components/FeaturedPostCard.astro
@@ -1,0 +1,227 @@
+---
+import { render, type CollectionEntry } from 'astro:content';
+import { getExcerpt } from '@utils/excerpt';
+import { getReadingTime } from '@utils/reading-time';
+import { getPostSlug } from '@utils/content';
+
+interface Props {
+  post: CollectionEntry<'posts'>;
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const excerpt500 = getExcerpt(post.body ?? '');
+const primaryTag = post.data.tags[0];
+const isoDate = new Date(post.data.pubDate).toISOString().slice(0, 10);
+const datetimeAttr = new Date(post.data.pubDate).toISOString();
+const readingTime = getReadingTime(post.body ?? '');
+const slug = getPostSlug(post.id);
+const href = `/posts/${slug}/`;
+---
+
+<article
+  class="gvns-featured"
+  data-post-slug={slug}
+  itemscope
+  itemtype="https://schema.org/CreativeWork"
+>
+  <header class="gvns-featured__header">
+    <span class="gvns-featured__tag">{primaryTag}</span>
+    <time datetime={datetimeAttr} class="gvns-featured__date">{isoDate}</time>
+  </header>
+
+  <h2 class="gvns-featured__title" itemprop="headline">
+    <a href={href} itemprop="url">{post.data.title}</a>
+  </h2>
+
+  <p class="gvns-featured__excerpt">{excerpt500}</p>
+
+  <details class="gvns-featured__body">
+    <summary class="gvns-featured__expand">
+      <span class="gvns-featured__reading-time">{readingTime} min read</span>
+      <span class="gvns-featured__cue">
+        <span data-when="closed">keep reading ↓</span>
+        <span data-when="open">collapse ↑</span>
+      </span>
+    </summary>
+    <div class="gvns-featured__expanded prose">
+      <Content />
+      <p class="gvns-featured__permalink">
+        <a href={href}>Read full post →</a>
+      </p>
+    </div>
+  </details>
+</article>
+
+<style>
+  .gvns-featured {
+    background: var(--colour-bg-secondary);
+    border-top: 2px solid var(--colour-p2-rose);
+    border-radius: 0;
+    padding: 1.25rem 1.5rem;
+  }
+
+  .gvns-featured__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 0.875rem;
+  }
+
+  .gvns-featured__tag {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--colour-text-secondary);
+  }
+
+  .gvns-featured__date {
+    font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--colour-text-muted);
+    letter-spacing: 0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .gvns-featured__title {
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-weight: 500;
+    font-size: 22px;
+    line-height: 1.22;
+    letter-spacing: -0.012em;
+    margin: 0 0 0.875rem;
+  }
+
+  .gvns-featured__title a {
+    color: var(--colour-text-primary);
+    text-decoration: none;
+    transition: color 120ms ease;
+  }
+
+  .gvns-featured__title a:hover,
+  .gvns-featured__title a:focus-visible {
+    color: var(--colour-p2-rose-hover);
+  }
+
+  /* Type-leads-the-talk hover: hovering title link OR summary tints title. */
+  .gvns-featured:has(:is(a:hover, summary:hover)) .gvns-featured__title a {
+    color: var(--colour-p2-rose-hover);
+  }
+
+  .gvns-featured__excerpt {
+    font-family: 'Inter', system-ui, sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 1.65;
+    color: var(--colour-text-secondary);
+    max-width: 60ch;
+    margin: 0 0 1rem;
+  }
+
+  /* Hide the standalone excerpt when the details element is open so the
+     full body owns the card. */
+  .gvns-featured:has(details[open]) .gvns-featured__excerpt {
+    display: none;
+  }
+
+  .gvns-featured__body {
+    margin: 0;
+  }
+
+  /* Strip default disclosure marker across browsers. */
+  .gvns-featured__expand {
+    list-style: none;
+  }
+  .gvns-featured__expand::-webkit-details-marker {
+    display: none;
+  }
+  .gvns-featured__expand::marker {
+    display: none;
+    content: '';
+  }
+
+  .gvns-featured__expand {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+    /* WCAG 2.5.8: target ≥ 24×24 CSS px. padding-block + line-height
+       on 11/12px type comfortably exceeds 24px. */
+    padding-top: 0.875rem;
+    padding-bottom: 0.25rem;
+    min-height: 24px;
+    border-top: 1px solid var(--colour-border);
+    cursor: pointer;
+  }
+
+  .gvns-featured__expand:focus-visible {
+    outline: 2px solid var(--colour-p2-rose);
+    outline-offset: 2px;
+  }
+
+  .gvns-featured__reading-time {
+    font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--colour-text-muted);
+    letter-spacing: 0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .gvns-featured__cue {
+    font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--colour-p2-rose-hover);
+  }
+
+  /* CSS-only open/closed label swap. */
+  details[open] [data-when='closed'] {
+    display: none;
+  }
+  details:not([open]) [data-when='open'] {
+    display: none;
+  }
+
+  .gvns-featured__expanded {
+    padding-top: 1rem;
+  }
+
+  .gvns-featured__permalink {
+    margin: 0;
+    padding-top: 0.625rem;
+    border-top: 1px solid var(--colour-border);
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 14px;
+    color: var(--colour-text-muted);
+  }
+
+  .gvns-featured__permalink a {
+    color: var(--colour-p2-rose-hover);
+    text-decoration: none;
+  }
+
+  .gvns-featured__permalink a:hover,
+  .gvns-featured__permalink a:focus-visible {
+    text-decoration: underline;
+  }
+
+  /* Mobile: tighten padding, scale title down, allow eyebrow to wrap so
+     the date can drop to its own line. */
+  @media (max-width: 640px) {
+    .gvns-featured {
+      padding: 1rem 1.125rem;
+    }
+
+    .gvns-featured__title {
+      font-size: 20px;
+    }
+
+    .gvns-featured__header {
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/src/content/posts/2026/05/sandbox-featured-fixture.md
+++ b/src/content/posts/2026/05/sandbox-featured-fixture.md
@@ -1,0 +1,31 @@
+---
+title: A measured note on rectangular things
+description: Sandbox fixture used to demo the FeaturedPostCard component during PR review.
+pubDate: 2026-05-01
+tags: [code]
+draft: true
+---
+
+This is the opening paragraph of a fixture post used to exercise the `FeaturedPostCard` component. It contains enough copy to push past the 500-character excerpt threshold so we can verify boundary-aware truncation behaves the way the spec calls for. The card itself stays still — the type does the talking — and the excerpt should clamp at a paragraph boundary if one is reachable, otherwise step down to a sentence break, otherwise to a word break.
+
+Below the excerpt sits a hairline footer and the `<details>` summary acts as the toggle. Selecting text inside this paragraph by click-drag must not toggle the disclosure, because the excerpt lives outside `<details>`.
+
+## A heading inside the body
+
+When the disclosure is open, this content appears beneath the excerpt slot (which is hidden via `:has(details[open])`). The expanded body inherits `prose` typography so headings, paragraphs, lists, and code blocks all look the way they do on a normal post page.
+
+```ts
+// Code blocks should render normally inside the expanded view.
+function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+A short list of things this fixture verifies:
+
+- Eyebrow shows tag plus ISO date with no "Featured" prefix anywhere
+- Title is a real anchor — keyboard tab order: title link, then summary, then permalink when open
+- Hovering either the title link or the summary tints the title to rose-hover
+- Mono surfaces (date, reading time, cue) keep `letter-spacing: 0.02em`
+
+The permalink at the bottom links back to the canonical `/posts/<slug>/` page so crawlers see "this is a showcase, see canonical" rather than two competing `BlogPosting` objects fighting for the same primary entity.

--- a/src/content/posts/2026/05/sandbox-featured-fixture.md
+++ b/src/content/posts/2026/05/sandbox-featured-fixture.md
@@ -2,7 +2,7 @@
 title: A measured note on rectangular things
 description: Sandbox fixture used to demo the FeaturedPostCard component during PR review.
 pubDate: 2026-05-01
-tags: [code]
+tags: [meta]
 draft: true
 ---
 

--- a/src/pages/sandbox/featured.astro
+++ b/src/pages/sandbox/featured.astro
@@ -1,0 +1,51 @@
+---
+export const prerender = true;
+
+import { getCollection } from 'astro:content';
+import PageLayout from '@layouts/PageLayout.astro';
+import FeaturedPostCard from '@components/FeaturedPostCard.astro';
+
+// Pick the sandbox fixture if present, otherwise fall back to the most
+// recent non-draft post in the collection.
+const allPosts = await getCollection('posts');
+const fixture = allPosts.find((p) =>
+  p.id.includes('sandbox-featured-fixture')
+);
+const fallback = allPosts
+  .filter((p) => !p.data.draft)
+  .sort(
+    (a, b) =>
+      new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf()
+  )[0];
+
+const post = fixture ?? fallback;
+---
+
+<PageLayout
+  title="Featured post card sandbox"
+  description="PR 6 review surface — FeaturedPostCard component"
+  accent="p2-rose"
+>
+  {
+    post ? (
+      <>
+        <p>
+          Manual checks: click-drag select text inside the excerpt and
+          release — the disclosure must remain closed. Tab through the card
+          and confirm the order: title link → summary toggle → permalink
+          (when open). Toggle the disclosure to verify the standalone
+          excerpt hides via <code>:has(details[open])</code>.
+        </p>
+        <hr />
+        <div class="not-prose">
+          <FeaturedPostCard post={post} />
+        </div>
+      </>
+    ) : (
+      <p>
+        No posts available in the collection. Add a fixture under{' '}
+        <code>src/content/posts/</code> to demo the component.
+      </p>
+    )
+  }
+</PageLayout>

--- a/src/pages/sandbox/featured.astro
+++ b/src/pages/sandbox/featured.astro
@@ -26,6 +26,9 @@ const post = fixture ?? fallback;
   description="PR 6 review surface — FeaturedPostCard component"
   accent="p2-rose"
 >
+  <Fragment slot="head">
+    <meta name="robots" content="noindex, nofollow" />
+  </Fragment>
   {
     post ? (
       <>

--- a/src/utils/excerpt.ts
+++ b/src/utils/excerpt.ts
@@ -1,0 +1,106 @@
+/**
+ * Boundary-aware excerpt extraction from markdown.
+ *
+ * Strips frontmatter and Markdown syntax to plain text, then truncates to
+ * `maxChars` preferring (in order): paragraph break, sentence boundary,
+ * word boundary. Never returns mid-word truncation.
+ *
+ * Returned string length is always <= maxChars (excluding trailing ellipsis).
+ */
+export function getExcerpt(markdown: string, maxChars = 500): string {
+  const plain = stripMarkdown(markdown);
+
+  if (plain.length <= maxChars) return plain;
+
+  // 1. Paragraph boundary — last double-newline before maxChars.
+  const slice = plain.slice(0, maxChars);
+  const paraIdx = slice.lastIndexOf('\n\n');
+  if (paraIdx >= Math.floor(maxChars * 0.5)) {
+    return slice.slice(0, paraIdx).trimEnd();
+  }
+
+  // 2. Sentence boundary — last `.!?` followed by whitespace before maxChars.
+  const sentenceMatch = slice.match(/[\s\S]*[.!?](?=\s)/);
+  if (sentenceMatch && sentenceMatch[0].length >= Math.floor(maxChars * 0.5)) {
+    return sentenceMatch[0].trimEnd();
+  }
+
+  // 3. Word boundary fallback — truncate at last whitespace before maxChars
+  //    so we never cut a word mid-stream. Append ellipsis.
+  const wordIdx = slice.lastIndexOf(' ');
+  if (wordIdx > 0) {
+    return slice.slice(0, wordIdx).trimEnd() + '…';
+  }
+
+  // Pathological: maxChars worth of unbroken text. Return as-is rather than
+  // cutting mid-word.
+  return plain.slice(0, maxChars);
+}
+
+/**
+ * Strip frontmatter and Markdown syntax to plain text.
+ * Handles: YAML frontmatter, fenced code blocks, inline code, images,
+ * links, headings, blockquotes, list markers, bold/italic/strikethrough,
+ * horizontal rules, HTML tags.
+ */
+function stripMarkdown(input: string): string {
+  let s = input;
+
+  // 1. Strip YAML frontmatter at the top of the file.
+  s = s.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+
+  // 2. Drop fenced code blocks (``` or ~~~).
+  s = s.replace(/^[ \t]*```[\s\S]*?```\s*/gm, '');
+  s = s.replace(/^[ \t]*~~~[\s\S]*?~~~\s*/gm, '');
+
+  // 3. Drop HTML tags iteratively (handles nested/crafted tags).
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/<[^>]*>/g, '');
+  } while (s !== prev);
+
+  // 4. Images → drop entirely (alt text often noisy).
+  s = s.replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+
+  // 5. Links → keep label only.
+  s = s.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+
+  // 6. Reference-style links: drop the label part.
+  s = s.replace(/^\[[^\]]+\]:\s*\S+.*$/gm, '');
+
+  // 7. Inline code → keep contents without the backticks.
+  s = s.replace(/`([^`]+)`/g, '$1');
+
+  // 8. Headings: strip leading `#` markers.
+  s = s.replace(/^#{1,6}\s+/gm, '');
+
+  // 9. Blockquote markers.
+  s = s.replace(/^>\s?/gm, '');
+
+  // 10. List markers (unordered + ordered).
+  s = s.replace(/^[ \t]*[-+*]\s+/gm, '');
+  s = s.replace(/^[ \t]*\d+\.\s+/gm, '');
+
+  // 11. Horizontal rules (---, ***, ___).
+  s = s.replace(/^\s*([-*_])\1{2,}\s*$/gm, '');
+
+  // 12. Emphasis: bold (**...** / __...__), italics (*...* / _..._),
+  //     strikethrough (~~...~~). Keep inner text.
+  s = s.replace(/(\*\*|__)(.+?)\1/g, '$2');
+  s = s.replace(/(\*|_)(.+?)\1/g, '$2');
+  s = s.replace(/~~(.+?)~~/g, '$1');
+
+  // 13. Collapse 3+ consecutive newlines to 2 (paragraph break).
+  s = s.replace(/\n{3,}/g, '\n\n');
+
+  // 14. Trim leading/trailing whitespace per line; strip leading/trailing
+  //     whitespace overall.
+  s = s
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+$/g, ''))
+    .join('\n')
+    .trim();
+
+  return s;
+}


### PR DESCRIPTION
## **User description**
Closes #346

## Summary

Adds `src/utils/excerpt.ts` (`getExcerpt(markdown, maxChars = 500)`) and `src/components/FeaturedPostCard.astro` per spec §2.3. The card is a brutalist top-stripe treatment: filled `bg-secondary`, 2px rose top border, zero radius, hairline footer divider with mono ISO date, mono reading time, and a `keep reading ↓` cue. Title is a real anchor — the ~500-char excerpt sits outside `<details>` so click-drag selection does not toggle the disclosure.

CSS-only mechanics throughout: default marker stripped across browsers, open/closed label swap via `[data-when]` siblings, standalone excerpt hidden via `:has(details[open])`, hover affordance scoped to `:is(a:hover, summary:hover)`. Snap-open is intentional v1 — animated `::details-content` deferred per spec §6.

Schema wraps as `CreativeWork`, NOT `BlogPosting`, so the canonical `BlogPosting` stays on `/posts/<slug>/`.

Component is NOT wired into `/` — that's PR 8.

## Files

- `src/utils/excerpt.ts` — boundary-aware excerpt: paragraph → sentence → word, never mid-word. Strips frontmatter, fenced code, HTML, images, links (label-only), inline code, headings, blockquotes, list markers, emphasis.
- `src/components/FeaturedPostCard.astro` — markup contract per §2.3 verbatim.
- `src/pages/sandbox/featured.astro` — review surface at `/sandbox/featured/`.
- `src/content/posts/2026/05/sandbox-featured-fixture.md` — draft-flagged fixture so the sandbox always has content to render.
- `scripts/test-excerpt.mjs` — dependency-free scratch test runner (no test framework in repo).

## Verification

**Excerpt tests** — `npx tsx scripts/test-excerpt.mjs`:
```
32 passed, 0 failed
```
Coverage: short-input passthrough, frontmatter stripping, heading/code-block/link handling, paragraph/sentence/word boundary fallbacks, mid-word guard, custom maxChars, empty input, full-post end-to-end.

**Build** — `npm run build`:
```
[build] Server built in ~12s
[build] Complete!
```
Clean. The new `/sandbox/featured/` route prerenders alongside the existing `/sandbox/starwind/` route.

**Rendered output spot-check** (from `dist/client/sandbox/featured/index.html`):
- `<article ... itemscope itemtype="https://schema.org/CreativeWork">` ✓
- All `gvns-featured__*` classes present ✓
- `border-top: 2px solid var(--colour-p2-rose); border-radius: 0` ✓
- Excerpt clamps at paragraph boundary on the fixture (verified in HTML output) ✓
- ISO date format `YYYY-MM-DD` rendered via `.toISOString().slice(0, 10)` (no `formatDate` shape drift) ✓

**Manual checks** (pending live review at `/sandbox/featured/`):
- [ ] Click-drag select inside excerpt — disclosure stays closed
- [ ] Tab order: title link → summary toggle → permalink (when open)
- [ ] Toggle disclosure — standalone excerpt hides via `:has(details[open])`
- [ ] Hover title link OR summary — title tints to `--colour-p2-rose-hover`
- [ ] Default disclosure marker invisible on Chrome / Firefox / Safari
- [ ] axe-core run on `/sandbox/featured/`
- [ ] **Screenshots** at mobile + desktop, collapsed + expanded — pending (this run is headless)

## Acceptance criteria

All 17 boxes from #346 covered in code; the four that need eyes-on a running browser (manual selection-drag, screenshots, axe-core, marker invisible cross-browser) are listed above.

## §2.4 radius decision

**Recommendation: Option B — zero radius for `MiniPostCard` (PR 7, #347).**

Reasoning:
- The Featured card is now zero-radius with a 2px rose top stripe. It establishes a deliberate rectangular language at the top of the home page.
- The widget strip cells already use `border-radius: 0 0 4px 4px` (square top, faintly rounded bottom) — they read as rectangular from the eyebrow side.
- A zero-radius `MiniPostCard` keeps the recents row coherent with both elements above and below it; the home page reads as one rectangular grammar.
- Going Option A (`6px`) would leave the recents row as the only rounded surface in the masthead → featured → recents → widgets stack. That reads as drift, not hierarchy. Hierarchy on the home page is already carried by: type sizes, the rose top stripe, and the eyebrow tag — radius does not need to do that work too.
- If hierarchy ever feels too flat after wiring up, we can dial it back via type weight or excerpt density rather than reintroducing rounded corners.

PR 7 should adopt zero-radius for `MiniPostCard`.

## Notes for review

- v1 ships snap-open `<details>` (no animation). `interpolate-size: allow-keywords` + `::details-content` is deferred per spec §6 — browser support uneven as of 2026-05.
- The summary footer row exceeds 24×24 CSS px (WCAG 2.5.8): `min-height: 24px` plus `padding-top: 0.875rem; padding-bottom: 0.25rem` against 11/12px type comfortably clears.
- Tints used: `--colour-p2-rose` for the top stripe and focus outline; `--colour-p2-rose-hover` for the cue and hover affordance. No new tokens introduced — existing `--colour-bg-secondary`, `--colour-text-primary/secondary/muted`, `--colour-border` cover the rest.
- Fixture is `draft: true` so it does not appear in production routes via the prod-time draft filter on `/posts/[slug]`. It is still picked up by the sandbox loader (which calls `getCollection` without filtering).


___

## **CodeAnt-AI Description**
**Add a featured post card with selectable preview text and an expandable full post view**

### What Changed
- Adds a featured post card that shows the post tag, date, title, excerpt, reading time, and a “keep reading” toggle
- Keeps the excerpt outside the expandable section so selecting text does not open or close the post
- Hides the preview excerpt when the full post is expanded and adds a canonical full-post link at the bottom
- Adds a sandbox page and fixture post for reviewing the card in isolation
- Adds excerpt tests that cover markdown cleanup and safe truncation at paragraph, sentence, or word boundaries

### Impact
`✅ Clearer featured post previews`
`✅ Fewer accidental toggles while selecting text`
`✅ Safer excerpt text from markdown posts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=dsP5sFuitAKbMyRsuo10iqmOgoe6aH-n7TRshwmH020&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Featured post card component for enhanced blog presentation.
  * Intelligent excerpt generator with paragraph/sentence/word-boundary awareness and Markdown stripping.
  * Sandbox page demonstrating the featured card and prerendered preview.

* **Tests**
  * CLI test runner covering excerpt-generation edge cases.
  * Draft fixture post added for component and excerpt validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->