### PR TITLE
fix: keep ThreadsWidget visible when posts.length <= 1

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,6 +52,11 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         </p>
       </section>
     )}
+    {posts.length <= 1 && (
+      <section class="gvns-home__threads-solo" aria-label="Recent Threads">
+        <ThreadsWidget compact />
+      </section>
+    )}
     <section class="gvns-activity-widgets" aria-label="Current activity">
       <div class="gvns-activity-grid">
         <ReadWidget compact />
@@ -93,6 +98,10 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     flex-direction: column;
     gap: var(--space-6);
     min-width: 0;
+  }
+
+  .gvns-home__threads-solo {
+    max-width: 24rem;
   }
 
   .gvns-home__posts--empty {


### PR DESCRIPTION
## **User description**
## Summary

PR #549 (which closed #547) introduced a regression: ThreadsWidget was moved out of the always-rendered `.gvns-activity-grid` into the multi-post branch's sidebar, so it disappears entirely when `posts.length` is 0 or 1.

CodeAnt flagged this as a Major finding after the merge:

> Rendering the Threads widget only inside the `posts.length > 1` branch makes it disappear entirely when there are zero or one posts, which is a behavior regression from the previous always-visible placement in the activity section.

## Fix

Add a `gvns-home__threads-solo` section that renders ThreadsWidget when `posts.length <= 1`, capped at `24rem` so the compact card doesn't stretch full-width in the empty/single-post layout. The multi-post sidebar path is unchanged.

```astro
{posts.length <= 1 && (
  <section class="gvns-home__threads-solo" aria-label="Recent Threads">
    <ThreadsWidget compact />
  </section>
)}
```

## Behaviour after fix

- **Multi-post (>1):** Threads in right sidebar, alongside posts (unchanged from #549).
- **Single post:** Featured card, then Threads as a left-aligned solo section (max 24rem).
- **Empty:** "Currently drafting in private…" message, then Threads as a left-aligned solo section.

## Test plan

- [ ] Preview deploy at 1280px / 768px / 480px in each post-count state renders Threads correctly.
- [ ] CodeRabbit CLI clean; `npm run build` passes.

Refs #547, #549.


___

## **CodeAnt-AI Description**
**Keep Threads visible when there are no or only one post**

### What Changed
- Threads now appear on the home page when there are zero or one posts, instead of disappearing in those states.
- The Threads section is shown as a compact solo card and stays narrow on the page.
- The existing multi-post layout is unchanged.

### Impact
`✅ Threads stay visible on empty home pages`
`✅ Threads stay visible when there is only one post`
`✅ Less layout stretching on the home page`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Threads widget now displays in a dedicated layout when there are minimal posts, providing improved visibility and user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->