### PR TITLE
feat: add P6 crimson token + 6-stop activity gradient (#565)

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -33,17 +33,18 @@ Based on the GVNS site spec. Dark-first, light-available. Each activity section 
 | Muted | `zinc-500` | `zinc-500` | Labels, metadata (same both modes) |
 | Subtle | `zinc-600` | `zinc-400` | Timestamps, tertiary |
 
-### Accent Colours (P1–P5)
+### Accent Colours (P1–P6)
 
 Each activity section has a dedicated colour. Maintain this consistently.
 
-| Name | Activity | Dark (500) | Light (600) | BG tint (50) |
-|------|----------|------------|-------------|--------------|
+| Name | Activity | Dark (500) | Light (600/700) | BG tint (50) |
+|------|----------|------------|-----------------|--------------|
 | **Violet** | Code, primary brand | `#8b5cf6` | `#7c3aed` | `#f5f3ff` |
 | **Rose** | Read | `#f43f5e` | `#e11d48` | `#fff1f2` |
 | **Emerald** | Listen | `#10b981` | `#059669` | `#ecfdf5` |
 | **Amber** | Write, Watch | `#f59e0b` | `#d97706` | `#fffbeb` |
 | **Sky** | Status indicators | `#0ea5e9` | `#0284c7` | `#f0f9ff` |
+| **Crimson** | Move (Whoop) | `#dc143c` | `#be123c` | `#fff1f2` |
 
 ### Colour Discipline
 
@@ -55,6 +56,7 @@ Each activity section has a dedicated colour. Maintain this consistently.
 > - Watch → Amber
 > - Write → Amber
 > - Status → Sky
+> - Move → Crimson
 
 ### Interactive States
 

--- a/src/components/ActivityBar.astro
+++ b/src/components/ActivityBar.astro
@@ -1,5 +1,5 @@
 ---
-// Decorative horizontal stripe of the P1-P5 accent palette
+// Decorative horizontal stripe of the P1-P6 accent palette
 ---
 
 <div class="gvns-activity-bar" role="presentation" aria-hidden="true">
@@ -8,6 +8,7 @@
   <span class="gvns-activity-bar__segment gvns-activity-bar__segment--p3"></span>
   <span class="gvns-activity-bar__segment gvns-activity-bar__segment--p4"></span>
   <span class="gvns-activity-bar__segment gvns-activity-bar__segment--p5"></span>
+  <span class="gvns-activity-bar__segment gvns-activity-bar__segment--p6"></span>
 </div>
 
 <style>
@@ -28,4 +29,5 @@
   .gvns-activity-bar__segment--p3 { background: var(--colour-p3-emerald); }
   .gvns-activity-bar__segment--p4 { background: var(--colour-p4-amber); }
   .gvns-activity-bar__segment--p5 { background: var(--colour-p5-sky); }
+  .gvns-activity-bar__segment--p6 { background: var(--colour-p6-crimson); }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,7 +23,7 @@
     --colour-text-muted: #71717a; /* zinc-500 */
     --colour-text-inverse: #0a0a0a; /* zinc-950 — dark text on light backgrounds */
 
-    /* P1-P5 Accent Palette */
+    /* P1-P6 Accent Palette */
     --colour-p1-violet: #8b5cf6; /* violet-500 — code activity */
     --colour-p1-violet-hover: #a78bfa; /* violet-400 */
     --colour-p2-rose: #f43f5e; /* rose-500 — read section */
@@ -34,16 +34,19 @@
     --colour-p4-amber-hover: #fbbf24; /* amber-400 */
     --colour-p5-sky: #0ea5e9; /* sky-500 — status */
     --colour-p5-sky-hover: #38bdf8; /* sky-400 */
+    --colour-p6-crimson: #dc143c; /* crimson — move activity (Whoop) */
+    --colour-p6-crimson-hover: #e63a5c; /* ~8% lighter (HSL L 47% → 55%) */
 
-    /* Activity gradient — 5-stop hard-stop linear gradient using P1–P5.
-       Single source of truth for masthead stripe (PR 3) and footer line (PR 5). */
+    /* Activity gradient — 6-stop hard-stop linear gradient using P1–P6.
+       Single source of truth for masthead stripe and footer line. */
     --gvns-activity-gradient: linear-gradient(
         90deg,
-        var(--colour-p1-violet) 0% 20%,
-        var(--colour-p2-rose) 20% 40%,
-        var(--colour-p3-emerald) 40% 60%,
-        var(--colour-p4-amber) 60% 80%,
-        var(--colour-p5-sky) 80% 100%
+        var(--colour-p1-violet) 0% 16.66%,
+        var(--colour-p2-rose) 16.66% 33.33%,
+        var(--colour-p3-emerald) 33.33% 50%,
+        var(--colour-p4-amber) 50% 66.66%,
+        var(--colour-p5-sky) 66.66% 83.33%,
+        var(--colour-p6-crimson) 83.33% 100%
     );
 
     /* Status surfaces — P5 sky tinted to 0.06 alpha for the "open to work"
@@ -158,6 +161,11 @@
     --colour-accent-hover: var(--colour-p5-sky-hover);
     --colour-link-text: var(--colour-p5-sky-hover);
 }
+[data-accent="p6-crimson"] {
+    --colour-accent-primary: var(--colour-p6-crimson);
+    --colour-accent-hover: var(--colour-p6-crimson-hover);
+    --colour-link-text: var(--colour-p6-crimson-hover);
+}
 [data-accent="neutral"] {
     --colour-accent-primary: var(--colour-accent-neutral);
     --colour-accent-hover: var(--colour-accent-neutral-hover);
@@ -189,6 +197,11 @@
     --colour-accent-primary: #0284c7;
     --colour-accent-hover: #0369a1;
     --colour-link-text: #0284c7;
+}
+:root:not(.dark)[data-accent="p6-crimson"] {
+    --colour-accent-primary: #be123c; /* rose-700 — deeper crimson for 5:1+ on light bg */
+    --colour-accent-hover: #9f1239; /* rose-800 */
+    --colour-link-text: #be123c;
 }
 :root:not(.dark)[data-accent="neutral"] {
     --colour-accent-primary: #52525b;


### PR DESCRIPTION
## **User description**
## Summary

Pure design-system change: introduces a sixth accent palette token (P6 crimson) and widens the shared activity gradient from 5 to 6 stops, in preparation for the Move/Whoop widget landing on the home strip, \`/now\` bento, and \`/move\` page.

- Adds \`--colour-p6-crimson\` (\`#dc143c\`) + \`--colour-p6-crimson-hover\` (\`#e63a5c\`, ~8 % lighter) to \`src/styles/global.css\`.
- Adds matching \`[data-accent="p6-crimson"]\` contextual blocks for dark and light themes — light uses \`#be123c\` / \`#9f1239\` for ≥5:1 contrast on light bg.
- \`--gvns-activity-gradient\` updated to 6 hard stops at 16.66 / 33.33 / 50 / 66.66 / 83.33 %. Auto-picked up by:
  - Header masthead stripe (\`src/components/Header.astro\`) — reads variable, no edit.
  - Footer 80×2px gradient line (\`src/components/Footer.astro\`) — reads variable, no edit.
- \`src/components/ActivityBar.astro\` — currently unused but listed as audit consumer; gains a sixth \`--p6\` segment for consistency.
- \`docs/DESIGN-SYSTEM.md\` — palette table extended to P1–P6; Colour Discipline list adds \`Move → Crimson\`.

## Notes / Open Q

- **Hex (\`#dc143c\`).** Per the spec's Open Q1, this is the placeholder. Deliberately distinct from P2 rose (\`#f43f5e\`) so the two cells don't visually rhyme on the home strip. Easy to iterate during UX mockup work — a single token edit.
- Crimson on light backgrounds uses the deeper \`#be123c\` (\`rose-700\`) shade in the \`[data-accent="p6-crimson"]\` block, matching the existing P1–P5 pattern.
- Old gradient was 5 × 20 % bands; new gradient is 6 × ~16.67 %. Order preserved (P1 → P6 left-to-right); each existing colour shrinks proportionally — flagged as expected per the issue's "the 6th stop only adds, doesn't reshape" framing.

## Test plan

- [x] \`npm run build\` clean.
- [ ] Visual diff on home page: masthead stripe shows 6-band gradient with crimson on the far right.
- [ ] Visual diff on footer: 80px gradient line shows 6-band gradient with crimson on the far right.
- [ ] No regression on any existing \`[data-accent="p1-violet"]\` … \`[data-accent="p5-sky"]\` page (no rule changed for them).
- [ ] \`--colour-p6-crimson\` resolvable from any component via \`var(--colour-p6-crimson)\`.

Closes #565
Part of #553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design system documentation to expand activity accent palette from P1–P5 to P1–P6.

* **Style**
  * Added new Crimson accent color to the design palette.
  * Extended activity bar to display six accent color segments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add a sixth crimson accent and extend the activity stripe**

### What Changed
- Added a new crimson accent for the Move/Whoop section, with matching hover colors for dark and light themes
- Extended the shared activity gradient from five colors to six, so the full activity strip now includes crimson at the end
- Updated the decorative activity bar and design guide to reflect the new sixth accent and its intended use

### Impact
`✅ Clearer Move section branding`
`✅ Consistent six-color activity strip`
`✅ Better color contrast on light pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
