### PR TITLE
chore: address inherited bot findings on migrated fetchers (#581)

### DIFF
--- a/.github/actions/fetch-hardcover/scripts/validate-inputs.sh
+++ b/.github/actions/fetch-hardcover/scripts/validate-inputs.sh
@@ -32,7 +32,7 @@ validate_output_path() {
   elif resolved="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1" 2>/dev/null)"; then
     :
   else
-    resolved="$(cd "$(dirname "$1")" 2>/dev/null && pwd)/$(basename "$1")"
+    resolved="$(cd "$(dirname "$1")" 2>/dev/null && pwd -P)/$(basename "$1")"
   fi
   if [ -n "${GITHUB_WORKSPACE:-}" ]; then
     if [[ "$resolved" != "${GITHUB_WORKSPACE}"/* ]]; then

--- a/.github/actions/fetch-steam/src/index.js
+++ b/.github/actions/fetch-steam/src/index.js
@@ -201,8 +201,15 @@ async function run() {
     const steamId = core.getInput('steam_id', { required: true });
     const outputPath = core.getInput('output_path') || 'src/data/gaming.json';
     const includeFree = core.getInput('include_free_games') !== 'false';
-    const recentCount = parseInt(core.getInput('recent_count') || '10', 10);
-    const dailyLogDays = parseInt(core.getInput('daily_log_days') || '90', 10);
+    const parsePositiveInt = (name, raw, max) => {
+      const n = parseInt(raw, 10);
+      if (!Number.isFinite(n) || n < 1 || (max && n > max)) {
+        throw new Error(`Invalid ${name}: '${raw}' (expected positive integer${max ? ` <= ${max}` : ''})`);
+      }
+      return n;
+    };
+    const recentCount = parsePositiveInt('recent_count', core.getInput('recent_count') || '10', 50);
+    const dailyLogDays = parsePositiveInt('daily_log_days', core.getInput('daily_log_days') || '90');
 
     core.info(`Fetching Steam data for ID ${steamId}...`);
 

--- a/.github/actions/fetch-trakt/scripts/fetch-history.sh
+++ b/.github/actions/fetch-trakt/scripts/fetch-history.sh
@@ -57,7 +57,7 @@ jq -r '[
   elif .type == "episode" then
     { tmdb_id: (.show.ids.tmdb // empty), media_type: "tv" }
   else empty end
-] | unique_by(.tmdb_id) | .[] | "\(.tmdb_id) \(.media_type)"' \
+] | unique_by([.media_type, .tmdb_id]) | .[] | "\(.tmdb_id) \(.media_type)"' \
   "$TRAKT_TMPDIR/history-response.tmp" > "$TRAKT_TMPDIR/tmdb-ids.txt" 2>/dev/null || true
 
 TMDB_COUNT=$(wc -l < "$TRAKT_TMPDIR/tmdb-ids.txt" | tr -d ' ')


### PR DESCRIPTION
## **User description**
## Summary
Follow-up to epic #556. Addresses 4 inherited bot findings (CodeAnt + CodeRabbit) that were deferred from the 5 fetcher migrations (#557, #558, #559, #560, #561) to keep each migration PR scoped to "pure relocation".

## Changes

### `.github/actions/fetch-hardcover/scripts/validate-inputs.sh` (1 line)
Fallback path normalization now uses `pwd -P` (physical) instead of `pwd` (logical). Prevents a symlink inside `$GITHUB_WORKSPACE` from making an outside path appear contained, which would have bypassed the workspace-containment check.

### `.github/actions/fetch-steam/src/index.js` (9 lines)
`recent_count` and `daily_log_days` are now validated as positive integers (with `recent_count` bounded at 50). Previously these were `parseInt`-ed without checks:
- `NaN` → `recentCount` would have returned empty list; `dailyLogDays` would have wiped the entire log via `.slice(0, NaN)` truncating to empty.
- Very large `recent_count` → excessive `appdetails` requests.

The validation throws with a clear message at the start of `run()` rather than failing silently downstream.

### `.github/actions/fetch-trakt/scripts/fetch-history.sh` (1 char)
TMDB lookups now dedup by `[media_type, tmdb_id]` instead of `tmdb_id` alone. Fixes the edge case where a movie and TV show sharing the same numeric TMDB ID would collapse into one entry and lose a poster lookup.

## Test plan
- [x] `bash -n` clean on both modified shell scripts
- [x] `node --check` clean on steam index.js
- [x] `npm test` (root) — 19/19 github action tests still pass
- [x] `npm run build` (Astro) — passes
- [ ] After merge: `fetch-daily.yml` dispatch produces unchanged output shape for `gaming.json`, `reading.json`, `watching.json`

## Notes
- No new bot findings expected — these changes ARE the findings being addressed.
- Each fix is mechanical and surgical; no functional change beyond the documented edge cases.

Fixes #581


___

## **CodeAnt-AI Description**
Fix path checks and input validation in migrated fetchers

### What Changed
- Steam fetcher now rejects invalid `recent_count` and `daily_log_days` values up front, instead of silently returning empty results or wiping history
- Trakt history import now keeps movie and TV poster lookups separate when they share the same TMDB ID
- Hardcover output path checks now use the actual filesystem path when falling back, so symlinks inside the workspace can’t hide an out-of-workspace destination

### Impact
`✅ Fewer empty Steam imports`
`✅ Fewer lost poster lookups in Trakt history`
`✅ Safer workspace path checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added comprehensive input validation for Steam action parameters to enforce positive integer values with configurable maximum limits
  * Refined watch history deduplication logic to correctly identify and handle duplicate entries when the same ID appears across different content media types

* **Chores**
  * Enhanced path resolution handling to properly support physical file paths and symbolic link scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->