### PR TITLE
chore: drop stretched-anchor pattern across post cards (#347)

### DIFF
--- a/src/components/HorizontalPostCard.astro
+++ b/src/components/HorizontalPostCard.astro
@@ -23,12 +23,11 @@ const { post, headingLevel = 'h3' } = Astro.props;
 const { title, description, pubDate, tags, heroImage, heroImageAlt } = post.data;
 const readingTime = getReadingTime(post.body ?? '');
 const slug = getPostSlug(post.id);
-const href = `/posts/${slug}`;
+const href = `/posts/${slug}/`;
 const HeadingTag = headingLevel;
 ---
 
 <article class="group relative isolate block">
-  <a class="absolute inset-0 z-1 rounded-xl" href={href} aria-label={title}></a>
   <Card class="overflow-hidden py-0 transition-colors group-hover:ring-primary">
     <div class="flex flex-col md:flex-row">
       {heroImage && (
@@ -67,8 +66,8 @@ const HeadingTag = headingLevel;
             </time>
           </div>
           <div>
-            <HeadingTag class="font-heading text-xl md:text-2xl leading-snug font-medium mb-1 group-hover:text-primary transition-colors">
-              {title}
+            <HeadingTag class="font-heading text-xl md:text-2xl leading-snug font-medium mb-1">
+              <a href={href} class="gvns-hpc-title-link">{title}</a>
             </HeadingTag>
             <p class="text-muted-foreground line-clamp-2">{description}</p>
           </div>
@@ -91,5 +90,13 @@ const HeadingTag = headingLevel;
   .gvns-horizontal-card-image {
     aspect-ratio: auto !important;
     height: 100% !important;
+  }
+  .gvns-hpc-title-link {
+    color: var(--colour-text-primary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+  article:has(a:hover) .gvns-hpc-title-link {
+    color: #ffffff;
   }
 </style>

--- a/src/components/MiniPostCard.astro
+++ b/src/components/MiniPostCard.astro
@@ -1,0 +1,69 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { Badge } from '@/components/starwind/badge';
+import { getPostSlug } from '@utils/content';
+
+interface Props {
+  post: CollectionEntry<'posts'>;
+}
+
+const { post } = Astro.props;
+const { title, pubDate, tags } = post.data;
+const slug = getPostSlug(post.id);
+const href = `/posts/${slug}/`;
+const isoDate = pubDate.toISOString().slice(0, 10);
+---
+
+<article class="gvns-mini-card">
+  {tags.length > 0 && (
+    <a href={`/posts/tags/${encodeURIComponent(tags[0])}`} class="gvns-mini-card__tag-link">
+      <Badge variant="ghost">{tags[0]}</Badge>
+    </a>
+  )}
+  <h3 class="gvns-mini-card__title">
+    <a href={href}>{title}</a>
+  </h3>
+  <time class="gvns-mini-card__date" datetime={pubDate.toISOString()}>
+    {isoDate}
+  </time>
+</article>
+
+<style>
+  .gvns-mini-card {
+    background: var(--colour-bg-secondary);
+    border: 1px solid var(--colour-border);
+    border-radius: 0;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    transition: border-color var(--transition-fast);
+  }
+  .gvns-mini-card:has(a:hover) {
+    border-color: var(--colour-border-hover);
+  }
+  .gvns-mini-card__tag-link {
+    text-decoration: none;
+  }
+  .gvns-mini-card__title {
+    font-family: var(--font-sans);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.4;
+    margin: 0;
+  }
+  .gvns-mini-card__title a {
+    color: var(--colour-text-primary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+  .gvns-mini-card:has(a:hover) .gvns-mini-card__title a {
+    color: #ffffff;
+  }
+  .gvns-mini-card__date {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--colour-text-muted);
+    letter-spacing: 0.02em;
+  }
+</style>

--- a/src/components/RecentPostsRow.astro
+++ b/src/components/RecentPostsRow.astro
@@ -1,0 +1,27 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import MiniPostCard from '@components/MiniPostCard.astro';
+
+interface Props {
+  posts: CollectionEntry<'posts'>[];
+}
+
+const { posts } = Astro.props;
+---
+
+<div class="gvns-recent-posts-row">
+  {posts.map((post) => <MiniPostCard post={post} />)}
+</div>
+
+<style>
+  .gvns-recent-posts-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+  }
+  @media (max-width: 640px) {
+    .gvns-recent-posts-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,7 @@
     --colour-bg-secondary: #18181b; /* zinc-900 */
     --colour-bg-tertiary: #27272a; /* zinc-800 */
     --colour-border: #3f3f46; /* zinc-700 */
+    --colour-border-hover: #71717a; /* zinc-500 */
 
     /* Text Hierarchy */
     --colour-text-primary: #f4f4f5; /* zinc-100 */
@@ -123,6 +124,7 @@
     --colour-bg-secondary: #ffffff;
     --colour-bg-tertiary: #f4f4f5; /* zinc-100 */
     --colour-border: #e4e4e7; /* zinc-200 */
+    --colour-border-hover: #a1a1aa; /* zinc-400 */
 
     --colour-text-primary: #18181b; /* zinc-900 */
     --colour-text-secondary: #52525b; /* zinc-600 */


### PR DESCRIPTION
## **User description**
## Summary

- Adds \`--colour-border-hover\` token to \`global.css\` (zinc-500 dark / zinc-400 light)
- New \`MiniPostCard.astro\`: zero-radius card with ghost Badge tag, Inter 500 14px title link, JetBrains Mono 10px ISO date, \`:has(a:hover)\` hover (border lifts + title brightens)
- New \`RecentPostsRow.astro\`: 3-up CSS grid wrapper, collapses to 1 column ≤640px
- \`HorizontalPostCard.astro\`: absolute stretched anchor removed; title wrapped in real \`<a>\`; hover migrated to \`article:has(a:hover)\` for border + title colour

Radius decision: Option B (zero radius) per §2.4 recorded in PR 6 (#355).

## Test Plan
- [ ] \`npm run build\` clean
- [ ] Click-drag to select text inside HorizontalPostCard — succeeds without navigating
- [ ] Hover title link in HorizontalPostCard — image zooms, arrow moves, title brightens
- [ ] Hover over a MiniPostCard title — border lifts, title brightens
- [ ] Tag Badge links still clickable in both card types

Closes #347


___

## **CodeAnt-AI Description**
**Refine post card links and add a compact recent-posts layout**

### What Changed
- Added a compact post card style for recent posts with a tag link, title link, and date, shown in a 3-column grid that stacks to one column on small screens
- Post cards now use a real title link instead of making the whole card one large clickable area, which keeps tags and text interactions separate
- Hovering a post card now lifts the border and brightens the title, with the same effect available in both dark and light themes

### Impact
`✅ Clearer post card clicks`
`✅ Easier text selection on post cards`
`✅ Cleaner recent-posts layout on mobile`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=8hlgeTdwXR-nZ51x-GTFOYiuX4g2mDkLsKD8wtngFLQ&org=ggfevans)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact post card and a responsive recent-posts row for displaying multiple posts.
* **Refactor**
  * Card link behavior adjusted so only post titles are clickable; title hover transitions consolidated into a dedicated style.
* **Style**
  * Added theme-aware border-hover colour variables for improved hover contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->