### PR TITLE
feat: add /move page with workouts list + strain heatmap (#570)

### DIFF
--- a/src/components/StrainHeatmap.astro
+++ b/src/components/StrainHeatmap.astro
@@ -1,0 +1,180 @@
+---
+/**
+ * 90-day strain heatmap — pure Astro/CSS, no JS island.
+ *
+ * Layout: 7 rows (days of week, Mon–Sun) × ~13 columns (calendar weeks).
+ * Each cell is the *max* strain across all workouts that day; days with
+ * no workout render as the empty-level cell.
+ *
+ * Strain is Whoop's 0–21 logarithmic scale. Buckets correspond to the
+ * conventional zones (light / moderate / strenuous / all-out):
+ *
+ *   level 0 : no workout that day              → neutral fill
+ *   level 1 : 0  < strain ≤ 8                  → 25% P6 crimson
+ *   level 2 : 8  < strain ≤ 13                 → 50%
+ *   level 3 : 13 < strain ≤ 17                 → 75%
+ *   level 4 :       strain > 17                → 100%
+ */
+interface Workout {
+  start: string;
+  strain: number;
+  scoreState: string;
+}
+
+interface Props {
+  workouts?: Workout[];
+  days?: number;            // default 90
+}
+
+const { workouts = [], days = 90 } = Astro.props;
+
+function bucketLevel(strain: number): 0 | 1 | 2 | 3 | 4 {
+  if (strain <= 0) return 0;
+  if (strain <= 8) return 1;
+  if (strain <= 13) return 2;
+  if (strain <= 17) return 3;
+  return 4;
+}
+
+// Build a Map<YYYY-MM-DD, maxStrain> from the workouts list.
+const byDay = new Map<string, number>();
+for (const w of workouts) {
+  if (w.scoreState !== 'SCORED') continue;
+  const d = new Date(w.start);
+  if (Number.isNaN(d.getTime())) continue;
+  const key = d.toISOString().slice(0, 10);
+  const prev = byDay.get(key) ?? 0;
+  if (w.strain > prev) byDay.set(key, w.strain);
+}
+
+// Build the cell array: oldest day first → newest day last.
+// Anchor the grid so the rightmost column ends today.
+const today = new Date();
+today.setUTCHours(0, 0, 0, 0);
+
+interface Cell {
+  iso: string;             // YYYY-MM-DD
+  strain: number;
+  level: 0 | 1 | 2 | 3 | 4;
+  isoWeekday: number;       // 1 (Mon) – 7 (Sun)
+}
+
+const cells: Cell[] = [];
+for (let i = days - 1; i >= 0; i -= 1) {
+  const d = new Date(today);
+  d.setUTCDate(today.getUTCDate() - i);
+  const iso = d.toISOString().slice(0, 10);
+  const strain = byDay.get(iso) ?? 0;
+  // Convert JS Sunday=0 → ISO Monday=1 .. Sunday=7
+  const jsDay = d.getUTCDay();
+  const isoWeekday = jsDay === 0 ? 7 : jsDay;
+  cells.push({ iso, strain, level: bucketLevel(strain), isoWeekday });
+}
+
+// Pad the start so the first column aligns to Monday.
+const leadingPad = cells.length > 0 ? (cells[0].isoWeekday - 1) : 0;
+
+const totalScored = workouts.filter((w) => w.scoreState === 'SCORED').length;
+---
+
+<figure class="gvns-strain-heatmap" aria-label={`Strain heatmap over the last ${days} days, ${totalScored} scored workouts`}>
+  <figcaption class="gvns-strain-heatmap__caption">
+    <span>Last {days} days · {totalScored} scored workouts</span>
+    <span class="gvns-strain-heatmap__legend" aria-hidden="true">
+      <span class="gvns-strain-heatmap__legend-label">Less</span>
+      <span class="gvns-strain-heatmap__cell gvns-strain-heatmap__cell--l0"></span>
+      <span class="gvns-strain-heatmap__cell gvns-strain-heatmap__cell--l1"></span>
+      <span class="gvns-strain-heatmap__cell gvns-strain-heatmap__cell--l2"></span>
+      <span class="gvns-strain-heatmap__cell gvns-strain-heatmap__cell--l3"></span>
+      <span class="gvns-strain-heatmap__cell gvns-strain-heatmap__cell--l4"></span>
+      <span class="gvns-strain-heatmap__legend-label">More</span>
+    </span>
+  </figcaption>
+  <div class="gvns-strain-heatmap__grid" role="presentation">
+    {Array.from({ length: leadingPad }).map(() => (
+      <span class="gvns-strain-heatmap__cell gvns-strain-heatmap__cell--pad" aria-hidden="true"></span>
+    ))}
+    {cells.map((c) => (
+      <span
+        class:list={['gvns-strain-heatmap__cell', `gvns-strain-heatmap__cell--l${c.level}`]}
+        title={c.strain > 0 ? `${c.iso} · strain ${c.strain.toFixed(1)}` : `${c.iso} · no workout`}
+      ></span>
+    ))}
+  </div>
+</figure>
+
+<style>
+  .gvns-strain-heatmap {
+    margin: 0;
+    padding: var(--space-4) 0;
+  }
+
+  .gvns-strain-heatmap__caption {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    justify-content: space-between;
+    align-items: center;
+    font-size: var(--text-xs);
+    color: var(--colour-text-secondary);
+    font-family: var(--font-mono);
+    margin-bottom: var(--space-3);
+  }
+
+  .gvns-strain-heatmap__legend {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  .gvns-strain-heatmap__legend-label {
+    color: var(--colour-text-muted);
+  }
+
+  /* Grid flows column-by-column (top→bottom, left→right) so each
+     column is one ISO calendar week (Mon row 1 … Sun row 7). */
+  .gvns-strain-heatmap__grid {
+    display: grid;
+    grid-template-rows: repeat(7, 12px);
+    grid-auto-flow: column;
+    grid-auto-columns: 12px;
+    gap: 3px;
+    overflow-x: auto;
+    padding-bottom: var(--space-1);
+  }
+
+  .gvns-strain-heatmap__cell {
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    background: var(--colour-bg-tertiary);
+  }
+
+  /* Padding cells take no visual space — kept invisible so the first
+     column still aligns to Monday. */
+  .gvns-strain-heatmap__cell--pad {
+    background: transparent;
+  }
+
+  /* Crimson scale via relative-colour syntax. Falls back to the base
+     swatch on browsers without rgb-from support (very old) — the
+     heatmap becomes monochrome but still readable. */
+  .gvns-strain-heatmap__cell--l0 { background: var(--colour-bg-tertiary); }
+  .gvns-strain-heatmap__cell--l1 { background: rgb(from var(--colour-p6-crimson) r g b / 0.28); }
+  .gvns-strain-heatmap__cell--l2 { background: rgb(from var(--colour-p6-crimson) r g b / 0.50); }
+  .gvns-strain-heatmap__cell--l3 { background: rgb(from var(--colour-p6-crimson) r g b / 0.75); }
+  .gvns-strain-heatmap__cell--l4 { background: var(--colour-p6-crimson); }
+
+  @media (max-width: 640px) {
+    .gvns-strain-heatmap__grid {
+      grid-template-rows: repeat(7, 10px);
+      grid-auto-columns: 10px;
+      gap: 2px;
+    }
+    .gvns-strain-heatmap__cell {
+      width: 10px;
+      height: 10px;
+    }
+  }
+</style>

--- a/src/components/WorkoutList.astro
+++ b/src/components/WorkoutList.astro
@@ -1,0 +1,74 @@
+---
+import WorkoutRow from '@components/WorkoutRow.astro';
+
+interface Workout {
+  id: string;
+  sport: string;
+  start: string;
+  durationMinutes: number;
+  strain: number;
+  scoreState: string;
+}
+
+interface Props {
+  title?: string;
+  workouts?: Workout[];
+  emptyMessage?: string;
+}
+
+const {
+  title = 'Recent workouts',
+  workouts = [],
+  emptyMessage = 'No sessions logged yet.',
+} = Astro.props;
+---
+
+<section class="gvns-workout-list" aria-labelledby="workout-list-title">
+  <h2 class="gvns-workout-list__title" id="workout-list-title">{title}</h2>
+  {workouts.length > 0 ? (
+    <ul class="gvns-workout-list__items" role="list">
+      {workouts.map((w) => (
+        <WorkoutRow
+          sport={w.sport}
+          start={w.start}
+          durationMinutes={w.durationMinutes}
+          strain={w.strain}
+          scoreState={w.scoreState}
+        />
+      ))}
+    </ul>
+  ) : (
+    <p class="gvns-workout-list__empty">{emptyMessage}</p>
+  )}
+</section>
+
+<style>
+  .gvns-workout-list {
+    margin-block: var(--space-8);
+  }
+
+  .gvns-workout-list__title {
+    font-size: var(--text-xl);
+    font-weight: 600;
+    color: var(--colour-text-primary);
+    margin: 0 0 var(--space-4) 0;
+  }
+
+  .gvns-workout-list__items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-top: 1px solid var(--colour-border);
+  }
+
+  .gvns-workout-list__empty {
+    color: var(--colour-text-muted);
+    font-size: var(--text-sm);
+    font-style: italic;
+    margin: 0;
+    padding: var(--space-4);
+    background: var(--colour-bg-secondary);
+    border: 1px dashed var(--colour-border);
+    border-radius: var(--radius-lg);
+  }
+</style>

--- a/src/components/WorkoutRow.astro
+++ b/src/components/WorkoutRow.astro
@@ -1,0 +1,127 @@
+---
+interface Props {
+  sport: string;
+  start: string;            // ISO timestamp
+  durationMinutes: number;
+  strain: number;
+  scoreState: string;        // SCORED / PENDING_SCORE / UNSCORABLE
+}
+
+const { sport, start, durationMinutes, strain, scoreState } = Astro.props;
+
+const startDate = new Date(start);
+const startIso = Number.isNaN(startDate.getTime()) ? '' : startDate.toISOString().slice(0, 10);
+const startLabel = Number.isNaN(startDate.getTime())
+  ? '—'
+  : startDate.toLocaleDateString('en-CA', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
+
+const isScored = scoreState === 'SCORED';
+const strainLabel = isScored ? strain.toFixed(1) : 'pending';
+
+// Strain bar width is the 0-21 scale clamped to 0-100%. Hidden when
+// pending so we don't imply a value that doesn't exist.
+const strainBarWidth = isScored ? Math.min(100, Math.max(0, (strain / 21) * 100)) : 0;
+---
+
+<li class="gvns-workout-row">
+  <span class="gvns-workout-row__sport">{sport}</span>
+  <time class="gvns-workout-row__date" datetime={startIso}>{startLabel}</time>
+  <span class="gvns-workout-row__duration">{durationMinutes} min</span>
+  <span class="gvns-workout-row__strain" aria-label={isScored ? `Strain ${strainLabel} out of 21` : 'Pending score'}>
+    <span class="gvns-workout-row__strain-value">{strainLabel}</span>
+    {isScored && (
+      <span class="gvns-workout-row__strain-track" aria-hidden="true">
+        <span class="gvns-workout-row__strain-fill" style={`width: ${strainBarWidth}%`}></span>
+      </span>
+    )}
+  </span>
+</li>
+
+<style>
+  .gvns-workout-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr) minmax(0, 0.7fr) minmax(0, 1.2fr);
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-3) 0;
+    border-bottom: 1px solid var(--colour-border);
+    font-size: var(--text-sm);
+  }
+
+  .gvns-workout-row:last-child {
+    border-bottom: none;
+  }
+
+  .gvns-workout-row__sport {
+    color: var(--colour-text-primary);
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .gvns-workout-row__date {
+    color: var(--colour-text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .gvns-workout-row__duration {
+    color: var(--colour-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .gvns-workout-row__strain {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--colour-text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .gvns-workout-row__strain-value {
+    font-weight: 500;
+    min-width: 2.5ch;
+    text-align: right;
+  }
+
+  .gvns-workout-row__strain-track {
+    flex: 1;
+    height: 4px;
+    background: var(--colour-bg-tertiary);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .gvns-workout-row__strain-fill {
+    display: block;
+    height: 100%;
+    background: var(--colour-p6-crimson);
+    border-radius: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .gvns-workout-row {
+      grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+      grid-template-rows: auto auto;
+      row-gap: var(--space-1);
+    }
+    .gvns-workout-row__sport {
+      grid-column: 1 / -1;
+    }
+    .gvns-workout-row__date {
+      grid-column: 1;
+    }
+    .gvns-workout-row__duration {
+      grid-column: 2;
+      text-align: right;
+    }
+    .gvns-workout-row__strain {
+      grid-column: 1 / -1;
+    }
+  }
+</style>

--- a/src/pages/move/index.astro
+++ b/src/pages/move/index.astro
@@ -1,0 +1,261 @@
+---
+export const prerender = true;
+
+import BaseLayout from '@layouts/BaseLayout.astro';
+import MoveWidget from '@components/widgets/MoveWidget.astro';
+import StrainHeatmap from '@components/StrainHeatmap.astro';
+import WorkoutList from '@components/WorkoutList.astro';
+import { breadcrumbSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
+import { SITE_MOVE_DESCRIPTION } from '@utils/site';
+
+interface Workout {
+  id: string;
+  sport: string;
+  sportRaw: string;
+  start: string;
+  end: string;
+  durationMinutes: number;
+  strain: number;
+  scoreState: string;
+}
+
+interface WhoopData {
+  lastUpdated: string | null;
+  profile?: { profileUrl?: string };
+  recentWorkouts: Workout[];
+}
+
+let data: WhoopData = { lastUpdated: null, recentWorkouts: [] };
+try {
+  const imported = (await import('../../data/whoop.json')).default as Partial<WhoopData>;
+  data = {
+    lastUpdated: imported.lastUpdated ?? null,
+    profile: imported.profile,
+    recentWorkouts: Array.isArray(imported.recentWorkouts) ? imported.recentWorkouts : [],
+  };
+} catch (e) {
+  if (import.meta.env.DEV) console.error('Failed to load Whoop data for /move:', e);
+}
+
+const hasData = data.recentWorkouts.length > 0;
+
+let formattedLastUpdated: string | null = null;
+let lastUpdatedIso: string | null = null;
+if (data.lastUpdated) {
+  const d = new Date(data.lastUpdated);
+  if (!Number.isNaN(d.getTime())) {
+    formattedLastUpdated = d.toLocaleDateString('en-CA', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+    lastUpdatedIso = d.toISOString().slice(0, 10);
+  }
+}
+
+const siteUrl = normalizeSiteUrl(Astro.site);
+const breadcrumbJsonLd = toJsonLd(
+  breadcrumbSchema([
+    { name: 'Home', url: siteUrl },
+    { name: 'Move', url: `${siteUrl}/move` },
+  ]),
+);
+---
+
+<BaseLayout
+  title="Move"
+  description={SITE_MOVE_DESCRIPTION}
+  accent="p6-crimson"
+  breadcrumbs={[
+    { label: 'Home', href: '/' },
+    { label: 'Move' },
+  ]}
+>
+  <script type="application/ld+json" set:html={breadcrumbJsonLd} slot="head" />
+
+  <main id="main-content" class="gvns-move" data-pagefind-body>
+    <div class="gvns-move__container">
+      <header class="gvns-move__header">
+        <div class="gvns-move__heading-row">
+          <h1 class="gvns-move__title">Move</h1>
+          {formattedLastUpdated && (
+            <time class="gvns-move__updated" datetime={lastUpdatedIso!}>
+              Updated {formattedLastUpdated}
+            </time>
+          )}
+        </div>
+        <p class="gvns-move__subtitle">{SITE_MOVE_DESCRIPTION}</p>
+      </header>
+
+      <section class="gvns-move__widget" aria-label="Latest workout">
+        <MoveWidget />
+      </section>
+
+      {hasData ? (
+        <>
+          <section class="gvns-move__heatmap" aria-label="90-day strain heatmap">
+            <h2 class="gvns-move__section-title">Strain — last 90 days</h2>
+            <StrainHeatmap workouts={data.recentWorkouts} days={90} />
+          </section>
+
+          <WorkoutList
+            title="Recent workouts"
+            workouts={data.recentWorkouts}
+            emptyMessage="No sessions logged yet."
+          />
+        </>
+      ) : (
+        <p class="gvns-move__empty">
+          No sessions logged yet. <a href="https://whoop.com" target="_blank" rel="noopener noreferrer">whoop.com</a>
+        </p>
+      )}
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .gvns-move__container {
+    max-width: var(--width-wide);
+    margin-inline: auto;
+    padding-inline: var(--space-6);
+    padding-block: var(--space-10);
+  }
+
+  .gvns-move__header {
+    margin-bottom: var(--space-8);
+  }
+
+  .gvns-move__heading-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-3);
+  }
+
+  .gvns-move__title {
+    font-family: var(--font-heading);
+    font-size: 32px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    margin: 0;
+  }
+
+  .gvns-move__updated {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+  }
+
+  .gvns-move__subtitle {
+    font-size: var(--text-base);
+    color: var(--colour-text-secondary);
+    margin: 0;
+    max-width: var(--width-content);
+  }
+
+  .gvns-move__widget :global(.gvns-widget) {
+    background: var(--colour-bg-secondary);
+    border: 1px solid var(--colour-border);
+    border-left-width: var(--border-accent);
+    border-radius: var(--radius-xl);
+    padding: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    width: 100%;
+  }
+
+  .gvns-move__widget :global(.gvns-widget__label) {
+    font-size: var(--text-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--colour-text-secondary);
+  }
+
+  .gvns-move__widget :global(.gvns-widget__detail) {
+    font-size: var(--text-lg);
+    color: var(--colour-text-primary);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .gvns-move__widget :global(.gvns-widget__detail--bold) {
+    font-weight: 600;
+  }
+
+  .gvns-move__widget :global(.gvns-widget__meta) {
+    font-size: var(--text-base);
+    color: var(--colour-text-secondary);
+    margin: var(--space-1) 0 0 0;
+  }
+
+  .gvns-move__widget :global(.gvns-widget__time) {
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
+    color: var(--colour-text-secondary);
+    margin: var(--space-1) 0 0 0;
+    display: block;
+  }
+
+  .gvns-move__widget :global(.gvns-widget__empty) {
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    font-style: italic;
+    margin: 0;
+  }
+
+  .gvns-move__widget :global(.gvns-widget__link) {
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .gvns-move__widget :global(.gvns-widget__link span) {
+    display: inline-block;
+    transition: transform var(--transition-fast);
+  }
+
+  .gvns-move__widget :global(.gvns-widget__link:hover span) {
+    transform: translateX(3px);
+  }
+
+  .gvns-move__heatmap {
+    margin-top: var(--space-10);
+  }
+
+  .gvns-move__section-title {
+    font-size: var(--text-xl);
+    font-weight: 600;
+    color: var(--colour-text-primary);
+    margin: 0 0 var(--space-2) 0;
+  }
+
+  .gvns-move__empty {
+    color: var(--colour-text-secondary);
+    font-size: var(--text-base);
+    margin: var(--space-10) 0 0 0;
+    padding: var(--space-6);
+    background: var(--colour-bg-secondary);
+    border: 1px dashed var(--colour-border);
+    border-radius: var(--radius-lg);
+    text-align: center;
+  }
+
+  .gvns-move__empty a {
+    color: var(--colour-accent-primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .gvns-move__title {
+      font-size: var(--text-2xl);
+    }
+  }
+</style>

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,1 +1,3 @@
 export const SITE_BIO = "Tech tinkerer in Qualicum Beach. I write about homelab, self-hosting, networking, and BJJ.";
+
+export const SITE_MOVE_DESCRIPTION = "Tracking my training via Whoop — recent workouts, duration, and strain.";


### PR DESCRIPTION
## **User description**
## Summary

Final piece of the Move epic. Adds the dedicated \`/move\` activity page (parallel to \`/code\`, \`/read\`, \`/listen\`, \`/watch\`) with a header row, the full \`MoveWidget\`, a 90-day strain heatmap, and a recent-workouts list.

## Files

- **\`src/pages/move/index.astro\`** — reads \`whoop.json\`, renders header (\`Move\` h1 + "Updated DD Month YYYY" mono right) → \`MoveWidget\` (full) → 90-day strain heatmap → recent workouts list. Empty state links to \`whoop.com\`. Breadcrumb **Home → Move** (2-level per spec §5.2 — flatter than the other activity pages on purpose; Move is reachable directly from the home strip's MoveWidget). Accent \`p6-crimson\`. Description sourced from \`SITE_MOVE_DESCRIPTION\`.
- **\`src/components/WorkoutList.astro\`** — section wrapper, title + list, dashed-border empty state.
- **\`src/components/WorkoutRow.astro\`** — single row: sport · ISO date · duration · strain. Strain rendered as numeric + a thin P6 crimson progress bar (0–21 scale) when scored; falls back to \`pending\` when \`scoreState !== "SCORED"\`. Hairline dividers between rows. Reflows to two rows × two columns on ≤640 px.
- **\`src/components/StrainHeatmap.astro\`** — pure Astro/CSS heatmap, no JS island. 7 rows × ~13 columns, anchored so the rightmost column ends today; leading pad cells so the first column starts on Monday. Cells coloured by max daily strain bucketed into the conventional Whoop zones (light / moderate / strenuous / all-out) using the P6 crimson token at 28 / 50 / 75 / 100 % via \`rgb(from …)\` relative-colour syntax. Ignores \`scoreState !== "SCORED"\` so pending workouts don't render fake colour.
- **\`src/utils/site.ts\`** — adds \`SITE_MOVE_DESCRIPTION\` (kept separate from \`SITE_BIO\` per the existing static-bio convention).

## Open Qs handled / deferred

- **Top-nav inclusion (spec §7 Q3).** Did not add \`Move\` to the top nav. Consistency with \`/read\`, \`/listen\`, \`/watch\`, \`/code\` wins — those pages aren't in the top nav either, and the home strip's compact MoveWidget already links here. Easy to revisit if first-month traffic shows people not finding the page.
- **Generalise \`ContributionHeatmap\` vs build standalone (spec §7 Q2).** Built standalone. \`ContributionHeatmap\` is a React island wrapping \`react-activity-calendar\`; the strain data is continuous (0–21) rather than discrete (commit counts) and the visual treatment is simpler, so generalising would have meant lifting the React dependency for no benefit. Standalone is ~180 lines of pure Astro + CSS with no client JS.

## Test plan

- [x] \`npm run build\` clean — 20 pages indexed (was 19), \`/move/index.html\` listed.
- [ ] Visual: \`/move\` renders header, full MoveWidget with crimson border, heatmap, workout list with hairlines.
- [ ] Visual: heatmap shows two filled cells from the fixture (Jiu-jitsu / Running), rest neutral.
- [ ] Visual: light theme — crimson stays legible at all four levels; check the heatmap's 28 % stop doesn't disappear on light backgrounds.
- [ ] Mobile reflow on \`WorkoutRow\`: sport span full-width, date and duration on row 2, strain row 3.
- [ ] Breadcrumb shows Home → Move (no Now intermediate).

Closes #570
Part of #553. Blocked by #568 (merged).


___

## **CodeAnt-AI Description**
**Add a dedicated Move page with workout history and strain tracking**

### What Changed
- Added a new `/move` page that shows the latest workout summary, the last update date, a 90-day strain heatmap, and a recent-workouts list
- Workout rows now show the sport, date, duration, and strain; unfinished workouts display as pending instead of showing a strain value
- The heatmap groups daily strain into clear intensity levels and skips unfinished workouts so the chart only reflects scored sessions
- When no workout data is available, the page shows a simple empty state with a link to Whoop

### Impact
`✅ Clearer training overview`
`✅ Easier workout history review`
`✅ Fewer misleading strain readings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Move" section for tracking training activity and workouts.
  * Added a 90-day strain heatmap visualization to monitor training intensity trends.
  * Added a recent workouts list displaying sport type, date, duration, and strain metrics.
  * Integrated Whoop workout data with automatic empty-state messaging when no data is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->