### PR TITLE
fix: clear placeholder posts from threads.json (#548)

### DIFF
--- a/src/data/threads.json
+++ b/src/data/threads.json
@@ -1,45 +1,4 @@
 {
-  "lastUpdated": "2026-05-18T12:00:00Z",
-  "posts": [
-    {
-      "id": "1",
-      "text": "This is a test original post on Threads. It should appear in the widget with a nice truncation and relative time.",
-      "permalink": "https://www.threads.net/@ggfevans/post/1",
-      "timestamp": "2026-05-18T11:00:00Z",
-      "mediaType": "TEXT_POST",
-      "isQuotePost": false
-    },
-    {
-      "id": "2",
-      "text": "Checking out a cool new feature in Astro 6. The build times are incredible!",
-      "permalink": "https://www.threads.net/@ggfevans/post/2",
-      "timestamp": "2026-05-17T10:00:00Z",
-      "mediaType": "IMAGE",
-      "isQuotePost": false
-    },
-    {
-      "id": "3",
-      "text": "Just finished the Threads widget implementation. Logic for idempotency and atomic writes is a must.",
-      "permalink": "https://www.threads.net/@ggfevans/post/3",
-      "timestamp": "2026-05-16T09:00:00Z",
-      "mediaType": "VIDEO",
-      "isQuotePost": false
-    },
-    {
-      "id": "4",
-      "text": "This post should be hidden because it's a quote.",
-      "permalink": "https://www.threads.net/@ggfevans/post/4",
-      "timestamp": "2026-05-15T08:00:00Z",
-      "mediaType": "TEXT_POST",
-      "isQuotePost": true
-    },
-    {
-      "id": "5",
-      "text": "This post should be hidden because it's a repost.",
-      "permalink": "https://www.threads.net/@ggfevans/post/5",
-      "timestamp": "2026-05-14T07:00:00Z",
-      "mediaType": "REPOST_FACADE",
-      "isQuotePost": false
-    }
-  ]
+  "lastUpdated": null,
+  "posts": []
 }


### PR DESCRIPTION
## **User description**
## Summary

- Reset `src/data/threads.json` to `{ "lastUpdated": null, "posts": [] }`.
- The original PR (#525) shipped with 5 hardcoded test posts; 3 rendered as visible fake content on the homepage.
- Live fetcher (`scripts/fetch-threads-feed.mjs` + hourly `.github/workflows/fetch-threads-feed.yml`) will repopulate on its next run, or via manual dispatch after merge.

## Verification

- `THREADS_ACCESS_TOKEN`, `THREADS_APP_ID`, `THREADS_APP_SECRET`, `THREADS_USER_ID` secrets confirmed configured in repo.
- The fetch workflow hasn't run yet post-#525 — `gh run list --workflow=fetch-threads-feed.yml` is empty. First trigger is the next hourly cron tick, or a manual dispatch after this PR merges.
- Widget already handles empty state: `posts.length === 0` renders "Quiet on Threads." (`ThreadsWidget.astro` line ~50).

## Test plan

- [ ] Preview deploy shows "Quiet on Threads." in the widget slot.
- [ ] After merge, dispatch `gh workflow run fetch-threads-feed.yml` and confirm an `update-threads-feed/…` PR opens with real post data.
- [ ] CodeRabbit CLI ran clean.

## Notes

- Pairs with #547 (placement). They're independent and merge in any order.

Closes #548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reset threads data store and cleared post entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Remove fake Threads posts from the homepage**

### What Changed
- Cleared the Threads data file so the widget starts empty instead of showing placeholder posts
- The widget now shows its empty state until real posts are fetched again

### Impact
`✅ Fewer fake posts on the homepage`
`✅ Clearer empty-state display`
`✅ No stale Threads content after deploy`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
