### PR TITLE
feat(home): add gaming/Steam activity widget (#335)

### DIFF
--- a/src/components/widgets/GameWidget.astro
+++ b/src/components/widgets/GameWidget.astro
@@ -41,7 +41,8 @@ const profileUrl = safeUrl(data.profile?.profileUrl) ?? 'https://store.steampowe
 const lastPlayedDate = latestGame?.lastPlayed && !Number.isNaN(new Date(latestGame.lastPlayed).getTime())
   ? latestGame.lastPlayed
   : null;
-const totalHours = latestGame ? Math.round(latestGame.playtimeForeverMinutes / 60) : 0;
+const rawMinutes = Number.isFinite(latestGame?.playtimeForeverMinutes) ? latestGame!.playtimeForeverMinutes : 0;
+const totalHours = Math.round(rawMinutes / 60);
 ---
 
 {compact ? (

--- a/src/components/widgets/GameWidget.astro
+++ b/src/components/widgets/GameWidget.astro
@@ -1,0 +1,113 @@
+---
+import { relativeTime, safeUrl } from '@utils/format';
+
+interface Props { compact?: boolean; }
+const { compact = false } = Astro.props;
+
+interface GameEntry {
+  name: string;
+  appId: number;
+  headerUrl?: string;
+  capsuleUrl?: string;
+  portraitUrl?: string;
+  playtimeForeverMinutes: number;
+  playtime2WeeksMinutes?: number;
+  lastPlayed?: string;
+}
+
+interface GamingData {
+  lastUpdated: string | null;
+  recentlyPlayed: GameEntry[];
+  profile?: { profileUrl?: string };
+  stats?: { totalPlaytimeHours?: number };
+}
+
+let data: GamingData = { lastUpdated: null, recentlyPlayed: [] };
+try {
+  const imported = (await import('../../data/gaming.json')).default as Partial<GamingData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    recentlyPlayed: Array.isArray(imported.recentlyPlayed) ? imported.recentlyPlayed : [],
+    profile: imported.profile,
+    stats: imported.stats,
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load gaming data for GameWidget:', e);
+}
+
+const latestGame = data.recentlyPlayed[0] ?? null;
+const coverSrc = safeUrl(latestGame?.portraitUrl);
+const profileUrl = safeUrl(data.profile?.profileUrl) ?? 'https://store.steampowered.com/';
+const lastPlayedDate = latestGame?.lastPlayed && !Number.isNaN(new Date(latestGame.lastPlayed).getTime())
+  ? latestGame.lastPlayed
+  : null;
+const totalHours = latestGame ? Math.round(latestGame.playtimeForeverMinutes / 60) : 0;
+---
+
+{compact ? (
+  <article class="gvns-widget-compact gvns-widget-compact--game">
+    <div class="gvns-widget-compact__label">Now Playing</div>
+    {latestGame ? (
+      <a href={profileUrl} class="gvns-widget-compact__body" target="_blank" rel="noopener noreferrer">
+        {coverSrc && (
+          <img src={coverSrc} alt={`Cover art for ${latestGame.name}`} class="gvns-widget-compact__cover" width="40" height="60" loading="lazy" decoding="async" />
+        )}
+        <div class="gvns-widget-compact__info">
+          <p class="gvns-widget-compact__title">{latestGame.name}</p>
+          <p class="gvns-widget-compact__subtitle">{totalHours}h played</p>
+        </div>
+      </a>
+    ) : (
+      <p class="gvns-widget-compact__empty">Nothing recent.</p>
+    )}
+  </article>
+) : (
+  <article class="gvns-widget gvns-widget--game">
+    <div class="gvns-widget__label">Game</div>
+    {latestGame ? (
+      <div class="gvns-widget__content gvns-widget__content--row">
+        {coverSrc && (
+          <img
+            src={coverSrc}
+            alt={`Cover art for ${latestGame.name}`}
+            class="gvns-widget__poster"
+            width="48"
+            height="72"
+            loading="lazy"
+            decoding="async"
+          />
+        )}
+        <div>
+          <p class="gvns-widget__detail gvns-widget__detail--bold">{latestGame.name}</p>
+          <p class="gvns-widget__meta">{totalHours}h played</p>
+          {lastPlayedDate && (
+            <time class="gvns-widget__time" datetime={lastPlayedDate}>
+              {relativeTime(lastPlayedDate)}
+            </time>
+          )}
+        </div>
+      </div>
+    ) : (
+      <p class="gvns-widget__empty">Nothing played recently.</p>
+    )}
+    <a href={profileUrl} class="gvns-widget__link" target="_blank" rel="noopener noreferrer">
+      Steam Profile <span aria-hidden="true">&rarr;</span>
+    </a>
+  </article>
+)}
+
+<style>
+  /* P5 Sky — chosen to not conflict with P1 Violet (code), P2 Rose (read),
+     P3 Emerald (listen), or P4 Amber (watch) */
+  .gvns-widget--game {
+    border-left-color: var(--colour-p5-sky);
+  }
+
+  .gvns-widget--game .gvns-widget__link:hover {
+    color: var(--colour-p5-sky);
+  }
+
+  .gvns-widget-compact--game {
+    border-top: var(--border-accent) solid var(--colour-p5-sky);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import ReadWidget from '@components/widgets/ReadWidget.astro';
 import ListenWidget from '@components/widgets/ListenWidget.astro';
 import WatchWidget from '@components/widgets/WatchWidget.astro';
 import CodeWidget from '@components/widgets/CodeWidget.astro';
+import GameWidget from '@components/widgets/GameWidget.astro';
 import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 import { SITE_BIO } from '@utils/site';
 import '@styles/widgets.css';
@@ -55,6 +56,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         <ListenWidget compact />
         <WatchWidget compact />
         <CodeWidget compact />
+        <GameWidget compact />
       </div>
     </section>
   </main>
@@ -99,8 +101,13 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   }
   .gvns-activity-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: var(--space-4);
+  }
+  @media (max-width: 1279px) {
+    .gvns-activity-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
   }
   @media (max-width: 1023px) {
     .gvns-activity-grid {


### PR DESCRIPTION
## **User description**
## Summary

- New `src/components/widgets/GameWidget.astro` reading `src/data/gaming.json` (`recentlyPlayed[0]`)
- Shows most recently played title, total hours played, and portrait cover art (Steam `library_600x900.jpg`) — links out to Steam profile
- Graceful empty state when `recentlyPlayed` is missing or empty
- **Accent colour: P5 Sky** (`--colour-p5-sky`) — the only palette slot not yet claimed by another activity widget (P1=code, P2=read, P3=listen, P4=watch)
- Homepage activity grid expanded: **5-col ≥1280px / 3-col 1024–1279px / 2-col 640–1023px / 1-col mobile**

## Implementation notes

- Data import uses the same defensive try/catch pattern as `WatchWidget`, `ReadWidget`, etc.
- `safeUrl` guards both the portrait cover and the Steam profile link
- `relativeTime` formats `lastPlayed` consistently with other widgets
- Full-variant (`compact=false`) follows WatchWidget layout with poster + meta — usable on `/now` bento when wired up there

## Test plan

- [ ] CI build green
- [ ] Homepage shows 5 widgets in a row on wide viewport, 3+2 on mid-width, 2-column on tablet, stacked on mobile
- [ ] "Now Playing" card shows DEATH STRANDING 2 with correct hours and portrait art
- [ ] Clicking the widget navigates to Steam profile in a new tab
- [ ] `gaming.json` empty/absent → widget renders "Nothing recent." without crashing

Fixes #335

https://claude.ai/code/session_017Knkbk1ZLi9sMCdndov92Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017Knkbk1ZLi9sMCdndov92Z)_


___

## **CodeAnt-AI Description**
Add a gaming activity widget to the homepage and show five widgets across wide screens

### What Changed
- Added a new gaming card that shows the most recent Steam game, total hours played, and cover art
- When no recent game is available, the widget now shows a clear empty state instead of breaking
- The homepage activity area now includes the gaming widget and adjusts from 5 columns on wide screens to 3, 2, and 1 on smaller screens
- The gaming widget uses a distinct sky accent and links out to the Steam profile in a new tab

### Impact
`✅ More homepage activity at a glance`
`✅ Clearer empty state for missing game data`
`✅ Better fit on tablet and mobile screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gaming activity widget showing your most recently played game, cover art, rounded playtime, relative "last played" time, and a persistent Steam profile link; includes a compact "Now Playing" card.
* **Style**
  * Activity grid updated for improved responsiveness: default 5 columns with a new intermediate breakpoint (reduces to 3 columns at narrower widths).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->