### PR TITLE
chore: migrate steam fetcher to local composite action (#558)

### DIFF
--- a/.github/actions/fetch-steam/action.yml
+++ b/.github/actions/fetch-steam/action.yml
@@ -1,0 +1,63 @@
+name: 'Fetch Steam'
+description: 'Fetch Steam gameplay data — playtime snapshots, daily deltas, and recently played games with artwork'
+author: 'ggfevans'
+
+branding:
+  icon: 'play'
+  color: 'blue'
+
+inputs:
+  steam_api_key:
+    description: 'Steam Web API key (https://steamcommunity.com/dev/apikey)'
+    required: true
+  steam_id:
+    description: 'Steam 64-bit numeric ID'
+    required: true
+  output_path:
+    description: 'Path to write the output JSON file'
+    required: false
+    default: 'src/data/gaming.json'
+  include_free_games:
+    description: 'Include free-to-play games in owned games list'
+    required: false
+    default: 'true'
+  recent_count:
+    description: 'Number of recently played games to include'
+    required: false
+    default: '10'
+  daily_log_days:
+    description: 'Number of days of daily playtime history to retain'
+    required: false
+    default: '90'
+
+outputs:
+  changes_detected:
+    description: 'Whether any playtime changes were detected since last run'
+    value: ${{ steps.run-fetcher.outputs.changes_detected }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '25'
+
+    - name: Install action dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci
+
+    - name: Run fetcher
+      id: run-fetcher
+      shell: bash
+      env:
+        # All inputs use POSIX-legal underscores, so @actions/core.getInput()
+        # reads INPUT_* env vars directly — no entrypoint shim needed.
+        INPUT_STEAM_API_KEY: ${{ inputs.steam_api_key }}
+        INPUT_STEAM_ID: ${{ inputs.steam_id }}
+        INPUT_OUTPUT_PATH: ${{ inputs.output_path }}
+        INPUT_INCLUDE_FREE_GAMES: ${{ inputs.include_free_games }}
+        INPUT_RECENT_COUNT: ${{ inputs.recent_count }}
+        INPUT_DAILY_LOG_DAYS: ${{ inputs.daily_log_days }}
+      run: node ${{ github.action_path }}/src/index.js

--- a/.github/actions/fetch-steam/package-lock.json
+++ b/.github/actions/fetch-steam/package-lock.json
@@ -1,0 +1,68 @@
+{
+  "name": "fetch-steam-action",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fetch-steam-action",
+      "version": "1.0.0",
+      "dependencies": {
+        "@actions/core": "^3.0.1"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "license": "MIT"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    }
+  }
+}

--- a/.github/actions/fetch-steam/package.json
+++ b/.github/actions/fetch-steam/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fetch-steam-action",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@actions/core": "^3.0.1"
+  }
+}

--- a/.github/actions/fetch-steam/src/index.js
+++ b/.github/actions/fetch-steam/src/index.js
@@ -1,0 +1,283 @@
+import * as core from '@actions/core';
+import fs from 'fs';
+import path from 'path';
+
+// ---------------------------------------------------------------------------
+// Steam Web API helpers
+// ---------------------------------------------------------------------------
+
+const STEAM_API_BASE = 'https://api.steampowered.com';
+
+async function steamGet(iface, method, version, params) {
+  const url = new URL(`${STEAM_API_BASE}/${iface}/${method}/${version}/`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null) url.searchParams.set(k, v);
+  }
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Steam API ${method} returned ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function getOwnedGames(apiKey, steamId, includeFree) {
+  const data = await steamGet('IPlayerService', 'GetOwnedGames', 'v1', {
+    key: apiKey,
+    steamid: steamId,
+    include_appinfo: 1,
+    include_played_free_games: includeFree ? 1 : 0,
+    format: 'json',
+  });
+  return data?.response?.games ?? [];
+}
+
+async function getPlayerSummary(apiKey, steamId) {
+  const data = await steamGet('ISteamUser', 'GetPlayerSummaries', 'v2', {
+    key: apiKey,
+    steamids: steamId,
+    format: 'json',
+  });
+  const players = data?.response?.players ?? [];
+  return players[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Artwork URLs
+// ---------------------------------------------------------------------------
+// Steam migrated newer titles to hashed storefront paths, so the predictable
+// legacy CDN URLs return 404 for them. The storefront `appdetails` endpoint
+// surfaces the correct hashed `header_image` and `capsule_image`. Library
+// `library_600x900.jpg` is not exposed by any public API, so portraitUrl stays
+// on the legacy pattern as best-effort — consumers should fall back gracefully.
+
+const LEGACY_CDN_BASE = 'https://cdn.akamai.steamstatic.com/steam/apps';
+const ARTWORK_CONCURRENCY = 4; // bounded so high `recent_count` doesn't burst Steam
+
+async function fetchAppDetails(appId) {
+  const url = `https://store.steampowered.com/api/appdetails?appids=${appId}&filters=basic`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      core.debug(`appdetails ${appId} → HTTP ${res.status}`);
+      return null;
+    }
+    const json = await res.json();
+    const entry = json?.[appId];
+    if (!entry?.success || !entry.data) {
+      core.debug(`appdetails ${appId} → unsuccessful entry: ${JSON.stringify(entry)}`);
+      return null;
+    }
+    return {
+      headerUrl: entry.data.header_image ?? null,
+      capsuleUrl: entry.data.capsule_image ?? null,
+    };
+  } catch (err) {
+    const reason = err?.name === 'AbortError' ? 'timeout' : (err?.message ?? String(err));
+    core.debug(`appdetails ${appId} → ${reason}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function artworkUrls(appId) {
+  const details = await fetchAppDetails(appId);
+  return {
+    headerUrl: details?.headerUrl ?? `${LEGACY_CDN_BASE}/${appId}/header.jpg`,
+    capsuleUrl: details?.capsuleUrl ?? `${LEGACY_CDN_BASE}/${appId}/capsule_231x87.jpg`,
+    portraitUrl: `${LEGACY_CDN_BASE}/${appId}/library_600x900.jpg`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Data processing
+// ---------------------------------------------------------------------------
+
+function buildSnapshot(games) {
+  const snapshot = {};
+  for (const g of games) {
+    snapshot[g.appid] = g.playtime_forever ?? 0;
+  }
+  return snapshot;
+}
+
+function computeDeltas(prevSnapshot, currentSnapshot, gamesMap) {
+  const deltas = [];
+  for (const [appId, currentMinutes] of Object.entries(currentSnapshot)) {
+    const prev = prevSnapshot[appId] ?? 0;
+    const diff = currentMinutes - prev;
+    if (diff > 0) {
+      const game = gamesMap.get(Number(appId));
+      deltas.push({
+        name: game?.name ?? `Unknown (${appId})`,
+        appId: Number(appId),
+        minutesPlayed: diff,
+      });
+    }
+  }
+  // Sort by most played first
+  deltas.sort((a, b) => b.minutesPlayed - a.minutesPlayed);
+  return deltas;
+}
+
+async function buildRecentlyPlayed(games, count) {
+  // Filter to games played in the last 2 weeks (have playtime_2weeks) or
+  // have a recent rtime_last_played, then sort by last played descending
+  const played = games
+    .filter((g) => g.rtime_last_played > 0)
+    .sort((a, b) => b.rtime_last_played - a.rtime_last_played)
+    .slice(0, count);
+
+  const buildEntry = async (g) => ({
+    name: g.name,
+    appId: g.appid,
+    ...(await artworkUrls(g.appid)),
+    playtimeForeverMinutes: g.playtime_forever ?? 0,
+    playtime2WeeksMinutes: g.playtime_2weeks ?? 0,
+    lastPlayed: new Date(g.rtime_last_played * 1000).toISOString(),
+    playtimeByPlatform: {
+      windows: g.playtime_windows_forever ?? 0,
+      mac: g.playtime_mac_forever ?? 0,
+      linux: g.playtime_linux_forever ?? 0,
+      deck: g.playtime_deck_forever ?? 0,
+    },
+  });
+
+  const result = [];
+  for (let i = 0; i < played.length; i += ARTWORK_CONCURRENCY) {
+    const chunk = played.slice(i, i + ARTWORK_CONCURRENCY);
+    result.push(...(await Promise.all(chunk.map(buildEntry))));
+  }
+  return result;
+}
+
+function buildStats(games) {
+  const played = games.filter((g) => (g.playtime_forever ?? 0) > 0);
+  const recentlyActive = games.filter((g) => (g.playtime_2weeks ?? 0) > 0);
+  const totalMinutes = games.reduce((sum, g) => sum + (g.playtime_forever ?? 0), 0);
+
+  return {
+    totalGamesOwned: games.length,
+    totalGamesPlayed: played.length,
+    totalPlaytimeMinutes: totalMinutes,
+    totalPlaytimeHours: Math.round((totalMinutes / 60) * 10) / 10,
+    gamesPlayedLast2Weeks: recentlyActive.length,
+    minutesLast2Weeks: recentlyActive.reduce((sum, g) => sum + (g.playtime_2weeks ?? 0), 0),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Daily log management
+// ---------------------------------------------------------------------------
+
+function updateDailyLog(existingLog, deltas, maxDays) {
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const totalMinutes = deltas.reduce((sum, d) => sum + d.minutesPlayed, 0);
+
+  // Remove any existing entry for today (idempotent re-runs)
+  const log = (existingLog ?? []).filter((entry) => entry.date !== today);
+
+  // Only add an entry if there was actual playtime
+  if (deltas.length > 0) {
+    log.push({
+      date: today,
+      totalMinutes,
+      games: deltas,
+    });
+  }
+
+  // Sort descending by date and trim to maxDays
+  log.sort((a, b) => b.date.localeCompare(a.date));
+  return log.slice(0, maxDays);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function run() {
+  try {
+    const apiKey = core.getInput('steam_api_key', { required: true });
+    const steamId = core.getInput('steam_id', { required: true });
+    const outputPath = core.getInput('output_path') || 'src/data/gaming.json';
+    const includeFree = core.getInput('include_free_games') !== 'false';
+    const recentCount = parseInt(core.getInput('recent_count') || '10', 10);
+    const dailyLogDays = parseInt(core.getInput('daily_log_days') || '90', 10);
+
+    core.info(`Fetching Steam data for ID ${steamId}...`);
+
+    // Load existing data file (if any) for delta calculation
+    let existing = {};
+    const absPath = path.resolve(outputPath);
+    if (fs.existsSync(absPath)) {
+      try {
+        existing = JSON.parse(fs.readFileSync(absPath, 'utf8'));
+        core.info('Loaded existing data file for delta calculation');
+      } catch (e) {
+        core.warning(`Could not parse existing file: ${e.message}`);
+      }
+    }
+
+    // Fetch from Steam API
+    const [games, playerSummary] = await Promise.all([
+      getOwnedGames(apiKey, steamId, includeFree),
+      getPlayerSummary(apiKey, steamId),
+    ]);
+
+    core.info(`Fetched ${games.length} owned games`);
+
+    // Build a lookup map
+    const gamesMap = new Map(games.map((g) => [g.appid, g]));
+
+    // Build current snapshot
+    const currentSnapshot = buildSnapshot(games);
+    const prevSnapshot = existing.snapshot?.games ?? {};
+
+    // Compute daily deltas
+    const deltas = computeDeltas(prevSnapshot, currentSnapshot, gamesMap);
+
+    if (deltas.length > 0) {
+      const totalMins = deltas.reduce((s, d) => s + d.minutesPlayed, 0);
+      core.info(`Detected ${totalMins} minutes of playtime across ${deltas.length} games since last run`);
+    } else {
+      core.info('No new playtime detected since last run');
+    }
+
+    // Build output
+    const output = {
+      lastUpdated: new Date().toISOString(),
+      profile: playerSummary
+        ? {
+            steamId,
+            personaName: playerSummary.personaname,
+            avatarUrl: playerSummary.avatarfull,
+            profileUrl: playerSummary.profileurl,
+          }
+        : existing.profile ?? { steamId },
+      recentlyPlayed: await buildRecentlyPlayed(games, recentCount),
+      stats: buildStats(games),
+      dailyLog: updateDailyLog(existing.dailyLog, deltas, dailyLogDays),
+      snapshot: {
+        date: new Date().toISOString().slice(0, 10),
+        games: currentSnapshot,
+      },
+    };
+
+    // Write output
+    const dir = path.dirname(absPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(absPath, JSON.stringify(output, null, 2) + '\n');
+    core.info(`Wrote output to ${outputPath}`);
+
+    // Git commit (unless skipped)
+    const changesDetected = deltas.length > 0 ||
+      !existing.lastUpdated ||
+      JSON.stringify(existing.stats) !== JSON.stringify(output.stats);
+
+    core.setOutput('changes_detected', changesDetected.toString());
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+run();

--- a/.github/workflows/fetch-daily.yml
+++ b/.github/workflows/fetch-daily.yml
@@ -26,14 +26,13 @@ jobs:
       - id: gaming
         name: Fetch Steam data
         continue-on-error: true
-        uses: ggfevans/steam-json-bourne@16a0ad5ed045d350a175d124c5100ff14c388a6a # main
+        uses: ./.github/actions/fetch-steam
         with:
           steam_api_key: ${{ secrets.STEAM_API_KEY }}
           steam_id: "76561197962113454"
           output_path: src/data/gaming.json
           recent_count: "10"
           daily_log_days: "90"
-          skip_commit: "true"
 
       - id: github
         name: Fetch GitHub activity


### PR DESCRIPTION
## **User description**
## Summary

Ports `ggfevans/steam-json-bourne` into `.github/actions/fetch-steam/` as a local composite action, following the shape established by the just-merged `fetch-github` pilot (#557). Part of the `*-json-bourne` consolidation epic (#556).

## Changes

- **New action** `.github/actions/fetch-steam/`:
  - `src/index.js` lifted byte-identical from `steam-json-bourne/src/index.js`, minus the internal `execSync('git ...')` block (lines 281–294 of source) — commits are handled by `commit-via-pr`.
  - `child_process` import and `skipCommit` variable removed (no longer used).
  - `package.json` + `package-lock.json` with the upstream `@actions/core ^3.0.1` dependency.
  - `action.yml` with `using: composite`, `node-version: 25` (bumped from 24 for parity with gvns.ca CI), scoped `npm ci`, and `node ${{ github.action_path }}/src/index.js`. Inputs are POSIX-legal (underscored) so no entrypoint shim is needed (unlike the GitHub pilot's hyphens).
  - `changes_detected` output is wired through the `run-fetcher` step `id`.
- **Workflow update** `.github/workflows/fetch-daily.yml`:
  - `uses: ggfevans/steam-json-bourne@16a0ad5...` → `uses: ./.github/actions/fetch-steam`
  - `skip_commit: "true"` line dropped (input no longer exists).
  - All other step inputs unchanged.

## Security pass

Ran the secure-coding skill against the new code. Surfaces inspected:

- **Secret handling (`steam_api_key`):** key flows into URL query strings to `api.steampowered.com`. Steam's error responses do not echo the key. Inherited from upstream — no new exposure.
- **Command injection:** zero `child_process`/`execSync`/shell escape after the Phase 2 strip (verified via grep). Attack surface **reduced** vs. upstream.
- **SSRF surface:** all outbound URLs use hardcoded bases (`api.steampowered.com`, `store.steampowered.com`, `cdn.akamai.steamstatic.com`). `appId` is a Steam-provided integer, not user input. No new SSRF surface.
- **Path traversal in `output_path`:** `path.resolve(outputPath)` + `fs.writeFileSync`; input comes from the committed workflow file (trusted), same posture as upstream.

**Verdict: no new exposures introduced; one surface (shell exec) eliminated.**

## Verification

- `node --check .github/actions/fetch-steam/src/index.js` — passes
- `npm run build` (Astro) — passes
- `npm install` inside `.github/actions/fetch-steam/` produces a deterministic lockfile

Snapshot continuity will be verified by the orchestrator post-dispatch.

## Acceptance criteria

- [x] `.github/actions/fetch-steam/action.yml` exists with inputs matching the current external action minus `skip_commit`
- [x] `src/index.js` lifted from `steam-json-bourne/src/` into `.github/actions/fetch-steam/src/index.js`
- [x] `.github/actions/fetch-steam/package.json` exists with `@actions/core` dep
- [x] Composite uses `using: composite` with scoped `npm ci` then `node .../src/index.js`
- [x] Internal `execSync` git-commit block removed; commits handled by `commit-via-pr`
- [x] `skip_commit` input dropped from `action.yml`
- [x] `fetch-daily.yml` updated: `uses: ./.github/actions/fetch-steam` and `skip_commit: "true"` line removed
- [ ] `workflow_dispatch` snapshot continuity verified (orchestrator-driven post-merge)

Fixes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Steam gameplay data fetching now includes flexible configuration options and enhanced change detection.
  * Recently played games are enriched with storefront artwork URLs.
  * Daily playtime history tracking with configurable retention period (up to 90 days by default).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fetch Steam playtime data through a local action and include richer game history in the output

### What Changed
- The daily Steam fetch now runs from this repo instead of an external action
- The saved Steam data now includes playtime snapshots, daily playtime changes, recently played games, and account stats
- Recently played games now include artwork and platform playtime details
- Re-runs update the same daily history cleanly and keep only the configured number of days

### Impact
`✅ More complete Steam activity summaries`
`✅ Clearer recent-game views with artwork`
`✅ Reliable daily playtime history`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
