### PR TITLE
feat(cms): add work collection to Sveltia CMS (#260)

### DIFF
--- a/docs/CMS-SETUP.md
+++ b/docs/CMS-SETUP.md
@@ -100,7 +100,21 @@ If the in-browser transform fails for a given file, Sveltia falls back to commit
 
 ## The `work` collection
 
-The `work` collection still uses the legacy `/uploads/...` absolute pattern (`uploadsPathSchema` in `src/content.config.ts`). Work entries are not authored via the CMS in the same flow. Migrate to the bundle pattern in a future PR if that changes.
+The `work` collection is editable from `/admin` alongside `posts` (#260). It uses the legacy `/uploads/...` absolute pattern (`uploadsPathSchema` in `src/content.config.ts`) rather than the bundle layout — work entries live as flat files in `src/content/work/<slug>.md`, and their hero images are committed under `public/uploads/`. Migration to bundle layout is a future-PR option if work entries grow inline image assets.
+
+Field shape (mirrors the Zod schema in `src/content.config.ts`):
+
+- `title` (string, max 100)
+- `description` (text, max 200)
+- `url` / `repo` (string, optional, http(s) URL)
+- `status` (select: `active` / `maintained` / `archived`)
+- `tags` (list, 1–6 free-form strings — typically technology names)
+- `heroImage` (image, optional — writes `/uploads/<file>`)
+- `heroImageAlt` (string, max 250, optional)
+- `featured` (boolean, default false)
+- `body` (markdown)
+
+The CMS does NOT set a per-collection `media_folder` override here (unlike `posts`, which overrides to `""` for bundle layout). Uploads from the work editor fall through to the top-level `media_folder: public/uploads` / `public_folder: /uploads` config, producing absolute `/uploads/...` refs in frontmatter — which is what `uploadsPathSchema` validates.
 
 ## Render-time hero optimisation
 

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -156,3 +156,78 @@ collections:
               label: "Body (markdown, 2 paragraphs)",
               widget: markdown,
             }
+
+  - name: work
+    label: Work
+    label_singular: Project
+    folder: src/content/work
+    create: true
+    slug: "{{slug}}"
+    extension: md
+    format: frontmatter
+    editor:
+      preview: false
+    fields:
+      - {
+          name: title,
+          label: Title,
+          widget: string,
+          required: true,
+          pattern: ["^.{1,100}$", "Max 100 characters"],
+        }
+      - {
+          name: description,
+          label: Description,
+          widget: text,
+          required: true,
+          pattern: ['^[\s\S]{1,200}$', "Max 200 characters"],
+        }
+      - {
+          name: url,
+          label: URL,
+          widget: string,
+          required: false,
+          pattern: ['^https?://.+', "Must be a full URL (http(s)://...)."],
+          hint: "Live URL of the project (optional).",
+        }
+      - {
+          name: repo,
+          label: Repository URL,
+          widget: string,
+          required: false,
+          pattern: ['^https?://.+', "Must be a full URL (http(s)://...)."],
+          hint: "Source code repository URL (optional).",
+        }
+      - name: status
+        label: Status
+        widget: select
+        required: true
+        default: active
+        options:
+          - active
+          - maintained
+          - archived
+      - name: tags
+        label: Tags
+        widget: list
+        min: 1
+        max: 6
+        hint: "Technologies or labels (e.g. Astro, Svelte, Tailwind)."
+      - {
+          name: heroImage,
+          label: Hero image,
+          widget: image,
+          required: false,
+          choose_url: false,
+          hint: "Uploads land in /uploads/. Schema requires absolute /uploads/... path.",
+        }
+      - {
+          name: heroImageAlt,
+          label: Hero image alt text,
+          widget: string,
+          required: false,
+          pattern: ['^.{0,250}$', "Keep alt text under 250 characters."],
+          hint: "Describe the image for screen readers + social previews (max 250 chars). Leave blank if purely decorative.",
+        }
+      - { name: featured, label: Featured, widget: boolean, default: false }
+      - { name: body, label: Body, widget: markdown }


### PR DESCRIPTION
## **User description**
## Summary

Add a `work` folder collection in `public/admin/config.yml` so work entries can be authored and edited from `gvns.ca/admin`, mirroring the Zod schema in `src/content.config.ts`.

## Implementation notes

- **No per-collection `media_folder` override** — uploads fall through to the top-level `public/uploads` / `/uploads` config, so hero image refs end up as the absolute `/uploads/<file>` path that `uploadsPathSchema` validates. Posts override to `""` for bundle layout; work doesn't (work entries are flat files, not folders).
- **Tags** use the `list` widget rather than `select` because work tags are free-form technology names (e.g. \"Astro\", \"Svelte\", \"Tailwind\") — different taxonomy from posts.
- **URL fields** include a permissive `^https?://.+` pattern as a frontend check; final URL validation lives in the Zod schema at build time.
- **CMS-SETUP.md** updated: replaced the \"work isn't authored via the CMS\" note with the field map and the rationale for skipping the media-folder override.

## Test Plan

- [x] `npm run build` clean.
- [ ] After Workers Build rebuild, open `gvns.ca/admin` and confirm both **Posts** and **Work** collections appear in the sidebar.
- [ ] Create a new work entry — confirm:
  - File lands at `src/content/work/<slug>.md` with valid frontmatter.
  - `npm run build` passes (Zod accepts the new entry).
  - All three `status` enum values (`active` / `maintained` / `archived`) are selectable.
  - Tag widget enforces 1–6 entries.
- [ ] Edit the existing `gvns-ca.md` entry through the CMS — confirm a single-file commit with only the edited fields.
- [ ] Upload a hero image — confirm it lands in `public/uploads/` and frontmatter writes `heroImage: /uploads/<slugified>.webp` (passing `UPLOADS_PATH_REGEX`).

Closes #260


___

## **CodeAnt-AI Description**
**Add CMS editing for work entries**

### What Changed
- Work projects can now be created and edited from `/admin` alongside posts
- The work editor now includes the full project fields: title, description, live URL, repository URL, status, tags, hero image, image alt text, featured, and body
- Hero image uploads for work keep using `/uploads/...` paths, so saved entries match the existing site format
- The CMS setup docs now describe the work collection fields and how uploads are handled

### Impact
`✅ Work entries can be managed from the CMS`
`✅ Fewer manual content edits for project pages`
`✅ Clearer image upload paths for work pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CMS setup guide with detailed field descriptions for the new work content type and clarified how uploaded images are referenced and stored.

* **Chores**
  * Added a work collection to the CMS with configurable fields: title, description, URL/repo, status, tags, optional hero image/alt, featured flag, and body preview.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->