### PR TITLE
chore: migrate trakt fetcher to local composite action (#561)

### DIFF
--- a/.github/actions/fetch-trakt/action.yml
+++ b/.github/actions/fetch-trakt/action.yml
@@ -1,0 +1,80 @@
+name: 'Fetch Trakt'
+description: 'Fetch watch history from Trakt and write to JSON with optional TMDB poster enrichment'
+branding:
+  icon: 'film'
+  color: 'red'
+
+inputs:
+  trakt_client_id:
+    description: 'Trakt API client ID (from https://trakt.tv/oauth/applications)'
+    required: true
+  trakt_username:
+    description: 'Trakt username to fetch history for'
+    required: true
+  tmdb_api_key:
+    description: 'TMDB API key for poster enrichment (optional)'
+    required: false
+    default: ''
+  output_path:
+    description: 'Path to write the JSON file'
+    required: false
+    default: 'src/data/watching.json'
+  history_limit:
+    description: 'Number of history items to fetch'
+    required: false
+    default: '30'
+
+outputs:
+  posters_status:
+    description: 'Status of poster enrichment (ok, skipped, partial, error)'
+    value: ${{ steps.posters.outputs.status }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        source "${{ github.action_path }}/scripts/validate-inputs.sh"
+        validate_required "trakt_client_id" "$TRAKT_CLIENT_ID"
+        validate_username "$TRAKT_USERNAME"
+        validate_positive_integer "history_limit" "$TRAKT_HISTORY_LIMIT"
+        validate_output_path "$TRAKT_OUTPUT_PATH"
+        validate_tmdb_api_key "$TMDB_API_KEY"
+      env:
+        TRAKT_CLIENT_ID: ${{ inputs.trakt_client_id }}
+        TRAKT_USERNAME: ${{ inputs.trakt_username }}
+        TRAKT_HISTORY_LIMIT: ${{ inputs.history_limit }}
+        TRAKT_OUTPUT_PATH: ${{ inputs.output_path }}
+        TMDB_API_KEY: ${{ inputs.tmdb_api_key }}
+
+    - name: Fetch Trakt history
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/fetch-history.sh"
+      env:
+        TRAKT_CLIENT_ID: ${{ inputs.trakt_client_id }}
+        TRAKT_USERNAME: ${{ inputs.trakt_username }}
+        TRAKT_HISTORY_LIMIT: ${{ inputs.history_limit }}
+        TRAKT_TMPDIR: ${{ runner.temp }}/trakt-${{ github.run_id }}
+
+    - name: Fetch TMDB posters
+      id: posters
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/fetch-posters.sh"
+      env:
+        TMDB_API_KEY: ${{ inputs.tmdb_api_key }}
+        TRAKT_TMPDIR: ${{ runner.temp }}/trakt-${{ github.run_id }}
+
+    - name: Build JSON
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/build-json.sh"
+      env:
+        TRAKT_OUTPUT_PATH: ${{ inputs.output_path }}
+        TRAKT_TMPDIR: ${{ runner.temp }}/trakt-${{ github.run_id }}
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf "$TRAKT_TMPDIR"
+      env:
+        TRAKT_TMPDIR: ${{ runner.temp }}/trakt-${{ github.run_id }}

--- a/.github/actions/fetch-trakt/scripts/build-json.sh
+++ b/.github/actions/fetch-trakt/scripts/build-json.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build-json.sh
+# Assembles the final JSON output from intermediate files.
+# No network calls - purely data transformation.
+#
+# Required env vars:
+#   TRAKT_OUTPUT_PATH - Path to write the final JSON file
+#   TRAKT_TMPDIR      - Temporary directory containing intermediate files
+
+: "${TRAKT_OUTPUT_PATH:?must be set}"
+: "${TRAKT_TMPDIR:?must be set}"
+
+# shellcheck source=validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+validate_output_path "$TRAKT_OUTPUT_PATH"
+
+mkdir -p "$(dirname "$TRAKT_OUTPUT_PATH")"
+
+if [ ! -f "$TRAKT_TMPDIR/history.json" ]; then
+  echo "Error: history.json not found in TRAKT_TMPDIR" >&2
+  exit 1
+fi
+
+if [ ! -f "$TRAKT_TMPDIR/posters.json" ]; then
+  echo '{}' > "$TRAKT_TMPDIR/posters.json"
+fi
+
+echo "Building final JSON output at ${TRAKT_OUTPUT_PATH}"
+
+CURRENT_MONTH=$(date -u +%Y-%m)
+
+jq --slurpfile posters "$TRAKT_TMPDIR/posters.json" \
+   --arg month "$CURRENT_MONTH" '
+  ($posters[0] // {}) as $poster_map |
+
+  sort_by(
+    if .type == "movie" then "movie_" + (.movie.ids.trakt | tostring)
+    elif .type == "episode" then "show_" + (.show.ids.trakt | tostring)
+    else "unknown" end
+  ) |
+  group_by(
+    if .type == "movie" then "movie_" + (.movie.ids.trakt | tostring)
+    elif .type == "episode" then "show_" + (.show.ids.trakt | tostring)
+    else "unknown" end
+  ) | map(sort_by(.watched_at) | reverse | first) |
+
+  sort_by(.watched_at) | reverse |
+
+  ([ .[] | select(.watched_at | startswith($month)) ] |
+    { movies: [ .[] | select(.type == "movie") ] | length,
+      shows: [ .[] | select(.type == "episode") ] | length }) as $month_stats |
+
+  {
+    lastUpdated: (now | todate),
+    recentlyWatched: [
+      .[] |
+      if .type == "movie" then
+        {
+          title: .movie.title,
+          type: "movie",
+          posterUrl: ($poster_map["movie_" + (.movie.ids.tmdb | tostring)] // null),
+          url: ("https://trakt.tv/movies/" + .movie.ids.slug),
+          watchedDate: .watched_at
+        }
+      elif .type == "episode" then
+        {
+          title: (.show.title + " \u2014 S" + (
+            if .episode.season < 10 then "0" else "" end
+          ) + (.episode.season | tostring) + "E" + (
+            if .episode.number < 10 then "0" else "" end
+          ) + (.episode.number | tostring)),
+          type: "show",
+          posterUrl: ($poster_map["tv_" + (.show.ids.tmdb | tostring)] // null),
+          url: ("https://trakt.tv/shows/" + .show.ids.slug),
+          watchedDate: .watched_at
+        }
+      else empty end
+    ],
+    stats: {
+      moviesThisMonth: $month_stats.movies,
+      showsThisMonth: $month_stats.shows
+    }
+  }
+' "$TRAKT_TMPDIR/history.json" > "$TRAKT_OUTPUT_PATH"
+
+echo "Successfully built watching.json"
+jq '{
+  recently_watched: (.recentlyWatched | length),
+  movies_this_month: .stats.moviesThisMonth,
+  shows_this_month: .stats.showsThisMonth
+}' "$TRAKT_OUTPUT_PATH"
+
+echo "build-json.sh completed successfully"

--- a/.github/actions/fetch-trakt/scripts/fetch-history.sh
+++ b/.github/actions/fetch-trakt/scripts/fetch-history.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fetch-history.sh
+# Fetches recent watch history from the Trakt API.
+# Critical path - if fetching history fails, the action fails.
+#
+# Required env vars:
+#   TRAKT_CLIENT_ID     - Trakt API client ID
+#   TRAKT_USERNAME      - Trakt username
+#   TRAKT_HISTORY_LIMIT - Number of history items to fetch
+#   TRAKT_TMPDIR        - Temporary directory for intermediate files
+
+TRAKT_API="https://api.trakt.tv"
+
+: "${TRAKT_CLIENT_ID:?must be set}"
+: "${TRAKT_USERNAME:?must be set}"
+: "${TRAKT_HISTORY_LIMIT:?must be set}"
+: "${TRAKT_TMPDIR:?must be set}"
+
+# shellcheck source=validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+# shellcheck source=http.sh
+source "$(dirname "$0")/http.sh"
+validate_username "$TRAKT_USERNAME"
+validate_positive_integer "history_limit" "$TRAKT_HISTORY_LIMIT"
+
+mkdir -p "$TRAKT_TMPDIR"
+
+echo "Fetching watch history for user: ${TRAKT_USERNAME} (limit: ${TRAKT_HISTORY_LIMIT})"
+
+HTTP_STATUS=$(fetch_url_with_headers \
+  "${TRAKT_API}/users/${TRAKT_USERNAME}/history?limit=${TRAKT_HISTORY_LIMIT}" \
+  "$TRAKT_TMPDIR/history-response.tmp" \
+  -H "Content-Type: application/json" \
+  -H "trakt-api-version: 2" \
+  -H "trakt-api-key: ${TRAKT_CLIENT_ID}")
+
+if [ "$HTTP_STATUS" -ne 200 ]; then
+  echo "Error: Trakt API returned HTTP ${HTTP_STATUS}" >&2
+  echo "::warning::Trakt API returned HTTP ${HTTP_STATUS}. Check API credentials and username."
+  rm -f "$TRAKT_TMPDIR/history-response.tmp"
+  exit 1
+fi
+
+if ! jq -e 'type == "array"' "$TRAKT_TMPDIR/history-response.tmp" > /dev/null 2>&1; then
+  echo "Error: Trakt API returned invalid JSON (expected array)" >&2
+  rm -f "$TRAKT_TMPDIR/history-response.tmp"
+  exit 1
+fi
+
+# Extract TMDB IDs for poster lookup
+jq -r '[
+  .[] |
+  if .type == "movie" then
+    { tmdb_id: (.movie.ids.tmdb // empty), media_type: "movie" }
+  elif .type == "episode" then
+    { tmdb_id: (.show.ids.tmdb // empty), media_type: "tv" }
+  else empty end
+] | unique_by(.tmdb_id) | .[] | "\(.tmdb_id) \(.media_type)"' \
+  "$TRAKT_TMPDIR/history-response.tmp" > "$TRAKT_TMPDIR/tmdb-ids.txt" 2>/dev/null || true
+
+TMDB_COUNT=$(wc -l < "$TRAKT_TMPDIR/tmdb-ids.txt" | tr -d ' ')
+echo "Extracted ${TMDB_COUNT} unique TMDB IDs for poster lookup"
+
+mv "$TRAKT_TMPDIR/history-response.tmp" "$TRAKT_TMPDIR/history.json"
+
+HISTORY_COUNT=$(jq length "$TRAKT_TMPDIR/history.json")
+echo "Wrote ${HISTORY_COUNT} history items to ${TRAKT_TMPDIR}/history.json"
+
+echo "fetch-history.sh completed successfully"

--- a/.github/actions/fetch-trakt/scripts/fetch-posters.sh
+++ b/.github/actions/fetch-trakt/scripts/fetch-posters.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fetch-posters.sh
+# Enriches history data with poster URLs from TMDB.
+# NOT on the critical path - failures are non-fatal.
+#
+# Required env vars:
+#   TRAKT_TMPDIR  - Temporary directory containing tmdb-ids.txt
+#
+# Optional env vars:
+#   TMDB_API_KEY  - TMDB API key (if not set, posters are skipped)
+
+TMDB_API="https://api.themoviedb.org/3"
+TMDB_IMAGE_BASE="https://image.tmdb.org/t/p/w342"
+POSTER_DELAY="${POSTER_DELAY:-0.25}"
+
+: "${TRAKT_TMPDIR:?must be set}"
+
+# shellcheck source=validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+# shellcheck source=http.sh
+source "$(dirname "$0")/http.sh"
+
+validate_tmdb_api_key "${TMDB_API_KEY:-}"
+
+echo '{}' > "$TRAKT_TMPDIR/posters.json"
+
+if [ -z "${TMDB_API_KEY:-}" ]; then
+  echo "TMDB_API_KEY not configured, skipping poster enrichment"
+  echo "skipped" > "$TRAKT_TMPDIR/posters-status.txt"
+  echo "status=skipped" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+if [ ! -s "$TRAKT_TMPDIR/tmdb-ids.txt" ]; then
+  echo "No TMDB IDs to fetch posters for"
+  echo "ok" > "$TRAKT_TMPDIR/posters-status.txt"
+  echo "status=ok" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+echo "Fetching TMDB posters (delay: ${POSTER_DELAY}s between requests)"
+
+TOTAL_IDS=$(wc -l < "$TRAKT_TMPDIR/tmdb-ids.txt" | tr -d ' ')
+FETCHED=0
+FAILED=0
+
+while IFS=' ' read -r tmdb_id media_type; do
+  [ -z "$tmdb_id" ] && continue
+
+  HTTP_STATUS=$(fetch_url \
+    "${TMDB_API}/${media_type}/${tmdb_id}?api_key=${TMDB_API_KEY}" \
+    "$TRAKT_TMPDIR/tmdb-item.tmp")
+
+  if [ "$HTTP_STATUS" -eq 200 ]; then
+    POSTER_PATH=$(jq -r '.poster_path // empty' "$TRAKT_TMPDIR/tmdb-item.tmp" 2>/dev/null || true)
+    if [ -n "$POSTER_PATH" ]; then
+      jq --arg key "${media_type}_${tmdb_id}" \
+         --arg url "${TMDB_IMAGE_BASE}${POSTER_PATH}" \
+         '. + { ($key): $url }' "$TRAKT_TMPDIR/posters.json" > "$TRAKT_TMPDIR/posters-tmp.json"
+      mv "$TRAKT_TMPDIR/posters-tmp.json" "$TRAKT_TMPDIR/posters.json"
+      FETCHED=$((FETCHED + 1))
+    fi
+  else
+    echo "::debug::TMDB lookup failed for ${media_type}/${tmdb_id}: HTTP ${HTTP_STATUS}"
+    FAILED=$((FAILED + 1))
+  fi
+
+  rm -f "$TRAKT_TMPDIR/tmdb-item.tmp"
+  sleep "$POSTER_DELAY"
+done < "$TRAKT_TMPDIR/tmdb-ids.txt"
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "ok" > "$TRAKT_TMPDIR/posters-status.txt"
+  echo "status=ok" >> "${GITHUB_OUTPUT:-/dev/null}"
+elif [ "$FETCHED" -gt 0 ]; then
+  echo "partial" > "$TRAKT_TMPDIR/posters-status.txt"
+  echo "status=partial" >> "${GITHUB_OUTPUT:-/dev/null}"
+else
+  echo "error" > "$TRAKT_TMPDIR/posters-status.txt"
+  echo "status=error" >> "${GITHUB_OUTPUT:-/dev/null}"
+fi
+
+echo "Fetched ${FETCHED}/${TOTAL_IDS} posters (${FAILED} failed)"
+echo "fetch-posters.sh completed"

--- a/.github/actions/fetch-trakt/scripts/http.sh
+++ b/.github/actions/fetch-trakt/scripts/http.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# http.sh
+# Shared HTTP fetch with retry and exponential backoff.
+# Source this file, then call fetch_url or fetch_url_with_headers.
+
+fetch_url() {
+  local url="$1" output="$2" max_attempts=3 attempt=0 status
+  while [ $attempt -lt $max_attempts ]; do
+    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+      --max-time 30 --connect-timeout 10 "$url") || status="000"
+    if [ "$status" -eq 429 ]; then
+      local wait=$((2 ** attempt))
+      echo "Rate limited (HTTP 429), retrying in ${wait}s..." >&2
+      sleep "$wait"
+      attempt=$((attempt + 1))
+    elif [ "$status" = "000" ] && [ $attempt -lt $((max_attempts - 1)) ]; then
+      echo "Connection failed, retrying in 2s..." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+    else
+      echo "$status"
+      return 0
+    fi
+  done
+  echo "$status"
+}
+
+fetch_url_with_headers() {
+  local url="$1" output="$2"
+  shift 2
+  local max_attempts=3 attempt=0 status
+  while [ $attempt -lt $max_attempts ]; do
+    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+      --max-time 30 --connect-timeout 10 "$@" "$url") || status="000"
+    if [ "$status" -eq 429 ]; then
+      local wait=$((2 ** attempt))
+      echo "Rate limited (HTTP 429), retrying in ${wait}s..." >&2
+      sleep "$wait"
+      attempt=$((attempt + 1))
+    elif [ "$status" = "000" ] && [ $attempt -lt $((max_attempts - 1)) ]; then
+      echo "Connection failed, retrying in 2s..." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+    else
+      echo "$status"
+      return 0
+    fi
+  done
+  echo "$status"
+}

--- a/.github/actions/fetch-trakt/scripts/validate-inputs.sh
+++ b/.github/actions/fetch-trakt/scripts/validate-inputs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# validate-inputs.sh
+# Shared input validation for all scripts.
+# Source this file, then call the needed validators.
+
+validate_required() {
+  local name="$1" value="$2"
+  if [ -z "$value" ]; then
+    echo "Error: ${name} is required but was not provided" >&2
+    exit 1
+  fi
+}
+
+validate_username() {
+  if [[ ! "$1" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo "Error: Invalid username format. Must be alphanumeric, hyphens, or underscores." >&2
+    exit 1
+  fi
+}
+
+validate_positive_integer() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: ${name} must be a positive integer, got '${value}'" >&2
+    exit 1
+  fi
+}
+
+validate_tmdb_api_key() {
+  local key="$1"
+  if [ -z "$key" ]; then
+    return 0  # Empty = skip posters
+  fi
+  if [[ ! "$key" =~ ^[a-fA-F0-9]{32}$ ]]; then
+    echo "Error: TMDB API key must be a 32-character hex string" >&2
+    exit 1
+  fi
+}
+
+validate_output_path() {
+  local resolved
+  if resolved="$(realpath -m "$1" 2>/dev/null)"; then
+    :
+  elif resolved="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1" 2>/dev/null)"; then
+    :
+  else
+    resolved="$(cd "$(dirname "$1")" 2>/dev/null && pwd)/$(basename "$1")"
+  fi
+  if [ -z "${GITHUB_WORKSPACE:-}" ]; then
+    echo "Error: GITHUB_WORKSPACE is not set. Cannot validate output path boundary." >&2
+    exit 1
+  fi
+  if [[ "$resolved" != "${GITHUB_WORKSPACE}"/* ]]; then
+    echo "Error: output_path must be within the workspace (${GITHUB_WORKSPACE}), got '${resolved}'" >&2
+    exit 1
+  fi
+}

--- a/.github/workflows/fetch-daily.yml
+++ b/.github/workflows/fetch-daily.yml
@@ -68,7 +68,7 @@ jobs:
       - id: watching
         name: Fetch Trakt data
         continue-on-error: true
-        uses: ggfevans/trakt-json-bourne@79005a28f68a285f6a4295781138423402ec6623
+        uses: ./.github/actions/fetch-trakt
         with:
           trakt_client_id: ${{ secrets.TRAKT_CLIENT_ID }}
           trakt_username: "gvns"


### PR DESCRIPTION
## **User description**
## Summary

Relocates `ggfevans/trakt-json-bourne` into `.github/actions/fetch-trakt/` as a local composite action. Pure bash relocation — no script edits, no input changes. Part of the *-json-bourne consolidation (parent #556).

Closes the gap left by the github pilot (#557 merged): mirrors the same `runs.using: composite` shape and follows the wired-outputs lesson learned there.

## Changes

- **Add** `.github/actions/fetch-trakt/action.yml` mirroring upstream (same 5 inputs: `trakt_client_id` (required), `trakt_username` (required), `tmdb_api_key`, `output_path`, `history_limit`).
- **Add** 5 bash scripts under `.github/actions/fetch-trakt/scripts/` (`validate-inputs.sh`, `http.sh`, `fetch-history.sh`, `fetch-posters.sh`, `build-json.sh`), all `chmod +x` (committed as mode `100755`).
- **Swap** `fetch-daily.yml` watching step: `ggfevans/trakt-json-bourne@79005a2...` → `./.github/actions/fetch-trakt`. Inputs block unchanged.

## Behavior preserved (pure relocation)

- No Node, public client-ID auth (no OAuth, no client secret).
- `posters_status` action output wired via `id: posters` + `value: ${{ steps.posters.outputs.status }}` — emits `ok` / `skipped` / `partial` / `error`.
- jq dedup: group by movie/show, keep most recent watch per show (one row per show, not per episode).
- Episode title format `Show Title — S01E03` with zero-pad.
- 0.25s delay between TMDB calls.
- 429 backoff with `2^attempt` retries; `--connect-timeout` retry on `000` status.
- Single Trakt history call capped by `history_limit` (no pagination).
- `TRAKT_TMPDIR` derives from `${{ runner.temp }}/trakt-${{ github.run_id }}` and is cleaned up via `if: always()` step.

## Security pass (per `secure-coding` skill)

Scope: NEW exposures from the relocation only — source is byte-identical to upstream `ggfevans/trakt-json-bourne@79005a2`.

| Surface | Finding |
| --- | --- |
| Command injection (`curl`, `jq`) | All vars quoted; `$TRAKT_USERNAME`, `$TMDB_API_KEY`, `$TRAKT_HISTORY_LIMIT` are regex-validated in `validate-inputs.sh` before use. No new exposure. |
| Secret handling (`trakt_client_id`, `tmdb_api_key`) | Passed via step `env:`, not interpolated into shell strings. GitHub auto-masks. No new exposure. |
| HTTP redirect handling | `curl -sL --max-redirs 3 --max-time 30 --connect-timeout 10` against fixed HTTPS hosts (`api.trakt.tv`, `api.themoviedb.org`). Inherited from source. No new exposure. |
| Path traversal (`output_path`) | `validate_output_path` does `realpath -m` then prefix-checks against `$GITHUB_WORKSPACE`. Solid. No new exposure. |
| Log leakage of secrets | Scripts log username, counts, and progress only — never the client ID or API key. TMDB API key sent only in HTTPS query string to TMDB. No new exposure. |

**Verdict: no new exposures.**

## Acceptance criteria

- [x] `.github/actions/fetch-trakt/action.yml` exists with same inputs as current external action
- [x] All 5 bash scripts copied into `.github/actions/fetch-trakt/scripts/`
- [x] `fetch-daily.yml` updated to `uses: ./.github/actions/fetch-trakt`
- [x] `npm run build` passes locally (Astro build OK)
- [x] `posters_status` action output preserved and wired
- [ ] `workflow_dispatch`: `src/data/watching.json` shape matches pre-migration; `WatchWidget.astro` and `/watch` page render unchanged — verified post-merge by orchestrator

Fixes #561
Refs #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented new GitHub Action to fetch Trakt watch history data and export to JSON format
  * Added optional TMDB poster metadata enrichment capability  
  * Transitioned from external to internal action for improved reliability and control

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Move Trakt history fetching into a local GitHub action and add safer input checks**

### What Changed
- The Trakt history fetch now runs from a local action in this repo instead of an external dependency.
- Inputs are checked before running so invalid usernames, bad history limits, invalid TMDB keys, and output paths outside the workspace are rejected early.
- Poster fetching still remains optional: it is skipped when no TMDB key is provided, and the action now reports whether poster enrichment succeeded, was skipped, or only partly succeeded.
- The generated JSON still includes recent watches, month counts, and poster links when available.

### Impact
`✅ Fewer failures from invalid Trakt input`
`✅ Safer JSON output file location`
`✅ Clearer poster enrichment status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
