### PR TITLE
feat: add MoveWidget (compact + full) + home strip 6-up (#568)

### DIFF
--- a/src/components/widgets/MoveWidget.astro
+++ b/src/components/widgets/MoveWidget.astro
@@ -1,0 +1,102 @@
+---
+import { relativeTime } from '@utils/format';
+
+interface Props { compact?: boolean; }
+const { compact = false } = Astro.props;
+
+interface WorkoutEntry {
+  id: string;
+  sport: string;
+  sportRaw: string;
+  start: string;
+  end: string;
+  durationMinutes: number;
+  strain: number;
+  scoreState: 'SCORED' | 'PENDING_SCORE' | 'UNSCORABLE' | string;
+}
+
+interface WhoopData {
+  lastUpdated: string | null;
+  profile?: { profileUrl?: string };
+  recentWorkouts: WorkoutEntry[];
+}
+
+let data: WhoopData = { lastUpdated: null, recentWorkouts: [] };
+try {
+  const imported = (await import('../../data/whoop.json')).default as Partial<WhoopData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    profile: imported.profile,
+    recentWorkouts: Array.isArray(imported.recentWorkouts) ? imported.recentWorkouts : [],
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load Whoop data for MoveWidget:', e);
+}
+
+const latest = data.recentWorkouts[0] ?? null;
+const isScored = latest?.scoreState === 'SCORED';
+const strainText = latest && isScored ? `strain ${latest.strain.toFixed(1)}` : '(pending score)';
+const durationText = latest ? `${latest.durationMinutes} min` : '';
+const startedAt = latest?.start && !Number.isNaN(new Date(latest.start).getTime())
+  ? latest.start
+  : null;
+---
+
+{compact ? (
+  <article class="gvns-widget-compact gvns-widget-compact--move">
+    <div class="gvns-widget-compact__label">Move</div>
+    {latest ? (
+      <a href="/move" class="gvns-widget-compact__body gvns-widget-compact__body--stack" aria-label={`Latest workout: ${latest.sport}, ${durationText}, ${strainText}`}>
+        <p class="gvns-widget-compact__title">{latest.sport}</p>
+        <p class="gvns-widget-compact__subtitle">{durationText} · {strainText}</p>
+      </a>
+    ) : (
+      <p class="gvns-widget-compact__empty">No recent sessions.</p>
+    )}
+  </article>
+) : (
+  <article class="gvns-widget gvns-widget--move">
+    <div class="gvns-widget__label">Move</div>
+    {latest ? (
+      <div class="gvns-widget__content">
+        <p class="gvns-widget__detail gvns-widget__detail--bold">{latest.sport}</p>
+        <p class="gvns-widget__meta">{durationText} · {strainText}</p>
+        {startedAt && (
+          <time class="gvns-widget__time" datetime={startedAt}>
+            {relativeTime(startedAt)}
+          </time>
+        )}
+      </div>
+    ) : (
+      <p class="gvns-widget__empty">No sessions logged yet.</p>
+    )}
+    <a href="/move" class="gvns-widget__link">
+      View movement <span aria-hidden="true">&rarr;</span>
+    </a>
+  </article>
+)}
+
+<style>
+  /* P6 Crimson — distinct from P2 Rose (read) so the home strip
+     reads as six discrete activities, not two flavours of pink. */
+  .gvns-widget--move {
+    border-left-color: var(--colour-p6-crimson);
+  }
+
+  .gvns-widget--move .gvns-widget__link:hover {
+    color: var(--colour-p6-crimson);
+  }
+
+  .gvns-widget-compact--move {
+    border-top: var(--border-accent) solid var(--colour-p6-crimson);
+  }
+
+  /* Compact body without poster art — stack title + subtitle vertically,
+     no flex row (matches the no-cover variant used by Watch/Listen
+     when artwork is missing). */
+  .gvns-widget-compact__body--stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import ListenWidget from '@components/widgets/ListenWidget.astro';
 import WatchWidget from '@components/widgets/WatchWidget.astro';
 import CodeWidget from '@components/widgets/CodeWidget.astro';
 import GameWidget from '@components/widgets/GameWidget.astro';
+import MoveWidget from '@components/widgets/MoveWidget.astro';
 import ThreadsWidget from '@components/widgets/ThreadsWidget.astro';
 import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 import { SITE_BIO } from '@utils/site';
@@ -64,6 +65,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         <WatchWidget compact />
         <CodeWidget compact />
         <GameWidget compact />
+        <MoveWidget compact />
       </div>
     </section>
   </main>
@@ -119,7 +121,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   }
   .gvns-activity-grid {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: var(--space-4);
   }
   @media (max-width: 1279px) {


### PR DESCRIPTION
## **User description**
## Summary

Lands the \`MoveWidget\` component and widens the home activity strip from 5-up to 6-up so the new Move cell sits alongside Read / Listen / Watch / Code / Game. Consumes the \`whoop.json\` fixture from #587 (will pick up real data once #566 bootstrap is run and \`fetch-daily.yml\` writes a non-fixture file).

- **\`src/components/widgets/MoveWidget.astro\`** — mirrors \`GameWidget.astro\` structure: two render modes via the \`compact\` prop, reads \`data.recentWorkouts[0]\`, P6 crimson accent.

  - **Compact (home strip):** \`MOVE\` label, sport name, \`47 min · strain 14.2\` subtitle. Whole cell links to \`/move\`. Border-top 2 px P6 crimson. Empty state \`No recent sessions.\` Renders \`(pending score)\` when \`scoreState !== "SCORED"\` (matches spec §3.4 + research §6 nuance).
  - **Full** (used by #569 \`/now\` bento + #570 \`/move\` page header): \`.gvns-widget\` shell, \`border-left-color: var(--colour-p6-crimson)\`, sport + duration + strain + relative time, \`View movement →\` link to \`/move\`. Empty state \`No sessions logged yet.\`

- **\`src/pages/index.astro\`** — widens \`.gvns-activity-grid\` from 5-up to 6-up on desktop. Breakpoint plan: 6 (desktop ≥1280px) / 3 (≤1279px) / 2 (≤1023px) / 1 (≤640px) — matches the existing 5-up cascade, no new breakpoints introduced.

## Notes / Open Q

- **Compact font sizes.** Spec §3.1 calls for 11 px sport / 10 px subtitle. The widget uses the shared \`.gvns-widget-compact__title\` / \`__subtitle\` classes (14 px / 12 px) for consistency with the other compact widgets. Going off-grid for one cell would make it visually distinct in a way that doesn't match the "sixth peer, not a special case" framing from spec §2. Open to dialling down if the UX mockups in #564 confirm the tighter sizes.
- **\`/move\` link.** Currently 404s — the page lands in #570. Acceptable temporary state while shipping the chain incrementally.
- **Visual smoke test:** rendered against the placeholder fixture (\`Jiu-jitsu · 47 min · strain 14.2\`) confirms layout. Will need a second pass once real workouts flow in (sport names of unexpected length, \`(pending score)\` edge case).

## Test plan

- [x] \`npm run build\` clean (19 pages indexed).
- [ ] Visual: home strip shows six cells on desktop, three on tablet, etc.
- [ ] Visual: Move cell sits to the right of Game with a 2 px crimson top border.
- [ ] Click-through from compact cell lands on \`/move\` (will 404 until #570 lands).
- [ ] When \`scoreState !== "SCORED"\`, compact subtitle renders \`(pending score)\` instead of \`strain N.N\`.

Closes #568
Part of #553. Blocked by #565 (P6 token, merged) and #567 (whoop.json fixture, merged). Unblocks #569 and #570.


___

## **CodeAnt-AI Description**
**Add a new Move activity tile to the home page**

### What Changed
- Added a new Move widget to the home activity strip, bringing the activity grid from 5 tiles to 6.
- The new tile shows the latest workout, including sport, duration, and strain, or a clear empty state when no sessions are available.
- The compact home version links to the Move page and shows pending score status when the workout has not been scored yet.
- The larger version shows workout time and includes a direct “View movement” link.

### Impact
`✅ Six activity tiles on the home page`
`✅ Clearer Move status at a glance`
`✅ Cleaner empty-state messaging for workout data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
