### PR TITLE
chore: migrate listenbrainz fetcher to local composite action (#560)

### DIFF
--- a/.github/actions/fetch-listenbrainz/action.yml
+++ b/.github/actions/fetch-listenbrainz/action.yml
@@ -1,0 +1,75 @@
+name: 'Fetch ListenBrainz'
+description: 'Fetch ListenBrainz listening data and write it as JSON. No authentication needed.'
+author: 'ggfevans'
+
+branding:
+  icon: 'music'
+  color: 'purple'
+
+inputs:
+  username:
+    description: 'ListenBrainz username'
+    required: true
+  output_path:
+    description: 'Path to write the JSON file'
+    required: false
+    default: 'src/data/music.json'
+  stats_range:
+    description: 'Time range for stats (this_week, this_month, this_year, week, month, quarter, half_yearly, all_time)'
+    required: false
+    default: 'this_month'
+  top_count:
+    description: 'Number of items in top lists'
+    required: false
+    default: '5'
+  recent_count:
+    description: 'Number of recent listens'
+    required: false
+    default: '5'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/validate-inputs.sh
+      env:
+        LB_USERNAME: ${{ inputs.username }}
+        LB_OUTPUT_PATH: ${{ inputs.output_path }}
+        LB_STATS_RANGE: ${{ inputs.stats_range }}
+        LB_TOP_COUNT: ${{ inputs.top_count }}
+        LB_RECENT_COUNT: ${{ inputs.recent_count }}
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
+
+    - name: Fetch recent listens
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/fetch-listens.sh
+      env:
+        LB_USERNAME: ${{ inputs.username }}
+        LB_RECENT_COUNT: ${{ inputs.recent_count }}
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
+
+    - name: Fetch stats
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/fetch-stats.sh
+      env:
+        LB_USERNAME: ${{ inputs.username }}
+        LB_STATS_RANGE: ${{ inputs.stats_range }}
+        LB_TOP_COUNT: ${{ inputs.top_count }}
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
+
+    - name: Build JSON
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/build-json.sh
+      env:
+        LB_USERNAME: ${{ inputs.username }}
+        LB_STATS_RANGE: ${{ inputs.stats_range }}
+        LB_OUTPUT_PATH: ${{ inputs.output_path }}
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf "$LB_TMPDIR"
+      env:
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}

--- a/.github/actions/fetch-listenbrainz/scripts/build-json.sh
+++ b/.github/actions/fetch-listenbrainz/scripts/build-json.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build-json.sh
+# Assembles the final JSON output from intermediate files produced by
+# fetch-listens.sh and fetch-stats.sh. No network calls are made.
+#
+# Required env vars:
+#   LB_STATS_RANGE  - Stats time range (e.g. this_week, this_month, this_year, all_time)
+#   LB_OUTPUT_PATH  - Path to write the final JSON file
+#   LB_TMPDIR       - Temporary directory containing intermediate files
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${LB_STATS_RANGE:?must be set}"
+: "${LB_OUTPUT_PATH:?must be set}"
+: "${LB_TMPDIR:?must be set}"
+
+# shellcheck source=scripts/validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+validate_stats_range "$LB_STATS_RANGE"
+validate_output_path "$LB_OUTPUT_PATH"
+
+# ---------------------------------------------------------------------------
+# Ensure parent directory of output path exists
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "$LB_OUTPUT_PATH")"
+
+# ---------------------------------------------------------------------------
+# Assemble the final JSON object
+# ---------------------------------------------------------------------------
+echo "Building final JSON output at ${LB_OUTPUT_PATH}"
+
+jq -n \
+  --argjson listens "$(cat "$LB_TMPDIR/listens.json")" \
+  --argjson artists "$(cat "$LB_TMPDIR/artists.json")" \
+  --argjson tracks "$(cat "$LB_TMPDIR/recordings.json")" \
+  --argjson albums "$(cat "$LB_TMPDIR/releases.json")" \
+  --arg artistsStatus "$(cat "$LB_TMPDIR/artists-status.txt")" \
+  --arg tracksStatus "$(cat "$LB_TMPDIR/recordings-status.txt")" \
+  --arg albumsStatus "$(cat "$LB_TMPDIR/releases-status.txt")" \
+  --arg range "$LB_STATS_RANGE" \
+  --argjson listenCount "$(cat "$LB_TMPDIR/listen-count.json" 2>/dev/null || echo null)" \
+  --argjson rangeListenCount "$(cat "$LB_TMPDIR/range-listen-count.json" 2>/dev/null || echo null)" \
+  --argjson artistCount "$(cat "$LB_TMPDIR/artists-total.txt" 2>/dev/null || echo null)" \
+  --argjson albumCount "$(cat "$LB_TMPDIR/releases-total.txt" 2>/dev/null || echo null)" \
+  --argjson trackCount "$(cat "$LB_TMPDIR/recordings-total.txt" 2>/dev/null || echo null)" \
+  '{
+    lastUpdated: (now | todate),
+    recentListens: $listens,
+    recentListensStatus: "ok",
+    topArtists: $artists,
+    topArtistsStatus: $artistsStatus,
+    topTracks: $tracks,
+    topTracksStatus: $tracksStatus,
+    topAlbums: $albums,
+    topAlbumsStatus: $albumsStatus,
+    stats: {
+      totalListenCount: $listenCount,
+      rangeListenCount: $rangeListenCount,
+      range: $range,
+      artistCount: $artistCount,
+      albumCount: $albumCount,
+      trackCount: $trackCount
+    }
+  }' > "$LB_OUTPUT_PATH"
+
+echo "build-json.sh completed successfully"

--- a/.github/actions/fetch-listenbrainz/scripts/fetch-listens.sh
+++ b/.github/actions/fetch-listenbrainz/scripts/fetch-listens.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fetch-listens.sh
+# Fetches recent listens and total listen count from the ListenBrainz API.
+# This is the critical path — if fetching listens fails, the action fails.
+#
+# Required env vars:
+#   LB_USERNAME      - ListenBrainz username
+#   LB_RECENT_COUNT  - Number of recent listens to fetch
+#   LB_TMPDIR        - Temporary directory for intermediate files
+
+API_BASE="https://api.listenbrainz.org/1/user"
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${LB_USERNAME:?must be set}"
+: "${LB_RECENT_COUNT:?must be set}"
+: "${LB_TMPDIR:?must be set}"
+
+# shellcheck source=scripts/validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+# shellcheck source=scripts/http.sh
+source "$(dirname "$0")/http.sh"
+validate_username "$LB_USERNAME"
+validate_positive_integer "recent_count" "$LB_RECENT_COUNT"
+
+# ---------------------------------------------------------------------------
+# 1. Create temp directory if it doesn't exist
+# ---------------------------------------------------------------------------
+mkdir -p "$LB_TMPDIR"
+
+# ---------------------------------------------------------------------------
+# 2-4. Fetch recent listens, check status, transform with jq
+# ---------------------------------------------------------------------------
+echo "Fetching recent listens for user: ${LB_USERNAME} (count: ${LB_RECENT_COUNT})"
+
+HTTP_STATUS=$(fetch_url "${API_BASE}/${LB_USERNAME}/listens?count=${LB_RECENT_COUNT}" "$LB_TMPDIR/listens-response.tmp")
+
+if [ "$HTTP_STATUS" -ne 200 ]; then
+  echo "Error: ListenBrainz API returned HTTP ${HTTP_STATUS} for listens endpoint" >&2
+  echo "::warning::ListenBrainz API error response (first 500 bytes): $(head -c 500 "$LB_TMPDIR/listens-response.tmp" 2>/dev/null)"
+  rm -f "$LB_TMPDIR/listens-response.tmp"
+  exit 1
+fi
+
+if ! jq empty "$LB_TMPDIR/listens-response.tmp" 2>/dev/null; then
+  echo "Error: ListenBrainz API returned invalid JSON for listens endpoint" >&2
+  rm -f "$LB_TMPDIR/listens-response.tmp"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Extract and reshape listens, write to listens.json
+# ---------------------------------------------------------------------------
+jq '[.payload.listens[] | {
+  track: .track_metadata.track_name,
+  artist: .track_metadata.artist_name,
+  album: .track_metadata.release_name,
+  listenedAt: (.listened_at | todate),
+  caaReleaseMbid: (.track_metadata.mbid_mapping.caa_release_mbid // null),
+  caaId: (.track_metadata.mbid_mapping.caa_id // null),
+  recordingMbid: (.track_metadata.mbid_mapping.recording_mbid // null),
+  artistMbids: (.track_metadata.mbid_mapping.artist_mbids // [])
+}]' "$LB_TMPDIR/listens-response.tmp" > "$LB_TMPDIR/listens.json"
+
+rm -f "$LB_TMPDIR/listens-response.tmp"
+
+LISTEN_COUNT=$(jq length "$LB_TMPDIR/listens.json")
+echo "Wrote ${LISTEN_COUNT} listens to ${LB_TMPDIR}/listens.json"
+
+# ---------------------------------------------------------------------------
+# 6. Fetch total listen count (non-fatal)
+# ---------------------------------------------------------------------------
+echo "Fetching total listen count for user: ${LB_USERNAME}"
+
+COUNT_STATUS=$(fetch_url "${API_BASE}/${LB_USERNAME}/listen-count" "$LB_TMPDIR/count-response.tmp")
+
+if [ "$COUNT_STATUS" -eq 200 ]; then
+  jq '.payload.count' "$LB_TMPDIR/count-response.tmp" > "$LB_TMPDIR/listen-count.json"
+  TOTAL=$(cat "$LB_TMPDIR/listen-count.json")
+  echo "Total listen count: ${TOTAL}"
+else
+  echo "Warning: Could not fetch listen count (HTTP ${COUNT_STATUS}), skipping" >&2
+  echo "null" > "$LB_TMPDIR/listen-count.json"
+fi
+
+rm -f "$LB_TMPDIR/count-response.tmp"
+
+echo "fetch-listens.sh completed successfully"

--- a/.github/actions/fetch-listenbrainz/scripts/fetch-stats.sh
+++ b/.github/actions/fetch-listenbrainz/scripts/fetch-stats.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fetch-stats.sh
+# Fetches top artists, recordings, releases, and listening activity from the ListenBrainz stats API.
+# This is NOT on the critical path — individual stat failures are non-fatal.
+#
+# Required env vars:
+#   LB_USERNAME    - ListenBrainz username
+#   LB_STATS_RANGE - Stats time range (e.g. this_week, this_month, this_year, all_time)
+#   LB_TOP_COUNT   - Number of top items to fetch
+#   LB_TMPDIR      - Temporary directory for intermediate files
+
+API_BASE="https://api.listenbrainz.org/1/stats/user"
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${LB_USERNAME:?must be set}"
+: "${LB_STATS_RANGE:?must be set}"
+: "${LB_TOP_COUNT:?must be set}"
+: "${LB_TMPDIR:?must be set}"
+
+# shellcheck source=scripts/validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+# shellcheck source=scripts/http.sh
+source "$(dirname "$0")/http.sh"
+validate_username "$LB_USERNAME"
+validate_stats_range "$LB_STATS_RANGE"
+validate_positive_integer "top_count" "$LB_TOP_COUNT"
+
+# ---------------------------------------------------------------------------
+# Create temp directory if it doesn't exist
+# ---------------------------------------------------------------------------
+mkdir -p "$LB_TMPDIR"
+
+# ---------------------------------------------------------------------------
+# fetch_stat: Fetch a single stat type from the API
+#
+# Arguments:
+#   $1 - endpoint suffix (e.g. "artists")
+#   $2 - response array key (e.g. "artists")
+#   $3 - jq filter for reshaping items
+#   $4 - output filename base (e.g. "artists")
+#   $5 - total count key (e.g. "total_artist_count")
+# ---------------------------------------------------------------------------
+fetch_stat() {
+  local endpoint="$1"
+  local array_key="$2"
+  local jq_filter="$3"
+  local output_name="$4"
+  local total_key="$5"
+
+  local url="${API_BASE}/${LB_USERNAME}/${endpoint}?range=${LB_STATS_RANGE}&count=${LB_TOP_COUNT}"
+  local tmp_file="$LB_TMPDIR/${output_name}-response.tmp"
+
+  echo "Fetching ${output_name} for user: ${LB_USERNAME} (range: ${LB_STATS_RANGE}, count: ${LB_TOP_COUNT})"
+
+  local http_status
+  http_status=$(fetch_url "$url" "$tmp_file")
+
+  if [ "$http_status" -eq 200 ]; then
+    if jq empty "$tmp_file" 2>/dev/null && \
+       jq "[.payload.${array_key}[] | ${jq_filter}]" "$tmp_file" > "$LB_TMPDIR/${output_name}.json" 2>/dev/null; then
+      echo "ok" > "$LB_TMPDIR/${output_name}-status.txt"
+      jq ".payload.${total_key}" "$tmp_file" > "$LB_TMPDIR/${output_name}-total.txt" 2>/dev/null || echo "null" > "$LB_TMPDIR/${output_name}-total.txt"
+
+      # Capture the time window for this stats range (used to filter listening activity to the same range)
+      jq '.payload.from_ts // null' "$tmp_file" > "$LB_TMPDIR/stats-from-ts.json" 2>/dev/null || true
+      jq '.payload.to_ts // null' "$tmp_file" > "$LB_TMPDIR/stats-to-ts.json" 2>/dev/null || true
+
+      local count
+      count=$(jq length "$LB_TMPDIR/${output_name}.json")
+      echo "Wrote ${count} ${output_name} to ${LB_TMPDIR}/${output_name}.json"
+    else
+      echo "[]" > "$LB_TMPDIR/${output_name}.json"
+      echo "error" > "$LB_TMPDIR/${output_name}-status.txt"
+      echo "null" > "$LB_TMPDIR/${output_name}-total.txt"
+      echo "Warning: Failed to parse ${output_name} response as expected JSON" >&2
+    fi
+  elif [ "$http_status" -eq 204 ]; then
+    echo "[]" > "$LB_TMPDIR/${output_name}.json"
+    echo "no_data" > "$LB_TMPDIR/${output_name}-status.txt"
+    echo "null" > "$LB_TMPDIR/${output_name}-total.txt"
+    echo "No ${output_name} data available (HTTP 204)" >&2
+  else
+    echo "[]" > "$LB_TMPDIR/${output_name}.json"
+    echo "error" > "$LB_TMPDIR/${output_name}-status.txt"
+    echo "null" > "$LB_TMPDIR/${output_name}-total.txt"
+    echo "Warning: ListenBrainz API returned HTTP ${http_status} for ${output_name} endpoint" >&2
+  fi
+
+  rm -f "$tmp_file"
+}
+
+# ---------------------------------------------------------------------------
+# fetch_listening_activity: Fetch listening activity and compute a range listen count
+# ---------------------------------------------------------------------------
+fetch_listening_activity() {
+  local url="${API_BASE}/${LB_USERNAME}/listening-activity?range=${LB_STATS_RANGE}"
+  local tmp_file="$LB_TMPDIR/listening-activity-response.tmp"
+
+  echo "Fetching listening activity for user: ${LB_USERNAME} (range: ${LB_STATS_RANGE})"
+
+  local http_status
+  http_status=$(fetch_url "$url" "$tmp_file")
+
+  if [ "$http_status" -eq 200 ]; then
+    local from_ts
+    local to_ts
+    from_ts="$(cat "$LB_TMPDIR/stats-from-ts.json" 2>/dev/null || echo null)"
+    to_ts="$(cat "$LB_TMPDIR/stats-to-ts.json" 2>/dev/null || echo null)"
+
+    if jq empty "$tmp_file" 2>/dev/null && \
+       jq --argjson fromTs "$from_ts" --argjson toTs "$to_ts" '
+          if ($fromTs == null or $toTs == null) then
+            [.payload.listening_activity[]?.listen_count] | add // 0
+          else
+            [.payload.listening_activity[]? | select(.from_ts >= $fromTs and .to_ts < $toTs) | .listen_count] | add // 0
+          end
+        ' "$tmp_file" > "$LB_TMPDIR/range-listen-count.json" 2>/dev/null; then
+      local count
+      count=$(cat "$LB_TMPDIR/range-listen-count.json")
+      echo "Range listen count: ${count}"
+    else
+      echo "null" > "$LB_TMPDIR/range-listen-count.json"
+      echo "Warning: Failed to parse listening-activity response as expected JSON" >&2
+    fi
+  elif [ "$http_status" -eq 204 ]; then
+    echo "null" > "$LB_TMPDIR/range-listen-count.json"
+    echo "No listening activity data available (HTTP 204)" >&2
+  else
+    echo "null" > "$LB_TMPDIR/range-listen-count.json"
+    echo "Warning: ListenBrainz API returned HTTP ${http_status} for listening-activity endpoint" >&2
+  fi
+
+  rm -f "$tmp_file"
+}
+
+# ---------------------------------------------------------------------------
+# Fetch each stat type
+# ---------------------------------------------------------------------------
+fetch_stat "artists" "artists" \
+  '{name: .artist_name, listenCount: .listen_count, artistMbid: (.artist_mbid // null)}' \
+  "artists" "total_artist_count"
+
+fetch_stat "recordings" "recordings" \
+  '{track: .track_name, artist: .artist_name, listenCount: .listen_count, recordingMbid: (.recording_mbid // null), caaReleaseMbid: (.caa_release_mbid // null), caaId: (.caa_id // null)}' \
+  "recordings" "total_recording_count"
+
+fetch_stat "releases" "releases" \
+  '{album: .release_name, artist: .artist_name, listenCount: .listen_count, caaReleaseMbid: (.caa_release_mbid // null), caaId: (.caa_id // null)}' \
+  "releases" "total_release_count"
+
+fetch_listening_activity
+
+echo "fetch-stats.sh completed successfully"

--- a/.github/actions/fetch-listenbrainz/scripts/http.sh
+++ b/.github/actions/fetch-listenbrainz/scripts/http.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# http.sh
+# Shared HTTP fetch with retry and backoff.
+# Source this file, then call fetch_url.
+
+fetch_url() {
+  local url="$1" output="$2" max_attempts=2 attempt=0 status
+  while [ $attempt -lt $max_attempts ]; do
+    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+      --max-time 30 --connect-timeout 10 "$url") || status="000"
+    if [ "$status" -eq 429 ]; then
+      local wait=$((2 ** attempt))
+      echo "Rate limited (HTTP 429), retrying in ${wait}s..." >&2
+      sleep "$wait"
+      attempt=$((attempt + 1))
+    elif [ "$status" = "000" ] && [ $attempt -eq 0 ]; then
+      echo "Connection failed, retrying in 2s..." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+    else
+      echo "$status"
+      return 0
+    fi
+  done
+  echo "$status"
+}

--- a/.github/actions/fetch-listenbrainz/scripts/validate-inputs.sh
+++ b/.github/actions/fetch-listenbrainz/scripts/validate-inputs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# validate-inputs.sh
+# Shared input validation for all scripts.
+# Source this file, then call the needed validators.
+
+validate_username() {
+  if [[ ! "$1" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo "Error: Invalid username format. Must be alphanumeric, hyphens, or underscores." >&2
+    exit 1
+  fi
+}
+
+validate_positive_integer() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: ${name} must be a positive integer, got '${value}'" >&2
+    exit 1
+  fi
+}
+
+validate_stats_range() {
+  case "$1" in
+    this_week|this_month|this_year|week|month|quarter|half_yearly|all_time) ;;
+    *) echo "Error: Invalid stats_range '${1}'. Must be one of: this_week, this_month, this_year, week, month, quarter, half_yearly, all_time" >&2; exit 1 ;;
+  esac
+}
+
+resolve_path() {
+  local resolved
+  if resolved="$(realpath -m "$1" 2>/dev/null)"; then
+    echo "$resolved"
+  elif resolved="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1" 2>/dev/null)"; then
+    echo "$resolved"
+  else
+    local dir
+    dir="$(dirname "$1")"
+    if [ -d "$dir" ]; then
+      echo "$(cd "$dir" && pwd)/$(basename "$1")"
+    else
+      # Return absolute path even in fallback to ensure consistent validation
+      case "$1" in
+        /*) echo "$1" ;;
+        *)  echo "${PWD}/$1" ;;
+      esac
+    fi
+  fi
+}
+
+validate_output_path() {
+  local resolved
+  resolved="$(resolve_path "$1")"
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    if [[ "$resolved" != "${GITHUB_WORKSPACE}"/* ]]; then
+      echo "Error: output_path must be within the workspace (${GITHUB_WORKSPACE}), got '${resolved}'" >&2
+      exit 1
+    fi
+  fi
+}

--- a/.github/workflows/fetch-daily.yml
+++ b/.github/workflows/fetch-daily.yml
@@ -47,14 +47,13 @@ jobs:
       - id: listening
         name: Fetch ListenBrainz data
         continue-on-error: true
-        uses: ggfevans/listenbrainz-json-bourne@4fb09726f8311185cc651cb41b480a6c7424009d # v3.1.0
+        uses: ./.github/actions/fetch-listenbrainz
         with:
           username: ${{ secrets.LISTENBRAINZ_USERNAME }}
           output_path: src/data/listening.json
           stats_range: this_month
           top_count: "10"
           recent_count: "10"
-          skip_commit: "true"
 
       - id: reading
         name: Fetch Hardcover data


### PR DESCRIPTION
## **User description**
## Summary

Relocates `ggfevans/listenbrainz-json-bourne` into `.github/actions/fetch-listenbrainz/` as a local composite action. Part of the `*-json-bourne` consolidation (parent: #556; pilot: #557 already merged).

Pure bash relocation — no rewrites — with **one stripped script** (`commit-changes.sh`) and **two dropped inputs** (`skip_commit`, `commit_message`). Commits are handled at the workflow level by `commit-via-pr`.

## Changes

- `.github/actions/fetch-listenbrainz/scripts/` — copied `fetch-listens.sh`, `fetch-stats.sh`, `build-json.sh`, `http.sh`, `validate-inputs.sh` from the source repo (executable bit preserved). `commit-changes.sh` intentionally NOT copied.
- `.github/actions/fetch-listenbrainz/action.yml` — composite action with `inputs`: `username` (required), `output_path` (default `src/data/music.json`), `stats_range` (default `this_month`), `top_count` (default `5`), `recent_count` (default `5`). Steps:
  1. `validate-inputs.sh`
  2. `fetch-listens.sh`
  3. `fetch-stats.sh`
  4. `build-json.sh`
  5. Cleanup (`if: always()`, removes `$LB_TMPDIR`)
  
  No commit step. `LB_TMPDIR` = `${{ runner.temp }}/listenbrainz-${{ github.run_id }}`.
- `.github/workflows/fetch-daily.yml` — `uses: ./.github/actions/fetch-listenbrainz`; `skip_commit: "true"` line removed. Other inputs unchanged.

## Outputs note

The source `action.yml` declared two outputs (`changes_detected`, `file_path`), both wired from the now-removed commit step. They've been dropped — the values literally cannot exist without that step, and no caller consumes them. `commit-via-pr` handles change detection at the workflow level.

## Security pass

Ran the `secure-coding` skill against bash surfaces. **No new exposures** — pure relocation:
- **Command injection:** `validate-inputs.sh` enforces `^[a-zA-Z0-9_-]+$` for username, `^[1-9][0-9]*$` for integer inputs, allowlist for `stats_range`. URLs are built only from validated values; `curl` and `jq` calls quote variables and use static filters (`--arg`/`--argjson` for data).
- **Path traversal:** `validate_output_path` canonicalises via `realpath -m` and asserts the resolved path lives under `$GITHUB_WORKSPACE`.
- **HTTP redirects:** `curl -sL --max-redirs 3` caps redirect chains; ListenBrainz host is fixed and no credentials are attached, so redirect-to-metadata wouldn't leak secrets. Pre-existing behaviour, flagged as a note rather than a finding.
- **Log leakage:** Error path emits first 500 bytes of response body via `::warning::`. ListenBrainz public endpoints return no secrets; `LB_USERNAME` is auto-masked by GitHub even though it's just a profile name.

## Acceptance Criteria

- [x] `.github/actions/fetch-listenbrainz/action.yml` exists with inputs `username`, `output_path`, `stats_range`, `top_count`, `recent_count` (commit-related inputs dropped)
- [x] All 5 bash scripts copied; `commit-changes.sh` NOT copied
- [x] `skip_commit` and `commit_message` inputs dropped
- [x] `fetch-daily.yml` updated: `uses: ./.github/actions/fetch-listenbrainz`, `skip_commit: "true"` removed
- [x] `npm run build` passes (Astro 6.x, all 19 pages indexed)
- [ ] Post-merge: dispatch `fetch-daily.yml`; verify `src/data/listening.json` shape and `/listen` rendering — orchestrator will handle

Fixes #560


___

## **CodeAnt-AI Description**
**Move ListenBrainz data fetching into the repository workflow**

### What Changed
- The daily data fetch now uses the local ListenBrainz action in this repo instead of an external action.
- ListenBrainz inputs are checked before running, and invalid usernames, counts, ranges, or output paths are rejected with clear errors.
- Recent listens, top artists/tracks/albums, and listening activity are still collected and written to the JSON output file, with temporary files cleaned up at the end.
- The workflow no longer relies on the old `skip_commit` setting or action-level change outputs.

### Impact
`✅ Fewer breakages from external action changes`
`✅ Clearer input error messages`
`✅ Cleaner daily ListenBrainz fetch runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GitHub composite action for fetching ListenBrainz music data, including recent listens and statistics.
  * Action supports configurable username, output path, stats range, and count preferences.

* **Chores**
  * Updated the daily fetch workflow to use the new internal action instead of external dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->