### PR TITLE
chore: migrate hardcover fetcher to local composite action (#559)

### DIFF
--- a/.github/actions/fetch-hardcover/action.yml
+++ b/.github/actions/fetch-hardcover/action.yml
@@ -1,0 +1,49 @@
+name: 'Fetch Hardcover'
+description: 'Fetch reading data from Hardcover and write to JSON'
+author: 'ggfevans'
+
+branding:
+  icon: 'book-open'
+  color: 'purple'
+
+inputs:
+  token:
+    description: 'Hardcover API token'
+    required: true
+  user_id:
+    description: 'Hardcover user ID (positive integer)'
+    required: true
+  output_path:
+    description: 'Path to write the JSON file'
+    required: false
+    default: 'src/data/reading.json'
+  limit:
+    description: 'Maximum number of books to fetch'
+    required: false
+    default: '50'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Fetch reading data
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/fetch-reading.sh"
+      env:
+        HC_TOKEN: ${{ inputs.token }}
+        HC_USER_ID: ${{ inputs.user_id }}
+        HC_LIMIT: ${{ inputs.limit }}
+        HC_TMPDIR: ${{ runner.temp }}/hardcover-${{ github.run_id }}
+
+    - name: Build JSON
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/build-json.sh"
+      env:
+        HC_OUTPUT_PATH: ${{ inputs.output_path }}
+        HC_TMPDIR: ${{ runner.temp }}/hardcover-${{ github.run_id }}
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf "$HC_TMPDIR"
+      env:
+        HC_TMPDIR: ${{ runner.temp }}/hardcover-${{ github.run_id }}

--- a/.github/actions/fetch-hardcover/scripts/build-json.sh
+++ b/.github/actions/fetch-hardcover/scripts/build-json.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build-json.sh
+# Transforms raw Hardcover API data into the reading.json schema.
+# No network calls are made.
+#
+# Required env vars:
+#   HC_OUTPUT_PATH - Path to write the final JSON file
+#   HC_TMPDIR      - Temporary directory containing intermediate files
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${HC_OUTPUT_PATH:?must be set}"
+: "${HC_TMPDIR:?must be set}"
+
+# shellcheck source=scripts/validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+validate_output_path "$HC_OUTPUT_PATH"
+
+# ---------------------------------------------------------------------------
+# Ensure parent directory of output path exists
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "$HC_OUTPUT_PATH")"
+
+# ---------------------------------------------------------------------------
+# Verify input file exists
+# ---------------------------------------------------------------------------
+if [ ! -f "$HC_TMPDIR/raw-books.json" ]; then
+  echo "Error: raw-books.json not found in ${HC_TMPDIR}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Transform to output schema
+# ---------------------------------------------------------------------------
+echo "Building final JSON output at ${HC_OUTPUT_PATH}"
+
+# Map status_id: 1=want, 2=reading, 3=finished, 4=dnf, 5=dropped
+jq '{
+  lastUpdated: (now | todate),
+  currentlyReading: [
+    .[]
+    | select(.status_id == 2)
+    | {
+        title: .book.title,
+        author: (.book.contributions[0].author.name // "Unknown"),
+        coverUrl: .book.image.url,
+        hardcoverUrl: ("https://hardcover.app/books/" + .book.slug)
+      }
+  ],
+  finished: [
+    .[]
+    | select(.status_id == 3)
+    | {
+        title: .book.title,
+        author: (.book.contributions[0].author.name // "Unknown"),
+        coverUrl: .book.image.url,
+        hardcoverUrl: ("https://hardcover.app/books/" + .book.slug),
+        rating: (.rating // null),
+        dateFinished: .updated_at
+      }
+  ],
+  wantToRead: [
+    .[]
+    | select(.status_id == 1)
+    | {
+        title: .book.title,
+        author: (.book.contributions[0].author.name // "Unknown"),
+        coverUrl: .book.image.url,
+        hardcoverUrl: ("https://hardcover.app/books/" + .book.slug)
+      }
+  ]
+}' "$HC_TMPDIR/raw-books.json" > "$HC_OUTPUT_PATH"
+
+# ---------------------------------------------------------------------------
+# Print summary
+# ---------------------------------------------------------------------------
+jq -r '{
+  currently_reading: (.currentlyReading | length),
+  finished: (.finished | length),
+  want_to_read: (.wantToRead | length)
+}' "$HC_OUTPUT_PATH"
+
+echo "build-json.sh completed successfully"

--- a/.github/actions/fetch-hardcover/scripts/fetch-reading.sh
+++ b/.github/actions/fetch-hardcover/scripts/fetch-reading.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fetch-reading.sh
+# Fetches reading data from the Hardcover GraphQL API.
+#
+# Required env vars:
+#   HC_TOKEN   - Hardcover API token
+#   HC_USER_ID - Hardcover user ID (positive integer)
+#   HC_LIMIT   - Maximum number of books to fetch
+#   HC_TMPDIR  - Temporary directory for intermediate files
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${HC_TOKEN:?must be set}"
+: "${HC_USER_ID:?must be set}"
+: "${HC_LIMIT:?must be set}"
+: "${HC_TMPDIR:?must be set}"
+
+# shellcheck source=scripts/validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+# shellcheck source=scripts/http.sh
+source "$(dirname "$0")/http.sh"
+
+validate_token "$HC_TOKEN"
+validate_positive_integer "user_id" "$HC_USER_ID"
+validate_positive_integer "limit" "$HC_LIMIT"
+
+# ---------------------------------------------------------------------------
+# Create temp directory if it doesn't exist
+# ---------------------------------------------------------------------------
+mkdir -p "$HC_TMPDIR"
+
+# ---------------------------------------------------------------------------
+# Construct GraphQL query
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC2016 # GraphQL variables ($userId/$limit) are interpreted by the API, not by bash.
+QUERY='query GetUserBooks($userId: Int!, $limit: Int!) {
+  user_books(
+    where: { user_id: { _eq: $userId } }
+    order_by: { updated_at: desc }
+    limit: $limit
+  ) {
+    status_id
+    rating
+    updated_at
+    book {
+      title
+      contributions(limit: 1) {
+        author { name }
+      }
+      image { url }
+      slug
+    }
+  }
+}'
+
+PAYLOAD=$(jq -n \
+  --arg query "$QUERY" \
+  --argjson userId "$HC_USER_ID" \
+  --argjson limit "$HC_LIMIT" \
+  '{ query: $query, variables: { userId: $userId, limit: $limit } }')
+
+# ---------------------------------------------------------------------------
+# Fetch data from Hardcover API
+# ---------------------------------------------------------------------------
+echo "Fetching reading data for user ID: ${HC_USER_ID} (limit: ${HC_LIMIT})"
+
+TMP_RESPONSE="$HC_TMPDIR/response.tmp"
+
+HTTP_STATUS=$(fetch_graphql "https://api.hardcover.app/v1/graphql" "$TMP_RESPONSE" "$HC_TOKEN" "$PAYLOAD")
+
+if [ "$HTTP_STATUS" -ne 200 ]; then
+  echo "Error: Hardcover API returned HTTP ${HTTP_STATUS}" >&2
+  rm -f "$TMP_RESPONSE"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Validate response
+# ---------------------------------------------------------------------------
+if ! jq empty "$TMP_RESPONSE" 2>/dev/null; then
+  echo "Error: Invalid JSON response from Hardcover API" >&2
+  rm -f "$TMP_RESPONSE"
+  exit 1
+fi
+
+if jq -e '.errors' "$TMP_RESPONSE" > /dev/null 2>&1; then
+  echo "Error: GraphQL errors from Hardcover API" >&2
+  rm -f "$TMP_RESPONSE"
+  exit 1
+fi
+
+if ! jq -e '.data.user_books' "$TMP_RESPONSE" > /dev/null 2>&1; then
+  echo "Error: Invalid response structure from Hardcover API" >&2
+  rm -f "$TMP_RESPONSE"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Extract book data
+# ---------------------------------------------------------------------------
+jq '.data.user_books' "$TMP_RESPONSE" > "$HC_TMPDIR/raw-books.json"
+rm -f "$TMP_RESPONSE"
+
+BOOK_COUNT=$(jq 'length' "$HC_TMPDIR/raw-books.json")
+echo "Fetched ${BOOK_COUNT} books from Hardcover"
+echo "fetch-reading.sh completed successfully"

--- a/.github/actions/fetch-hardcover/scripts/http.sh
+++ b/.github/actions/fetch-hardcover/scripts/http.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# http.sh
+# Shared HTTP fetch with retry and backoff for authenticated GraphQL requests.
+# Source this file, then call fetch_graphql.
+
+fetch_graphql() {
+  local url="$1" output="$2" token="$3" payload="$4"
+  local max_attempts=3 attempt=0 status
+
+  while [ $attempt -lt $max_attempts ]; do
+    status=$(curl -s -w "%{http_code}" -o "$output" \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${token}" \
+      -d "$payload" \
+      --max-time 30 --connect-timeout 10 \
+      "$url") || status="000"
+
+    if [ "$status" -eq 429 ]; then
+      local wait=$((2 ** attempt))
+      echo "Rate limited (HTTP 429), retrying in ${wait}s..." >&2
+      sleep "$wait"
+      attempt=$((attempt + 1))
+    elif [ "$status" = "000" ] && [ $attempt -lt $((max_attempts - 1)) ]; then
+      local wait=$((2 ** attempt))
+      echo "Connection failed, retrying in ${wait}s..." >&2
+      sleep "$wait"
+      attempt=$((attempt + 1))
+    else
+      echo "$status"
+      return 0
+    fi
+  done
+  echo "$status"
+}

--- a/.github/actions/fetch-hardcover/scripts/validate-inputs.sh
+++ b/.github/actions/fetch-hardcover/scripts/validate-inputs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# validate-inputs.sh
+# Shared input validation for all scripts.
+# Source this file, then call the needed validators.
+
+validate_token() {
+  local token="$1"
+  if [ -z "$token" ]; then
+    echo "Error: Token must not be empty" >&2
+    exit 1
+  fi
+  if [ "${#token}" -lt 10 ]; then
+    echo "Error: Token appears too short" >&2
+    exit 1
+  fi
+}
+
+validate_positive_integer() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: ${name} must be a positive integer, got '${value}'" >&2
+    exit 1
+  fi
+}
+
+validate_output_path() {
+  local resolved
+  # realpath -m works on GNU/Linux (GitHub Actions runners) but not macOS.
+  # Fall back to python3 or plain realpath when -m is unavailable.
+  if resolved="$(realpath -m "$1" 2>/dev/null)"; then
+    :
+  elif resolved="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1" 2>/dev/null)"; then
+    :
+  else
+    resolved="$(cd "$(dirname "$1")" 2>/dev/null && pwd)/$(basename "$1")"
+  fi
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    if [[ "$resolved" != "${GITHUB_WORKSPACE}"/* ]]; then
+      echo "Error: output_path must be within the workspace (${GITHUB_WORKSPACE}), got '${resolved}'" >&2
+      exit 1
+    fi
+  fi
+}

--- a/.github/workflows/fetch-daily.yml
+++ b/.github/workflows/fetch-daily.yml
@@ -59,7 +59,7 @@ jobs:
       - id: reading
         name: Fetch Hardcover data
         continue-on-error: true
-        uses: ggfevans/hardcover-github-action@f68d44fb791e471a33a52f04f61052faa8654cb4 # v1
+        uses: ./.github/actions/fetch-hardcover
         with:
           token: ${{ secrets.HARDCOVER_TOKEN }}
           user_id: ${{ secrets.HARDCOVER_USER_ID }}


### PR DESCRIPTION
## **User description**
## Summary

Relocates `ggfevans/hardcover-github-action` into `.github/actions/fetch-hardcover/` as a local composite action. Part of the *-json-bourne consolidation epic (#556).

- Bash scripts (`fetch-reading.sh`, `build-json.sh`, `http.sh`, `validate-inputs.sh`) copied byte-identical from the upstream `hardcover-json-bourne` repo into `.github/actions/fetch-hardcover/scripts/` (executable bits preserved as `100755`).
- New `action.yml` mirrors the upstream `action.yml` exactly — same inputs (`token`, `user_id`, `output_path`, `limit`), same three composite steps (fetch -> build -> cleanup), same env-var contract (`HC_TOKEN`, `HC_USER_ID`, `HC_OUTPUT_PATH`, `HC_LIMIT`, `HC_TMPDIR`).
- `fetch-daily.yml`: swapped `uses: ggfevans/hardcover-github-action@f68d44fb...` -> `uses: ./.github/actions/fetch-hardcover`. Inputs block unchanged.
- Renamed `hardcover-github-action` -> `fetch-hardcover` resolves the upstream naming inconsistency (other fetchers are `*-json-bourne`).

## Preserved behaviour

- Single Hardcover GraphQL call (`GetUserBooks`), default limit 50, no pagination.
- HTTP retry layer in `http.sh`: `2^attempt` second backoff on 429, 3 attempts.
- `validate_output_path` enforces `$GITHUB_WORKSPACE` containment.
- Status-ID mapping in jq: `1=want, 2=reading, 3=finished, 4=dnf, 5=dropped`.
- Output top-level keys: `lastUpdated`, `currentlyReading[]`, `finished[]`, `wantToRead[]`.
- Source action declares no `outputs:`, so none are exposed here either.

## Security pass (vibe security skill)

Relocation-only assessment — bash files are byte-identical to upstream (verified via `diff`), so existing security posture inherits unchanged. Spot-checks for **new** exposures:

- **Command injection:** Scripts use proper quoted `"$VAR"` expansions. `jq -n --arg/--argjson` parameterises the GraphQL payload. No `eval` or `bash -c` of user input.
- **Secret handling:** `token` is passed via env var `HC_TOKEN` and only appears in the `Authorization: Bearer` curl header — never `echo`d.
- **HTTP redirect handling:** `curl` in `http.sh` does NOT use `-L`/`--location`, so attacker-controlled redirects cannot silently divert the request.
- **Action-level injection:** `action.yml` passes `inputs.*` via the `env:` block rather than interpolating `${{ }}` directly inside `run:` strings — avoids the GitHub Actions script-injection class. Script paths are double-quoted in `run:` for defence-in-depth against spaces in `github.action_path`.
- **Path traversal:** Preserved upstream `validate_output_path` via `realpath -m` + `$GITHUB_WORKSPACE` prefix check.

**Verdict: no new exposures introduced by the relocation.**

## Acceptance criteria

- [x] `.github/actions/fetch-hardcover/action.yml` exists with same inputs as current external action (`token`, `user_id`, `output_path`, `limit`)
- [x] All bash scripts (`fetch-reading.sh`, `build-json.sh`, `http.sh`, `validate-inputs.sh`) copied into `.github/actions/fetch-hardcover/scripts/`
- [x] `fetch-daily.yml` updated: `uses: ./.github/actions/fetch-hardcover`
- [ ] `workflow_dispatch`: `src/data/reading.json` shape matches pre-migration; `ReadWidget.astro` and `/read` page render unchanged *(orchestrator verifies post-merge)*

## Verification

- `npm run build` passes locally (Astro server build + prerender of 20 routes completes cleanly).

## Plan deviations

- Used the source `action.yml`'s 3-step composite layout (fetch -> build -> cleanup) rather than adding a separate `validate-inputs.sh` step. The script only defines functions and is sourced internally by `fetch-reading.sh` and `build-json.sh`; making it a standalone step would require editing the script, which violates the "pure relocation" constraint.

Fixes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated reading data integration from Hardcover API with status categorization (currently reading, finished, want to read).

* **Chores**
  * Replaced external third-party action with local composite action implementation for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Move Hardcover data fetching into a local workflow action and add input checks**

### What Changed
- The daily Hardcover fetch now runs from the repository’s local action instead of an external action reference.
- The action now checks that required inputs are present and valid before fetching or writing files.
- Output files are only written inside the workspace, and API failures, invalid responses, and rate limits are handled with clearer retries and error messages.

### Impact
`✅ Fewer workflow breaks from external action changes`
`✅ Safer Hardcover file writes`
`✅ Clearer errors when Hardcover fetches fail`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
