### PR TITLE
docs: Move widget (Whoop) spec + API research (#553)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ node_modules/
 docs/.claude/
 docs/notes/
 docs/plans/
-docs/research/
 docs/superpowers/
 
 # logs

--- a/docs/research/whoop-api.md
+++ b/docs/research/whoop-api.md
@@ -1,0 +1,281 @@
+# Whoop Developer API — research notes
+
+**Spike deliverable for [#563](https://github.com/ggfevans/gvns.ca/issues/563).**
+**Date:** 2026-05-19
+**Sources:** [Whoop developer docs](https://developer.whoop.com/docs/introduction) — specifically [OAuth 2.0](https://developer.whoop.com/docs/developing/oauth), [v1→v2 migration](https://developer.whoop.com/docs/developing/v1-v2-migration), [Workout data type](https://developer.whoop.com/docs/developing/user-data/workout), and [Pagination](https://developer.whoop.com/docs/developing/pagination).
+
+This document confirms or revises every assumption in `docs/specs/move-widget-whoop-2026-05.md` §4–5 against the live Whoop docs. Where the spec is wrong, this doc is right.
+
+---
+
+## 1. Headline corrections to the spec
+
+| Spec assumption | Reality | Impact |
+|---|---|---|
+| Workouts endpoint is `…/developer/v1/activity/workout` | **`…/v2/activity/workout`** — v1 is fully deprecated, no longer supported; v2 only going forward | Fetch script uses v2 paths. |
+| Workout `id` is a UUID string | Confirmed for v2 (was `long` in v1) | Data contract unchanged. |
+| Spec needs a hand-maintained `scripts/whoop-sports.json` lookup table | **Not needed.** v2 returns `sport_name` directly as a string. `sport_id` is the legacy integer enum and will not exist past 2025-09-01 | Delete the lookup file from spec §4.1 and from issue #567 acceptance. |
+| Recovery / sleep / cycle endpoints are separate concerns deferred | **"Recovery activities are included in the Workouts endpoint"** in v2 | We may see `Activity` / `Recovery` entries in the workouts response. Decide whether to filter them out at fetch time. See §3.5. |
+
+Everything else in the spec stands.
+
+---
+
+## 2. Authentication
+
+### 2.1 App registration
+
+App already exists — client ID `e888c435-61b2-4118-a80d-a5f781931fd3`, secret in 1Password. No new dashboard step needed for #566. When the bootstrap runs, set two repo secrets:
+
+- `WHOOP_CLIENT_ID` — `e888c435-61b2-4118-a80d-a5f781931fd3` (not strictly secret — it's exposed to the user's browser during the OAuth redirect — but keeping it as a secret matches the convention)
+- `WHOOP_CLIENT_SECRET` — the value from 1Password
+
+### 2.2 OAuth endpoints (confirmed)
+
+```
+Authorize : https://api.prod.whoop.com/oauth/oauth2/auth
+Token     : https://api.prod.whoop.com/oauth/oauth2/token   (also handles refresh)
+```
+
+### 2.3 Scopes
+
+The OAuth docs reference scopes generically and link to the API spec for the full list. From the migration guide, the v2 scope constants are `READ_WORKOUT`, `READ_SLEEP`, `READ_CYCLES` — string form in OAuth requests is conventionally lowercase-colon (`read:workout`, etc.). For the Move widget v1 we request:
+
+- `read:workout` — required for the `/v2/activity/workout` endpoint
+- `read:profile` — for the User endpoint (currently used only for the future "link to Whoop profile" idea; could drop if we never link out)
+- `offline` — required to receive a refresh token
+
+**Open item for the bootstrap PR (#566):** confirm exact scope string casing during first successful authorize call. Treat lowercase-colon as best-known; adjust if Whoop rejects it.
+
+### 2.4 Token lifecycle — exact mechanics
+
+- **Access tokens**: short-lived. Lifetime returned in `expires_in` (seconds) on every token response. Treat as expiring at `now + expires_in - 60s` to account for clock skew.
+- **Refresh tokens**: single-use. Whoop's docs are explicit: *"the refresh token from the refresh response is now the valid refresh token, and your app must use the new refresh token on the subsequent refresh request."* This validates spec §4.4 — rotate first, persist new tokens before fetching.
+- **Concurrent refresh hazard**: *"the first refresh request that reaches WHOOP will succeed. The second request would fail because the first request invalidates the refresh token."* The `fetch-daily.yml` workflow already has `concurrency: { group: fetch-daily, cancel-in-progress: false }` which prevents this for the cron path, but any manual `workflow_dispatch` run while another is in-flight would clobber. Add a refresh-mutex note to the script's preamble.
+
+### 2.5 Token request shape (confirmed)
+
+Refresh POST body — JSON, matching docs exactly:
+
+```json
+{
+  "grant_type": "refresh_token",
+  "refresh_token": "<previous refresh token>",
+  "client_id": "e888c435-61b2-4118-a80d-a5f781931fd3",
+  "client_secret": "<from 1Password>",
+  "scope": "offline"
+}
+```
+
+Response:
+
+```json
+{
+  "access_token": "<new access token>",
+  "expires_in": 3600,
+  "refresh_token": "<new refresh token — replace immediately>",
+  "scope": "offline read:workout read:profile",
+  "token_type": "bearer"
+}
+```
+
+The docs example shows `expires_in: 3600` — i.e. one-hour access tokens. Confirm on first call; treat as the working assumption.
+
+### 2.6 Revocation
+
+There's a `revokeUserOauthAccess` endpoint if we ever need to disable the integration cleanly. Not needed for v1 of this widget.
+
+---
+
+## 3. Workouts endpoint
+
+### 3.1 Path + auth
+
+```
+GET https://api.prod.whoop.com/v2/activity/workout
+Authorization: Bearer <access_token>
+```
+
+(Note the `v2` prefix is bare — not `/developer/v2`. The legacy pagination doc still shows `/developer/v1/…` in its example, but the migration guide is unambiguous: drop the `/developer` segment going forward.)
+
+### 3.2 Query parameters
+
+- `start` — ISO 8601 timestamp, inclusive lower bound
+- `end` — ISO 8601 timestamp, exclusive upper bound
+- `limit` — page size; endpoint-specific max (check OpenAPI; default works)
+- `nextToken` — opaque cursor for pagination (see §3.4)
+
+### 3.3 Response shape — workout record
+
+Verbatim from the [Whoop Workout data type docs](https://developer.whoop.com/docs/developing/user-data/workout/) sample:
+
+```json
+{
+  "id": "ecfc6a15-4661-442f-a9a4-f160dd7afae8",
+  "v1_id": 1043,
+  "user_id": 9012,
+  "created_at": "2022-04-24T11:25:44.774Z",
+  "updated_at": "2022-04-24T14:25:44.774Z",
+  "start": "2022-04-24T02:25:44.774Z",
+  "end": "2022-04-24T10:25:44.774Z",
+  "timezone_offset": "-05:00",
+  "sport_name": "running",
+  "score_state": "SCORED",
+  "score": {
+    "strain": 8.2463,
+    "average_heart_rate": 123,
+    "max_heart_rate": 146,
+    "kilojoule": 1569.34033203125,
+    "percent_recorded": 100,
+    "distance_meter": 1772.77035916,
+    "altitude_gain_meter": 46.64384460449,
+    "altitude_change_meter": -0.781372010707855,
+    "zone_durations": {
+      "zone_zero_milli": 300000,
+      "zone_one_milli": 600000,
+      "zone_two_milli": 900000,
+      "zone_three_milli": 900000,
+      "zone_four_milli": 600000,
+      "zone_five_milli": 300000
+    }
+  },
+  "sport_id": 1
+}
+```
+
+Key fields for the widget:
+
+- **`id`** — UUID, primary key for dedupe.
+- **`start`, `end`** — both required, ISO timestamps. Duration = `end - start`. Don't compute from `created_at` — that's when Whoop ingested the activity, not when it happened.
+- **`timezone_offset`** — display in user's local zone if we ever want "this morning's BJJ" framing. v1 of the widget can ignore.
+- **`sport_name`** — string, lowercase (`"running"`, `"jiu jitsu"`, etc.). We may want to title-case for display, or maintain a tiny presentation map for special cases (`"jiu jitsu"` → `"Jiu-jitsu"`, `"hiit"` → `"HIIT"`).
+- **`score_state`** — `SCORED` / `PENDING_SCORE` / `UNSCORABLE`. **Only show in widget when `SCORED`.** Pending or unscorable workouts have no `score` object and can't render strain.
+- **`score.strain`** — float, 0–21 logarithmic. Render to one decimal place per spec §3.4.
+
+Fields we deliberately ignore for v1: `average_heart_rate`, `max_heart_rate`, `kilojoule`, `percent_recorded`, `distance_meter`, `altitude_*`, `zone_durations`. They're available if we want them later on `/move`.
+
+### 3.4 Pagination
+
+Response envelope (from docs):
+
+```json
+{
+  "records": [ /* workout objects */ ],
+  "next_token": "eyIkIjoib0AxIiwibyI6MTB9"
+}
+```
+
+Iterate until `next_token` is empty string. We're capping at 30 entries in `whoop.json` so one page should almost always suffice — but the script should still handle pagination correctly for the first-run backfill (last 30 days might span multiple pages on heavy training schedules).
+
+### 3.5 Decision: filter out non-workout activities
+
+v2 returns recovery activities through the workouts endpoint. The sport_name values likely include things like `"Activity"` (sport_id -1) for generic, plus things like `"Meditation"`, `"Ice Bath"`, `"Stretching"`, `"Sauna"` from the v1 sport-id table that look like recovery, not training. For the headline "latest workout" framing, those would be noise.
+
+**Recommendation:** during the fetch script, filter the response down to a sport allowlist for the headline / widget. Keep the full unfiltered list available in `whoop.json` for `/move` if we want to surface recovery activities there later.
+
+Initial allowlist (training-coded sports — refine based on what the user's account actually returns):
+
+```js
+const TRAINING_SPORTS = new Set([
+  "running", "cycling", "rowing", "swimming",
+  "weightlifting", "powerlifting", "functional fitness", "hiit",
+  "jiu jitsu", "martial arts", "boxing", "kickboxing", "wrestling",
+  "rock climbing", "hiking/rucking", "cross country skiing",
+  "strength trainer", "spin", "elliptical", "stairmaster",
+  "yoga", "pilates", "barre", "f45 training",
+  // ...etc — expand on first-run review
+]);
+```
+
+Out: meditation, ice bath, sauna, massage, stretching, air compression, percussive massage, dog walking, etc.
+
+Mark this list as a `// TUNE ME` block in the fetch script — refine after a week of real data.
+
+---
+
+## 4. Other relevant endpoints (not used in v1)
+
+For completeness, in case scope expands later:
+
+| Endpoint | Purpose | Required scope |
+|---|---|---|
+| `GET /v2/cycle` | Daily cycle (cumulative strain, kilojoules, HR) | `read:cycles` |
+| `GET /v2/recovery` | Morning recovery score, HRV, RHR | `read:recovery` |
+| `GET /v2/activity/sleep` | Sleep duration, efficiency, stages | `read:sleep` |
+| `GET /v2/user/profile/basic` | First name, last name, email | `read:profile` |
+| `GET /v1/activity-mapping/{activityV1Id}` | Migration-only: v1 ID → v2 UUID | none specific |
+
+Webhooks exist in v2 with UUID payloads for `workout.updated/deleted`, `sleep.updated/deleted`, `recovery.updated/deleted`. If we ever want near-realtime widget updates we'd add a Cloudflare Workers webhook receiver — out of scope for the current epic.
+
+---
+
+## 5. Rate limiting
+
+The docs reference an [API Rate Limiting](https://developer.whoop.com/docs/developing/rate-limiting) page (not fetched during this spike — flag as residual unknown). Given the fetch script runs once daily and makes ≤2 calls (refresh + workouts), rate limits are extremely unlikely to bite. Verify the exact limits during PR for #567 so we can document them in the script preamble.
+
+---
+
+## 6. Recommended sample `whoop.json` shape
+
+Aligned to the data contract in spec §3.3, but post-v2-correction (no `sportId` field — `sport_name` only):
+
+```json
+{
+  "lastUpdated": "2026-05-19T03:00:00.000Z",
+  "profile": {
+    "profileUrl": "https://www.whoop.com/"
+  },
+  "recentWorkouts": [
+    {
+      "id": "ecfc6a15-4661-442f-a9a4-f160dd7afae8",
+      "sport": "Jiu-jitsu",
+      "sportRaw": "jiu jitsu",
+      "start": "2026-05-18T18:00:00.000Z",
+      "end": "2026-05-18T18:47:00.000Z",
+      "durationMinutes": 47,
+      "strain": 14.2,
+      "scoreState": "SCORED"
+    }
+  ]
+}
+```
+
+Fields:
+
+- `sport` — display-ready string (title-cased + special-case map). What the widget renders.
+- `sportRaw` — Whoop's lowercase value, kept for debugging / future filter changes.
+- `durationMinutes` — pre-computed (rounded) so the widget doesn't need to do date math.
+- `scoreState` — kept so the widget knows whether `strain` is real or a pending fill.
+
+Workouts with `scoreState !== "SCORED"` should still appear in the array, but the widget renders them as `(pending score)` rather than `strain 14.2`.
+
+---
+
+## 7. Implementation notes for #566 (bootstrap) and #567 (fetch)
+
+### Bootstrap (#566)
+
+- Client ID is already provisioned — script can hard-code it as a constant or read from env. Prefer env for portability across users.
+- Redirect URL needs to be registered in the Whoop dashboard before the first bootstrap run. `http://localhost:8910/callback` won't work because Whoop's docs show `https://` or app-scheme URLs only. **Verify whether Whoop accepts `http://localhost` for development.** If not, route through a temporary public URL (ngrok, or a one-time Cloudflare quick tunnel). This is the one residual unknown that could bite during bootstrap.
+- After bootstrap success, the script should print three `gh secret set` commands ready to copy.
+
+### Fetch (#567)
+
+- **No `whoop-sports.json` lookup table needed.** Strike that line item from the issue. Build a tiny presentation map directly in the fetch script for known special cases (`"jiu jitsu"` → `"Jiu-jitsu"`, `"hiit"` → `"HIIT"`, `"f45 training"` → `"F45 Training"`, etc.).
+- Filter the workouts array via the movement-sport allowlist (§3.5) before writing to JSON.
+- On first run (no existing `whoop.json` or no `lastUpdated`): fetch last 30 days.
+- On subsequent runs: fetch from `lastUpdated - 24h` to now (the 24h buffer catches late-syncing workouts).
+- Dedupe on `id`, sort by `start` descending, cap to 30 entries.
+- Always `JSON.stringify(data, null, 2)` so the committed file is diff-friendly.
+
+---
+
+## 8. Residual unknowns to verify during implementation
+
+1. **Exact scope string casing** (`read:workout` vs `READ_WORKOUT` vs something else). Confirm on first authorize call.
+2. **Rate limit numbers.** Likely irrelevant for daily polling but document in script header.
+3. **Redirect URL — does Whoop accept `http://localhost`?** Critical for bootstrap UX. If not, use a Cloudflare quick tunnel or similar for the one-time flow.
+4. **Whether `sport_name` for Brazilian Jiu-Jitsu is `"jiu jitsu"` or `"jiu-jitsu"` or `"brazilian jiu-jitsu"`.** Inspect first real response and update the presentation map.
+5. **Behaviour when `score_state` is `PENDING_SCORE`** — does the score object exist with nulls, or is it omitted entirely? Affects widget render logic.
+
+None of these are blockers for landing the issue — they're things to confirm-and-document during the implementation PRs.

--- a/docs/specs/move-widget-whoop-2026-05.md
+++ b/docs/specs/move-widget-whoop-2026-05.md
@@ -1,0 +1,265 @@
+# Move widget (Whoop integration) — #553 spec
+
+**Status:** Spec, awaiting implementation
+**Drafted:** 2026-05-19
+**Revised:** 2026-05-19 (post-API-research) — corrected to Whoop **v2** API paths, removed `whoop-sports.json` (v2 returns `sport_name` directly), added movement-sport allowlist (recovery activities now share the workouts endpoint). See `docs/research/whoop-api.md`.
+**Replaces:** the one-line stub on issue [#553](https://github.com/ggfevans/gvns.ca/issues/553)
+**Related work:** in-flight consolidation of the `*-json-bourne` sibling repos into in-repo fetch scripts. This integration is the **first instance** of the new in-repo pattern, so the script + workflow shape it establishes should be reusable when the existing fetchers (steam / github / hardcover / listenbrainz / trakt) are migrated.
+
+---
+
+## 1. Decision summary
+
+| Question | Decision |
+|---|---|
+| What does the widget show? | **Latest workout, headline metric.** Single signal per cell: `sport · duration · strain`. Example: `BJJ · 47 min · strain 14.2`. Optimised for the compact home-strip cell; on `/now` the same component renders the same headline at full size. |
+| Name + colour token | **`MoveWidget`** consuming a new **P6 crimson** palette token. Verb naming matches Read / Listen / Watch / Code / Write. New token avoids collision with the five claimed accents and gives the activity its own identity rather than borrowing P2 rose (already "read"). |
+| Where it appears | **Home widget strip** (added as 6th cell, grid expands from 5-up → 6-up) · **`/now` bento** (always rendered) · **dedicated `/move` page** (parallel to `/code`, `/read`, `/listen`, `/watch` — workout list + per-day strain heatmap). |
+| Data pipeline | **In-repo Node script + GitHub Actions workflow.** No `whoop-json-bourne` sibling repo. `scripts/fetch-whoop.mjs` writes `src/data/whoop.json` on a daily cron; `scripts/refresh-whoop-token.mjs` rotates the OAuth refresh token on a separate schedule (Whoop refresh tokens are single-use, so the fetch script also handles per-run rotation — see §4.4). Matches the consolidated direction the other fetchers are moving toward. |
+| OAuth scopes requested | `read:workout` (required) · `read:profile` (for the link target) · `offline` (refresh tokens). **Deliberately not requesting** `read:recovery`, `read:cycles`, `read:sleep` for v1 — keeps the JSON small and the privacy surface minimal. Easy to add later. |
+
+---
+
+## 2. Goal & non-goals
+
+**Goal.** Surface the most recent movement session as a glanceable signal across the home strip, `/now` bento, and a dedicated `/move` activity page. Match the visual + data treatment used by the other activity widgets so the addition feels like a sixth peer, not a special case.
+
+**Non-goals (this round).**
+
+- **Recovery + sleep + cycles data.** Whoop's signature paired narrative (recovery % + strain) is deliberately deferred. Adding the scopes is cheap later; deciding what they *render as* on the public site is the work.
+- **HRV / RHR / heart-rate detail.** Personal-medical surface; defer until there's a clear use.
+- **Workout drill-down pages.** Each workout is a row, not a page. No `/move/<workout-id>/` routes.
+- **Live data on page load.** Same build-time data freshness as the other widgets — daily cron, JSON committed to repo, no client fetch.
+- **Editing past workouts via CMS.** Read-only from the public site's perspective. Workouts are source-of-truth in Whoop.
+
+---
+
+## 3. Widget design — `src/components/widgets/MoveWidget.astro`
+
+### 3.1 Compact (home strip)
+
+Header label `MOVE` · primary text: latest workout sport name (Inter 500, 11px) · secondary subtitle: `47 min · strain 14.2` (Inter 400, 10px, muted). Whole cell is a link to `/move`. Border-top 2px P6 crimson. Empty state: `No recent sessions.`
+
+### 3.2 Full (`/now` bento, `/move` page header)
+
+Same component, `compact={false}`. Renders inside `.gvns-widget` shell with `border-left-color: var(--colour-p6-crimson)`. Adds: relative time (`time` element with `relativeTime()`), `View movement →` link to `/move`. Empty state: `No sessions logged yet.`
+
+Visual reference: `GameWidget.astro` is the closest sibling — same shape, same affordances, same empty/error handling.
+
+### 3.3 Data contract
+
+```ts
+interface WorkoutEntry {
+  id: string;                  // Whoop workout id (UUID, v2)
+  sport: string;               // display-ready, e.g. "Jiu-jitsu" (title-cased + special-cases)
+  sportRaw: string;            // Whoop's lowercase string, e.g. "jiu jitsu" (debugging / filter changes)
+  start: string;               // ISO timestamp
+  end: string;                 // ISO timestamp
+  durationMinutes: number;     // derived from start/end
+  strain: number;              // 0–21, one decimal (score.strain) — only meaningful when scoreState === "SCORED"
+  scoreState: "SCORED" | "PENDING_SCORE" | "UNSCORABLE";
+}
+
+interface WhoopData {
+  lastUpdated: string | null;  // ISO; null if first run failed
+  profile?: { profileUrl?: string }; // Whoop has no public profile URL; falls back to whoop.com
+  recentWorkouts: WorkoutEntry[]; // sorted newest-first, capped to 30
+}
+```
+
+The widget reads `data.recentWorkouts[0]` for the headline. The `/move` page uses the full list (§5).
+
+### 3.4 Strain rendering rule
+
+Strain is a 0–21 logarithmic scale (Whoop convention). Render to one decimal place (`14.2`). Don't render `/21` or a coloured indicator in the compact view — the cell is too tight. The `/move` page (§5) can add a small horizontal strain bar per row.
+
+---
+
+## 4. Data pipeline — in-repo
+
+### 4.1 Files
+
+| File | Action |
+|---|---|
+| `scripts/fetch-whoop.mjs` | **New.** Node ESM script. Reads `WHOOP_ACCESS_TOKEN` + `WHOOP_REFRESH_TOKEN` from env, fetches latest workouts, writes `src/data/whoop.json`. Rotates both tokens back to GH secrets on success (refresh tokens are single-use). |
+| `scripts/refresh-whoop-token.mjs` | **New, optional.** Standalone refresh script following the `refresh-threads-token.mjs` pattern (incl. failure-as-issue reporter). Useful when the fetch script hasn't run for a while and tokens are close to expiry. |
+| `scripts/whoop-auth-bootstrap.mjs` | **New.** One-time local utility to walk through Whoop's OAuth flow (browser redirect → code → first refresh token). Run once locally, `gh secret set` the result, never touch again unless the refresh chain breaks. |
+| ~~`scripts/whoop-sports.json`~~ | **Dropped post-research.** Whoop v2 returns `sport_name` directly; the v1 `sport_id` enum is being phased out 2025-09-01. The fetch script will keep a tiny inline presentation map for special cases (`"jiu jitsu"` → `"Jiu-jitsu"`, `"hiit"` → `"HIIT"`, etc.) — no external lookup needed. |
+| `.github/workflows/fetch-daily.yml` | **Edit.** Add a `whoop` step calling `node scripts/fetch-whoop.mjs`. Reuse the existing `commit-via-pr` flow. `continue-on-error: true` so a Whoop outage doesn't fail the whole daily fetch. |
+| `src/data/whoop.json` | **New.** Generated artefact. Committed (matches the pattern of `gaming.json`, `github.json`, etc.). |
+
+### 4.2 OAuth flow
+
+Whoop uses OAuth2 with the authorization-code grant + refresh tokens. The flow:
+
+1. **Bootstrap (one-time, local).** Run `node scripts/whoop-auth-bootstrap.mjs`. Script:
+   - Opens browser to Whoop's authorize URL with the chosen scopes (`read:workout`, `read:profile`, `offline`).
+   - Listens on `localhost:8910/callback` for the redirected `code`.
+   - Exchanges `code` → `{ access_token, refresh_token, expires_in }`.
+   - Prints the values; user pipes them into `gh secret set WHOOP_ACCESS_TOKEN` and `gh secret set WHOOP_REFRESH_TOKEN`.
+2. **Daily fetch (CI).** `scripts/fetch-whoop.mjs` runs:
+   - Always refresh first (cheap, ~200ms; means the access token is fresh for the fetch and we exercise refresh every day, catching breakage early).
+   - Fetch workouts since the last `lastUpdated` (or last 30 days on first run).
+   - Merge with existing `whoop.json`, dedupe on `id`, sort newest-first, cap at 30 entries.
+   - Write `src/data/whoop.json`.
+   - **Rotate tokens.** Pipe the new `access_token` + `refresh_token` to `gh secret set` (stdin, to keep them out of argv / logs / shell history — same pattern as `refresh-threads-token.mjs`).
+3. **Failure surfacing.** On any error, open or comment on a `[whoop-auth] …` issue (mirrors the Threads pattern). Don't fail the whole `fetch-daily.yml` run — `continue-on-error: true` on the step.
+
+### 4.3 Why "always refresh"
+
+Whoop's access tokens last 1 hour; refresh tokens are single-use and rotate on every refresh call. The cleanest model is: refresh → fetch → save both new tokens. This way:
+
+- We never have a stale access token at fetch time.
+- The refresh chain is exercised daily, so if Whoop changes the refresh flow we find out within 24h, not in 60 days.
+- A separate `refresh-whoop-token.mjs` exists only as a manual recovery tool, not a cron.
+
+### 4.4 Single-use refresh token gotcha
+
+Because refresh tokens rotate, **the script must persist the new refresh token back to the secret before exiting, even if the subsequent fetch fails.** Sequence:
+
+1. Refresh → get new `{access, refresh}`.
+2. **`gh secret set WHOOP_REFRESH_TOKEN` immediately**, before anything else can fail.
+3. Then `gh secret set WHOOP_ACCESS_TOKEN`.
+4. Then fetch + write JSON.
+
+If we fetch first and the fetch errors, the old refresh token is already invalidated by Whoop's side — we'd lose the chain and have to re-bootstrap. The "rotate first" order avoids this.
+
+### 4.5 Endpoint reference (confirmed against live docs 2026-05-19)
+
+- **Authorize:** `https://api.prod.whoop.com/oauth/oauth2/auth`
+- **Token / refresh:** `https://api.prod.whoop.com/oauth/oauth2/token`
+- **Workouts collection (v2):** `https://api.prod.whoop.com/v2/activity/workout` (paginated via `next_token`; `start`/`end` query params accept ISO timestamps; `limit` controls page size)
+
+Full response shape + field-by-field notes live in `docs/research/whoop-api.md` §3. Reference that doc rather than re-deriving fields. Pin the script preamble to "v2 schema confirmed 2026-05-19" so future-us knows when to revisit.
+
+### 4.6 Movement-sport allowlist
+
+Whoop v2 returns recovery activities (meditation, ice bath, sauna, massage, etc.) through the workouts endpoint alongside actual training sessions. For the headline "latest workout" framing on the home strip and `/now`, those are noise.
+
+The fetch script filters via an inline allowlist before writing `whoop.json`. Initial set (refine after first week of real data):
+
+```
+running, cycling, rowing, swimming, weightlifting, powerlifting,
+functional fitness, hiit, jiu jitsu, martial arts, boxing,
+kickboxing, wrestling, rock climbing, hiking/rucking,
+strength trainer, spin, elliptical, stairmaster,
+yoga, pilates, barre, f45 training, …
+```
+
+Excluded: meditation, ice bath, sauna, massage therapy, air compression, percussive massage, stretching, dog walking, etc. Marked `// TUNE ME` in the script so it's findable.
+
+The `/move` page (§5) can optionally surface recovery activities in a separate section — out of scope for v1.
+
+---
+
+## 5. `/move` page — `src/pages/move/index.astro`
+
+Light first cut, modelled on `/code` and `/listen`. Full design can iterate; this section sets the scope.
+
+### 5.1 Layout
+
+1. **Page header** — `<h1>Move</h1>` left, "Updated DD Month YYYY" mono right (sourced from `whoop.json` `lastUpdated`).
+2. **Headline row** — `MoveWidget` (full variant) at the top, full-width.
+3. **Strain heatmap** — per-day max strain over the last 90 days, rendered as a contribution-style grid. Reuses `ContributionHeatmap` semantics if practical (it currently expects GitHub-shaped data — extracting a generic heatmap is a maybe, see §7).
+4. **Recent workouts list** — vertical list of `recentWorkouts`, one row each: sport name, ISO date, duration, strain. Hairline divider between rows. No avatars/icons.
+5. **Empty state** — `No sessions logged yet. <a href="https://whoop.com">whoop.com</a>` if `recentWorkouts` is empty.
+
+### 5.2 Breadcrumb + meta
+
+- Breadcrumb: Home → Move.
+- Title: `Move`.
+- Description: short string in `src/utils/site.ts` (e.g. `SITE_MOVE_DESCRIPTION`). Not in the BIO; that stays static per `feedback_gvns_bio_static`.
+- Accent: P6 crimson throughout.
+
+### 5.3 Files
+
+| File | Action |
+|---|---|
+| `src/pages/move/index.astro` | **New.** Reads `src/data/whoop.json`, renders header + widget + heatmap + list. |
+| `src/components/WorkoutList.astro` | **New.** Section wrapper. Mirrors `BookList.astro` shape. |
+| `src/components/WorkoutRow.astro` | **New.** One row. Mirrors `BookCard.astro`'s compact density. |
+| `src/components/StrainHeatmap.astro` | **New** (or generalise `ContributionHeatmap`). 90-day grid, P6 crimson scale. |
+| `src/components/Header.astro` | **Edit.** Add `Move` to the nav links (or omit — see §7). |
+
+---
+
+## 6. Design system — P6 crimson token
+
+### 6.1 Token
+
+| Token | Light | Dark |
+|---|---|---|
+| `--colour-p6-crimson` | `#dc143c` (TBD — see §7) | `#dc143c` (TBD) |
+| `--colour-p6-crimson-hover` | derive 8% lighter | derive 8% lighter |
+
+Add to `src/styles/global.css` alongside P1–P5. Update any shared gradient that enumerates the palette (`--gvns-activity-gradient` in `global.css`, consumed by the masthead stripe + footer gradient line) to **6 stops** instead of 5, hard stops at 16.6 / 33.3 / 50 / 66.6 / 83.3 %.
+
+### 6.2 Audit of consumers
+
+- `ActivityBar.astro` — reads the gradient variable, no change beyond the variable update.
+- `Header.astro` masthead stripe — same.
+- `Footer.astro` 80×2px gradient line — same.
+- Any existing P1–P5 enum-style references in components → grep for `--colour-p1-` through `--colour-p5-` and confirm no code relies on a 5-stop assumption.
+
+### 6.3 Why crimson, not Whoop-brand red
+
+Whoop's brand red is roughly `#FF0026` — saturated, very close to P2 rose. Pulling the value down to a crimson (`#dc143c` range) puts visible distance between this widget and "read" on the home strip, and reads less product-branded. Open to a riff (§7).
+
+---
+
+## 7. Open questions
+
+1. **Exact P6 hex.** `#dc143c` is a placeholder. Worth dropping P2 rose, the candidate P6, and the existing palette into a swatch grid before PR 1 lands. Crimson vs deeper burgundy vs orange-leaning — small choice, big visual.
+2. **Generalise `ContributionHeatmap` or build `StrainHeatmap` standalone?** GitHub-shaped vs strain-shaped data differs (continuous score vs discrete count). Could go either way; defer the call until PR 4.
+3. **Add `Move` to the top-nav?** The other activity pages (`/read`, `/listen`, `/watch`, `/code`) aren't in the top-nav — they're reached via `/now` widget links. Consistency says don't add. But "Move" being net-new might warrant a launch nudge for the first month. Decide at PR 5.
+4. **Sport-name display mapping.** v2 returns `sport_name` directly — no lookup table. The fetch script keeps a small inline `SPORT_DISPLAY_MAP` for special cases (`jiu jitsu` → `Jiu-jitsu`, `hiit` → `HIIT`, etc.) and title-cases the rest. Log unseen `sport_name` values as warnings so the map + the movement-sport allowlist stay current.
+5. **Display when the latest workout is ≥7 days old.** The compact cell saying "Jiu-jitsu · 47 min · strain 14.2" with `time` saying "9 days ago" is slightly awkward. Either show the timestamp prominently in compact, or render an empty state after N days idle. Suggest: 14-day cutoff to empty state.
+6. **Privacy review.** Workout names + strain + duration are fine. The sport list reveals BJJ days, gym days, etc. — also fine. Add a `.privacy.md` note to `docs/` if anything subtler shows up during implementation.
+
+---
+
+## 8. Acceptance criteria
+
+The integration ships when:
+
+1. **Data pipeline.** `scripts/fetch-whoop.mjs` runs cleanly in CI on a daily cron, fetches workouts via Whoop's v2 API, writes a valid `src/data/whoop.json` matching §3.3, and rotates both access + refresh tokens back to GH secrets on every run (refresh first, before fetch).
+2. **Bootstrap script.** `node scripts/whoop-auth-bootstrap.mjs` walks through Whoop's OAuth flow locally and prints the two tokens for `gh secret set`. Documented in a comment block at the top of the script.
+3. **Failure surfacing.** Any fetch / refresh failure opens or comments on an existing `[whoop-auth] …` GitHub issue (mirrors `refresh-threads-token.mjs`).
+4. **Widget — compact.** `MoveWidget.astro` (compact mode) renders inside the home widget strip. Strip grid expands to 6-up (`.gvns-activity-grid` breakpoints updated: 6 desktop / 3 tablet / 2 mobile / 1 narrow). Empty state reads `No recent sessions.`
+5. **Widget — full.** Same component (`compact={false}`) renders inside the `/now` bento. Sits in a single cell; existing bento layout adapts (one cell either becomes wide-1×1, or `/now` grows to 7 cells with the responsive plan updated accordingly).
+6. **`/move` page.** Reachable at `/move`. Renders the full `MoveWidget`, a 90-day strain heatmap (P6 crimson scale), and the `recentWorkouts` list. Breadcrumb Home → Move. Description meta string lives in `src/utils/site.ts`.
+7. **P6 crimson token.** `--colour-p6-crimson` + `--colour-p6-crimson-hover` defined in `global.css`. `--gvns-activity-gradient` updated to a 6-stop gradient consumed correctly by the masthead stripe + footer gradient line + any `ActivityBar` instance. No visual regression on existing surfaces.
+8. **No regressions.** `npm run build` clean. Lighthouse on `/`, `/now`, `/move` shows no regression vs current production. No new console warnings.
+9. **Documentation.** Brief note added to `docs/INFRASTRUCTURE.md` (or equivalent) explaining the in-repo fetch + rotate pattern, since this is the first instance. Future fetchers (steam, github, hardcover, listenbrainz, trakt) should be able to use the same shape.
+
+---
+
+## 9. Suggested PR order
+
+PR 1 — **P6 crimson token + gradient update.** `global.css` adds `--colour-p6-crimson` / `--colour-p6-crimson-hover`. `--gvns-activity-gradient` updates to 6 stops. Visual diff on masthead stripe + footer + any `ActivityBar` use. Pure design-system change; no widget yet. Resolves Open Q1 (exact hex).
+
+PR 2 — **Whoop OAuth bootstrap + data pipeline.** `scripts/whoop-auth-bootstrap.mjs` + `scripts/fetch-whoop.mjs` + `scripts/refresh-whoop-token.mjs`. New `whoop` step in `fetch-daily.yml`. `WHOOP_ACCESS_TOKEN` + `WHOOP_REFRESH_TOKEN` set in repo secrets. **First successful `whoop.json` committed** before merging — that's the live integration test.
+
+PR 3 — **`MoveWidget` (compact + full) + home strip integration.** Component lands consuming `whoop.json`. Home grid widens to 6-up. Doesn't touch `/now` or `/move` yet — small PR, easy to review visually.
+
+PR 4 — **`/now` bento integration.** Wire `MoveWidget` (full) into the bento. Update responsive cell plan (6 → 7 cells, decide which cell becomes wide / large).
+
+PR 5 — **`/move` page.** `WorkoutList`, `WorkoutRow`, strain heatmap (decide §7 Q2 here), header + breadcrumb. Optionally add `Move` to top-nav (§7 Q3).
+
+PR 6 — **Documentation + cleanup.** Update `docs/INFRASTRUCTURE.md` with the in-repo fetch pattern; cross-link from `docs/SESSION-START.md`. Add a `docs/specs/` reference back to this file. Mark Open Questions as resolved or moved to follow-up issues.
+
+**Dependency graph:**
+- PR 1 → PR 3 (widget needs the token).
+- PR 2 → PR 3 (widget needs the JSON).
+- PR 3 → PRs 4 & 5 (parallelisable after PR 3).
+- PR 6 last.
+
+**Recommended landing order:** 1 → 2 (parallelisable with 1) → 3 → 4 → 5 → 6.
+
+---
+
+## 10. Notes for future me
+
+- This is the **prototype** for in-repo data fetching. When migrating the existing fetchers (steam / github / hardcover / listenbrainz / trakt) off their sibling repos, the shape established by `fetch-whoop.mjs` + the `fetch-daily.yml` step is the template. Anything weird-but-necessary about Whoop's flow (refresh-first ordering, single-use refresh tokens) is genuinely specific to Whoop and shouldn't propagate.
+- Refresh-token rotation is the riskiest part. The chain breaking means a manual bootstrap re-run. Worth setting a calendar reminder to spot-check the first month.
+- If Whoop ever ships a public webhook (they've teased one), revisit whether daily cron is still the right shape — webhooks would let `/now` reflect a just-finished workout much sooner.


### PR DESCRIPTION
## **User description**
Docs-only PR for the **Move widget (Whoop integration)** epic ([#553](https://github.com/ggfevans/gvns.ca/issues/553)).

## What's here

- **`docs/specs/move-widget-whoop-2026-05.md`** — full implementation spec. Latest-workout headline (`sport · duration · strain`), `MoveWidget` + new P6 crimson token, three surfaces (home strip 6-up, `/now` bento, `/move` page), in-repo fetch pipeline. Includes data contract, OAuth refresh-then-rotate ordering, file-by-file tables, 9 acceptance criteria, suggested PR order.
- **`docs/research/whoop-api.md`** — API research deliverable for [#563](https://github.com/ggfevans/gvns.ca/issues/563). Confirms Whoop's **v2** API (workouts at `/v2/activity/workout`, `sport_name` returned directly so no lookup table, single-use refresh tokens), with a worked-example `whoop.json`.
- **`.gitignore`** — removed `docs/research/` so the research deliverable can be tracked.

## Notes for review

- No code — spec + research only. Implementation lands in child issues #565–#570.
- The spec was reworked from "Train" → "Move" naming; the v1→v2 API corrections from the research spike are folded in (no stale `whoop-sports.json` / v1 references remain).

Part of #553. Completes the deliverable for #563.


___

## **CodeAnt-AI Description**
**Document the Move widget plan and Whoop API research**

### What Changed
- Added a full spec for the new Move widget, including what it shows, where it appears, and the planned `/move` page layout
- Updated the spec to use Whoop v2, remove the old sport lookup file, and account for recovery activities appearing in the workouts feed
- Added research notes confirming the Whoop OAuth flow, workout endpoint shape, pagination, and the single-use refresh token behavior
- Documented the in-repo fetch-and-rotate approach that future data syncs can follow

### Impact
`✅ Clearer Move widget implementation plan`
`✅ Fewer Whoop API integration mistakes`
`✅ Faster follow-up work on data syncs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added technical research documentation and project specifications for internal planning and reference purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->