### PR TITLE
feat: add MoveWidget to /now bento (#569)

### DIFF
--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -9,6 +9,7 @@ import ListenWidget from "@components/widgets/ListenWidget.astro";
 import WatchWidget from "@components/widgets/WatchWidget.astro";
 import WriteWidget from "@components/widgets/WriteWidget.astro";
 import StatusWidget from "@components/widgets/StatusWidget.astro";
+import MoveWidget from "@components/widgets/MoveWidget.astro";
 import { Content as NowIntroContent, frontmatter as nowIntroFrontmatter } from "../../data/now-intro.md";
 
 const siteUrl = normalizeSiteUrl(Astro.site);
@@ -70,6 +71,9 @@ const breadcrumbJsonLd = toJsonLd(
                 </div>
                 <div class="gvns-now__cell">
                     <WriteWidget />
+                </div>
+                <div class="gvns-now__cell">
+                    <MoveWidget />
                 </div>
                 <div class="gvns-now__cell">
                     <WatchWidget />


### PR DESCRIPTION
## **User description**
## Summary

Wires the \`MoveWidget\` (full variant) into the \`/now\` bento as the 7th cell. Inherits the existing \`.gvns-widget\` shell styles from \`src/pages/now/index.astro\` (no new CSS needed).

## Responsive cell plan

Picked option (b) from the issue — Move slots in as a 1×1 default cell rather than promoting one of the existing cells to wide/large. Reasons:

- Spec §3.2 / §5.1 frame Move as a peer to Write / Watch / Status, all of which are 1×1. Promoting Move to wide/large would over-weight a still-young widget.
- The 6→7 transition fits cleanly into the existing 4-column auto-flow without needing a new \`--medium\` modifier or rebalancing the existing cells.

**Desktop (≥1024px, 4-col grid):**

\`\`\`
Row 1: [ Code (2×2)        ][ Read   (2×1) ]
Row 2: [                    ][ Listen (2×1) ]
Row 3: [ Write ][ Move ][ Watch ][ Status ]
\`\`\`

- Move sits row 3 col 2; Read sits row 1 cols 3–4 — three cells of distance, no shared edge → crimson non-adjacent to rose, per the issue's visual-rhyme constraint.
- Side effect: Move now splits the two amber cells (Write + Watch), which incidentally breaks up the only existing same-accent pair in the bento.

**Tablet (768–1023px, 2-col), mobile (≤640px, 1-col):** auto-flow. No \`--large\` / \`--wide\` modifiers active at these breakpoints, so cells stack in source order:

- Tablet: Move appears row 3 col 1, adjacent to Watch (amber) and Listen (emerald). Not adjacent to Read.
- Mobile: Move is the 5th cell, with Listen / Write between it and Read — non-adjacent.

## Test plan

- [x] \`npm run build\` clean.
- [ ] Visual: \`/now\` desktop shows 4-col grid with Move on row 3 between Write and Watch.
- [ ] Visual: tablet and mobile fall through cleanly with Move not adjacent to Read.
- [ ] Hovering Move cell shows the standard widget shadow + border treatment.

Closes #569
Part of #553. Blocked by #568 (merged).


___

## **CodeAnt-AI Description**
**Add the Move widget to the /now bento grid**

### What Changed
- Added the Move widget as a new 1×1 cell in the `/now` bento layout
- Placed it between Write and Watch so it appears alongside the other smaller widgets in the grid

### Impact
`✅ A new Move section on /now`
`✅ Clearer bento layout on desktop`
`✅ Consistent widget order across screen sizes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
