### PR TITLE
chore: wire now-intro.md into Sveltia CMS (#349)

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -134,3 +134,25 @@ collections:
           hint: "Full URL of the original post if cross-published (validated at build by Zod).",
         }
       - { name: body, label: Body, widget: markdown }
+
+  - name: now-intro
+    label: "/now intro"
+    files:
+      - name: now-intro
+        label: "/now intro content"
+        file: src/data/now-intro.md
+        fields:
+          - {
+              name: lastUpdated,
+              label: "Last updated",
+              widget: datetime,
+              format: "YYYY-MM-DD",
+              date_format: "YYYY-MM-DD",
+              time_format: false,
+              required: true,
+            }
+          - {
+              name: body,
+              label: "Body (markdown, 2 paragraphs)",
+              widget: markdown,
+            }


### PR DESCRIPTION
## **User description**
## Summary

Add a `now-intro` files collection in `public/admin/config.yml` so the `/now` prose intro can be edited through `gvns.ca/admin` instead of by hand-editing `src/data/now-intro.md`.

## Implementation notes

- Used the `datetime` widget with `time_format: false` for `lastUpdated` to match the convention used by `pubDate` in the existing posts collection. The issue body mentioned `widget: date` but that isn't a documented Sveltia widget — `datetime` with `time_format: false` is the canonical date-only field.
- Single-file `files` shape since there's exactly one document, per the issue.

## Test Plan

- [x] `npm run build` clean.
- [ ] After merge + Workers Build rebuild, open `gvns.ca/admin` and confirm the `/now intro` collection appears.
- [ ] Edit `lastUpdated` + both paragraphs from the CMS, confirm a clean commit lands on `main` with frontmatter + body intact.
- [ ] Visit `/now` after rebuild and confirm both the heading date and prose body reflect the edit.
- [ ] Edit a post via `/admin` to confirm no regression on existing collections.

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "now-intro" content collection to the CMS admin panel, enabling direct editing of timestamped markdown content from the admin interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Edit the /now intro from the admin panel**

### What Changed
- Added a `/now intro` entry in the admin panel so the intro text can be updated without editing the source file directly
- The intro now includes a date field and a markdown body field for the two-paragraph content

### Impact
`✅ Easier /now updates`
`✅ Fewer manual file edits`
`✅ Safer content changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
