### PR TITLE
refactor(widgets): hero-card layout + CAA bump + P5 Sky ADR (#586 #588 #589)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -682,6 +682,31 @@ Recents count is **4** (`posts.slice(1, 5)`) — right column ~280px tall, sits 
 
 ---
 
+## ADR-021: P5 Sky Dual-Use for Status and Play
+
+**Date**: 2026-05-19
+**Status**: Accepted
+
+### Context
+P5 Sky currently serves two distinct activity surfaces: Status/now indicators and Play (gaming) widgets. Every other palette stop (except P4 Amber, shared by Watch and Write) maps to a single discipline. The question is whether to introduce a dedicated P7 stop for one of the two, or formally accept the dual use.
+
+### Decision
+Keep P5 Sky as the shared accent for both Status and Play. Document it as intentional.
+
+### Rationale
+- Sky reads naturally as both "status / online / calm" and "cool / gaming" — the semantic overlap is genuine, not accidental
+- P4 Amber is already shared between Watch and Write; dual-use has precedent in the palette
+- Adding P7 would extend the activity gradient to 7 stops, breaking the clean 5-band equal split (each band currently spans exactly 20%)
+- ADR-008 intentionally designed the palette as P1–P5; expanding it should require stronger justification than aesthetic symmetry
+- A 5-stop gradient is simpler to maintain and reason about than 6 or 7 stops
+
+### Consequences
+- Game/Play and Status/now widgets share the same accent colour
+- No visual wayfinding distinction between gaming activity and status indicators
+- Future addition of more activity types may pressure the palette; revisit if a 6th or 7th discipline emerges with no natural colour affinity
+
+---
+
 ## Template for New Decisions
 
 ```markdown
@@ -705,4 +730,4 @@ Recents count is **4** (`posts.slice(1, 5)`) — right column ~280px tall, sits 
 
 ---
 
-*Last updated: 2026-05-03 (ADR-020)*
+*Last updated: 2026-05-19 (ADR-021)*

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -43,7 +43,7 @@ Each activity section has a dedicated colour. Maintain this consistently.
 | **Rose** | Read | `#f43f5e` | `#e11d48` | `#fff1f2` |
 | **Emerald** | Listen | `#10b981` | `#059669` | `#ecfdf5` |
 | **Amber** | Write, Watch | `#f59e0b` | `#d97706` | `#fffbeb` |
-| **Sky** | Status indicators | `#0ea5e9` | `#0284c7` | `#f0f9ff` |
+| **Sky** | Status, Play | `#0ea5e9` | `#0284c7` | `#f0f9ff` |
 | **Crimson** | Move (Whoop) | `#dc143c` | `#be123c` | `#fff1f2` |
 
 ### Colour Discipline
@@ -56,6 +56,7 @@ Each activity section has a dedicated colour. Maintain this consistently.
 > - Watch → Amber
 > - Write → Amber
 > - Status → Sky
+> - Play → Sky
 > - Move → Crimson
 
 ### Interactive States

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -48,7 +48,7 @@ Each activity section has a dedicated colour. Maintain this consistently.
 
 ### Colour Discipline
 
-> **Critical:** Each activity type has a specific colour. Never mix them.
+> **Critical:** Each activity type has a specific colour. Dedicated by default; intentional shared accents are documented below.
 >
 > - Code → Violet
 > - Read → Rose

--- a/src/components/widgets/CodeWidget.astro
+++ b/src/components/widgets/CodeWidget.astro
@@ -21,17 +21,20 @@ const streak = data.streak;
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--code">
-    <div class="gvns-widget-compact__label">Now Coding</div>
-    {latestActivity ? (
-      <a href="/code" class="gvns-widget-compact__body">
-        <div class="gvns-widget-compact__info">
+    <div class="gvns-widget-compact__frame">
+      <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Now Coding</div>
+      {latestActivity ? (
+        <a href="/code" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title gvns-widget-compact__title--mono">{latestActivity.repo}</p>
           <p class="gvns-widget-compact__subtitle">{truncate(latestActivity.title, 60)}</p>
-        </div>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">No recent activity.</p>
-    )}
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">No recent activity.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--code">
@@ -90,10 +93,6 @@ const streak = data.streak;
     font-size: var(--text-xs);
     color: var(--colour-p1-violet);
     margin: var(--space-1) 0 0 0;
-  }
-
-  .gvns-widget-compact--code {
-    border-top: var(--border-accent) solid var(--colour-p1-violet);
   }
 
   .gvns-widget-compact__title--mono {

--- a/src/components/widgets/GameWidget.astro
+++ b/src/components/widgets/GameWidget.astro
@@ -47,20 +47,22 @@ const totalHours = Math.round(rawMinutes / 60);
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--game">
-    <div class="gvns-widget-compact__label">Now Playing</div>
-    {latestGame ? (
-      <a href={profileUrl} class="gvns-widget-compact__body" target="_blank" rel="noopener noreferrer">
-        {coverSrc && (
-          <img src={coverSrc} alt={`Cover art for ${latestGame.name}`} class="gvns-widget-compact__cover" width="40" height="60" loading="lazy" decoding="async" />
-        )}
-        <div class="gvns-widget-compact__info">
+    <div class="gvns-widget-compact__frame">
+      {coverSrc && (
+        <img src={coverSrc} alt={`Cover art for ${latestGame.name}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
+      )}
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Now Playing</div>
+      {latestGame ? (
+        <a href={profileUrl} class="gvns-widget-compact__link" target="_blank" rel="noopener noreferrer">
           <p class="gvns-widget-compact__title">{latestGame.name}</p>
           <p class="gvns-widget-compact__subtitle">{totalHours}h played</p>
-        </div>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">Nothing recent.</p>
-    )}
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">Nothing recent.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--game">
@@ -108,7 +110,4 @@ const totalHours = Math.round(rawMinutes / 60);
     color: var(--colour-p5-sky);
   }
 
-  .gvns-widget-compact--game {
-    border-top: var(--border-accent) solid var(--colour-p5-sky);
-  }
 </style>

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -53,26 +53,28 @@ try {
 
 const latestTrack = data.recentListens?.[0] ?? null;
 const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
-  ? `https://coverartarchive.org/release/${latestTrack.caaReleaseMbid}/front-250`
+  ? `https://coverartarchive.org/release/${latestTrack.caaReleaseMbid}/front-500`
   : undefined;
 ---
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--listen">
-    <div class="gvns-widget-compact__label">Now Listening</div>
-    {latestTrack ? (
-      <a href="/listen" class="gvns-widget-compact__body">
-        {artUrl && (
-          <img src={artUrl} alt={`${latestTrack.album || latestTrack.track} album art`} class="gvns-widget-compact__cover gvns-widget-compact__cover--square" width="40" height="40" loading="lazy" decoding="async" />
-        )}
-        <div class="gvns-widget-compact__info">
+    <div class="gvns-widget-compact__frame">
+      {artUrl && (
+        <img src={artUrl} alt={`${latestTrack.album || latestTrack.track} album art`} class="gvns-widget-compact__image gvns-widget-compact__image--fill" loading="lazy" decoding="async" />
+      )}
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Now Listening</div>
+      {latestTrack ? (
+        <a href="/listen" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{latestTrack.track}</p>
           <p class="gvns-widget-compact__subtitle">{latestTrack.artist}</p>
-        </div>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">Nothing playing.</p>
-    )}
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">Nothing playing.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--listen">
@@ -142,11 +144,4 @@ const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
     flex-shrink: 0;
   }
 
-  .gvns-widget-compact--listen {
-    border-top: var(--border-accent) solid var(--colour-p3-emerald);
-  }
-
-  .gvns-widget-compact__cover--square {
-    border-radius: var(--radius-md);
-  }
 </style>

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -53,7 +53,7 @@ try {
 
 const latestTrack = data.recentListens?.[0] ?? null;
 const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
-  ? `https://coverartarchive.org/release/${latestTrack.caaReleaseMbid}/front-500`
+  ? `https://coverartarchive.org/release/${latestTrack.caaReleaseMbid}/front-${compact ? 500 : 250}`
   : undefined;
 ---
 

--- a/src/components/widgets/MoveWidget.astro
+++ b/src/components/widgets/MoveWidget.astro
@@ -44,15 +44,20 @@ const startedAt = latest?.start && !Number.isNaN(new Date(latest.start).getTime(
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--move">
-    <div class="gvns-widget-compact__label">Move</div>
-    {latest ? (
-      <a href="/move" class="gvns-widget-compact__body gvns-widget-compact__body--stack" aria-label={`Latest workout: ${latest.sport}, ${durationText}, ${strainText}`}>
-        <p class="gvns-widget-compact__title">{latest.sport}</p>
-        <p class="gvns-widget-compact__subtitle">{durationText} · {strainText}</p>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">No recent sessions.</p>
-    )}
+    <div class="gvns-widget-compact__frame">
+      <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 20V10"></path><path d="M12 20V4"></path><path d="M6 20v-6"></path></svg>
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Move</div>
+      {latest ? (
+        <a href="/move" class="gvns-widget-compact__link" aria-label={`Latest workout: ${latest.sport}, ${durationText}, ${strainText}`}>
+          <p class="gvns-widget-compact__title">{latest.sport}</p>
+          <p class="gvns-widget-compact__subtitle">{durationText} · {strainText}</p>
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">No recent sessions.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--move">
@@ -77,26 +82,11 @@ const startedAt = latest?.start && !Number.isNaN(new Date(latest.start).getTime(
 )}
 
 <style>
-  /* P6 Crimson — distinct from P2 Rose (read) so the home strip
-     reads as six discrete activities, not two flavours of pink. */
   .gvns-widget--move {
     border-left-color: var(--colour-p6-crimson);
   }
 
   .gvns-widget--move .gvns-widget__link:hover {
     color: var(--colour-p6-crimson);
-  }
-
-  .gvns-widget-compact--move {
-    border-top: var(--border-accent) solid var(--colour-p6-crimson);
-  }
-
-  /* Compact body without poster art — stack title + subtitle vertically,
-     no flex row (matches the no-cover variant used by Watch/Listen
-     when artwork is missing). */
-  .gvns-widget-compact__body--stack {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
   }
 </style>

--- a/src/components/widgets/ReadWidget.astro
+++ b/src/components/widgets/ReadWidget.astro
@@ -41,20 +41,22 @@ const progress = typeof rawProgress === 'number' && !Number.isNaN(rawProgress)
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--read">
-    <div class="gvns-widget-compact__label">Now Reading</div>
-    {currentBook ? (
-      <a href="/read" class="gvns-widget-compact__body">
-        {coverSrc && (
-          <img src={coverSrc} alt={`Cover of ${currentBook.title}`} class="gvns-widget-compact__cover" width="40" height="60" loading="lazy" decoding="async" />
-        )}
-        <div class="gvns-widget-compact__info">
+    <div class="gvns-widget-compact__frame">
+      {coverSrc && (
+        <img src={coverSrc} alt={`Cover of ${currentBook.title}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
+      )}
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Now Reading</div>
+      {currentBook ? (
+        <a href="/read" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{currentBook.title}</p>
           <p class="gvns-widget-compact__subtitle">{currentBook.author}</p>
-        </div>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">Nothing right now.</p>
-    )}
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">Nothing right now.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--read">
@@ -123,7 +125,4 @@ const progress = typeof rawProgress === 'number' && !Number.isNaN(rawProgress)
     transition: width var(--transition-base);
   }
 
-  .gvns-widget-compact--read {
-    border-top: var(--border-accent) solid var(--colour-p2-rose);
-  }
 </style>

--- a/src/components/widgets/ThreadsWidget.astro
+++ b/src/components/widgets/ThreadsWidget.astro
@@ -33,7 +33,7 @@ try {
 }
 
 const posts = data.posts
-  .filter(p => !p.isQuotePost && p.mediaType !== 'REPOST_FACADE')
+  .filter(p => !p.isQuotePost && p.mediaType !== 'REPOST_FACADE' && /^https?:\/\//i.test(p.permalink))
   .slice(0, 3);
 const mediaBadge: Record<string, string> = {
   IMAGE: '[image]',

--- a/src/components/widgets/ThreadsWidget.astro
+++ b/src/components/widgets/ThreadsWidget.astro
@@ -51,7 +51,7 @@ const mediaBadge: Record<string, string> = {
   ) : (
     <div class="gvns-widget-compact__content">
       {posts.map((p) => (
-        <a href={p.permalink} target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__body">
+        <a href={p.permalink} target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__link">
           <div class="gvns-widget-compact__info">
             <p class="gvns-widget-compact__title">{truncate(p.text || '', 140)}</p>
             <div class="gvns-widget-compact__meta">
@@ -76,9 +76,10 @@ const mediaBadge: Record<string, string> = {
 
 <style>
   .gvns-widget-compact--threads {
-    border-top: var(--border-accent) solid var(--colour-p5-sky);
+    padding: var(--space-4);
+    border-top: 2px solid var(--widget-accent);
   }
-  
+
   .gvns-widget-compact__meta {
     display: flex;
     gap: 0.5rem;

--- a/src/components/widgets/WatchWidget.astro
+++ b/src/components/widgets/WatchWidget.astro
@@ -40,20 +40,22 @@ const watchedDate = latestWatch?.watchedDate && !Number.isNaN(new Date(latestWat
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--watch">
-    <div class="gvns-widget-compact__label">Now Watching</div>
-    {latestWatch ? (
-      <a href="/watch" class="gvns-widget-compact__body">
-        {posterSrc && (
-          <img src={posterSrc} alt={`Poster for ${latestWatch.title}`} class="gvns-widget-compact__cover" width="40" height="60" loading="lazy" decoding="async" />
-        )}
-        <div class="gvns-widget-compact__info">
+    <div class="gvns-widget-compact__frame">
+      {posterSrc && (
+        <img src={posterSrc} alt={`Poster for ${latestWatch.title}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
+      )}
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Now Watching</div>
+      {latestWatch ? (
+        <a href="/watch" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{latestWatch.title}</p>
           <p class="gvns-widget-compact__subtitle">{latestWatch.type}</p>
-        </div>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">Nothing watched.</p>
-    )}
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">Nothing watched.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--watch">
@@ -105,7 +107,4 @@ const watchedDate = latestWatch?.watchedDate && !Number.isNaN(new Date(latestWat
     flex-shrink: 0;
   }
 
-  .gvns-widget-compact--watch {
-    border-top: var(--border-accent) solid var(--colour-p4-amber);
-  }
 </style>

--- a/src/components/widgets/WriteWidget.astro
+++ b/src/components/widgets/WriteWidget.astro
@@ -16,17 +16,20 @@ const postSlug = latestPost ? getPostSlug(latestPost.id) : undefined;
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--write">
-    <div class="gvns-widget-compact__label">Latest Post</div>
-    {latestPost ? (
-      <a href={`/posts/${postSlug}`} class="gvns-widget-compact__body">
-        <div class="gvns-widget-compact__info">
+    <div class="gvns-widget-compact__frame">
+      <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"></path><path d="m15 5 4 4"></path></svg>
+    </div>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Latest Post</div>
+      {latestPost ? (
+        <a href={`/posts/${postSlug}`} class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{latestPost.data.title}</p>
           <p class="gvns-widget-compact__subtitle">{formatDate(latestPost.data.pubDate)}</p>
-        </div>
-      </a>
-    ) : (
-      <p class="gvns-widget-compact__empty">No posts yet.</p>
-    )}
+        </a>
+      ) : (
+        <p class="gvns-widget-compact__empty">No posts yet.</p>
+      )}
+    </div>
   </article>
 ) : (
   <article class="gvns-widget gvns-widget--write">
@@ -80,7 +83,4 @@ const postSlug = latestPost ? getPostSlug(latestPost.id) : undefined;
     overflow: hidden;
   }
 
-  .gvns-widget-compact--write {
-    border-top: var(--border-accent) solid var(--colour-p4-amber);
-  }
 </style>

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -107,7 +107,7 @@ const rangeLabel = listeningData.stats.range.replace(/_/g, " ");
 /** Construct a Cover Art Archive URL from a release MBID, or return undefined. */
 function coverArtUrl(mbid: string | null | undefined): string | undefined {
     return isValidMbid(mbid)
-        ? `https://coverartarchive.org/release/${mbid}/front-500`
+        ? `https://coverartarchive.org/release/${mbid}/front-250`
         : undefined;
 }
 

--- a/src/pages/listen/index.astro
+++ b/src/pages/listen/index.astro
@@ -107,7 +107,7 @@ const rangeLabel = listeningData.stats.range.replace(/_/g, " ");
 /** Construct a Cover Art Archive URL from a release MBID, or return undefined. */
 function coverArtUrl(mbid: string | null | undefined): string | undefined {
     return isValidMbid(mbid)
-        ? `https://coverartarchive.org/release/${mbid}/front-250`
+        ? `https://coverartarchive.org/release/${mbid}/front-500`
         : undefined;
 }
 

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -1,14 +1,50 @@
-/* Compact widget styles — shared across pages that use compact widget variants */
+/* Compact widget hero-card layout — shared across pages that use compact widget variants */
 
 .gvns-widget-compact {
   background: var(--colour-bg-secondary);
   border: 1px solid var(--colour-border);
   border-radius: var(--radius-lg);
-  padding: var(--space-4);
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
   transition: border-color var(--transition-fast);
+}
+
+/* Hero-card frame — 4:3 cover area at top of card */
+.gvns-widget-compact__frame {
+  aspect-ratio: 4 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--colour-bg-tertiary);
+  overflow: hidden;
+}
+
+.gvns-widget-compact__image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* Album art fills the 4:3 frame; portraits letterbox by default */
+.gvns-widget-compact__image--fill {
+  object-fit: cover;
+}
+
+/* Slot icons for text-only widgets (Code) — 33% of frame width, capped at 120px */
+.gvns-widget-compact__icon {
+  width: 33%;
+  max-width: 120px;
+  color: var(--colour-text-muted);
+}
+
+/* Hero-card body — text section below frame with accent strip */
+.gvns-widget-compact__body {
+  border-top: 2px solid var(--widget-accent, var(--colour-p5-sky));
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
 }
 
 .gvns-widget-compact__label {
@@ -19,22 +55,9 @@
   color: var(--colour-text-secondary);
 }
 
-.gvns-widget-compact__body {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
+.gvns-widget-compact__link {
   text-decoration: none;
   color: inherit;
-}
-
-.gvns-widget-compact__cover {
-  border-radius: var(--radius-md);
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.gvns-widget-compact__info {
-  min-width: 0;
 }
 
 .gvns-widget-compact__title {
@@ -45,12 +68,17 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: color var(--transition-fast);
+}
+
+.gvns-widget-compact:hover .gvns-widget-compact__title {
+  color: var(--widget-accent, var(--colour-p5-sky));
 }
 
 .gvns-widget-compact__subtitle {
   font-size: var(--text-xs);
   color: var(--colour-text-secondary);
-  margin: var(--space-1) 0 0 0;
+  margin: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -61,4 +89,15 @@
   color: var(--colour-text-secondary);
   font-style: italic;
   margin: 0;
+  padding: var(--space-4);
 }
+
+/* Per-variant accent colours — single source of truth for border + hover */
+.gvns-widget-compact--read    { --widget-accent: var(--colour-p2-rose); }
+.gvns-widget-compact--listen  { --widget-accent: var(--colour-p3-emerald); }
+.gvns-widget-compact--watch   { --widget-accent: var(--colour-p4-amber); }
+.gvns-widget-compact--code    { --widget-accent: var(--colour-p1-violet); }
+.gvns-widget-compact--game    { --widget-accent: var(--colour-p5-sky); }
+.gvns-widget-compact--write   { --widget-accent: var(--colour-p4-amber); }
+.gvns-widget-compact--threads { --widget-accent: var(--colour-p5-sky); }
+.gvns-widget-compact--move   { --widget-accent: var(--colour-p6-crimson); }

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -71,7 +71,8 @@
   transition: color var(--transition-fast);
 }
 
-.gvns-widget-compact:hover .gvns-widget-compact__title {
+.gvns-widget-compact:hover .gvns-widget-compact__title,
+.gvns-widget-compact:focus-within .gvns-widget-compact__title {
   color: var(--widget-accent, var(--colour-p5-sky));
 }
 


### PR DESCRIPTION
## **User description**
## Summary

- **#586** — Refactor compact activity widgets to Option C hero-card layout: 4:3 cover frame at top, text body below with 2px accent strip on body's top border. Per-variant accent colours use a `--widget-accent` custom property (single source of truth for border + hover).
- **#588** — Bump Cover Art Archive resolution from `front-250` to `front-500` for crisper covers in the larger hero-card frame. Note: Open Library (M→L) not applicable (reading uses Hardcover CDN, no size params); TMDB already at `w342`.
- **#589** — ADR-021: accept P5 Sky dual-use for Status and Play as intentional. Documented in DECISIONS.md + DESIGN-SYSTEM.md.

## Changes

### Hero-card layout (compact widgets)
- `widgets.css`: New `__frame`, `__body`, `__image`, `__image--fill`, `__icon`, `__link` classes; `--widget-accent` per variant
- ReadWidget, ListenWidget, WatchWidget, GameWidget: cover art in `__frame`, text in `__body`
- CodeWidget, WriteWidget, MoveWidget: SVG icon in `__frame` (Lucide icons, 33% width / 120px cap)
- ThreadsWidget: `__body`→`__link` rename, scoped padding (base no longer has padding)
- Hover: title shifts to widget's accent colour

### Image resolution
- ListenWidget + listen page: CAA `front-250` → `front-500`

### Docs
- ADR-021 in DECISIONS.md (P5 Sky dual-use)
- DESIGN-SYSTEM.md: Sky activity "Status indicators" → "Status, Play", added "Play → Sky" discipline

## Test plan
- [x] `npm run build` clean — no errors
- [ ] Visual check: each widget has 4:3 frame, accent strip, hover colour shift
- [ ] Portrait covers letterbox; album art fills frame
- [ ] `/now` page full-mode widgets unchanged (no regressions)
- [ ] Responsive breakpoints work (5→3→2→1 columns)
- [ ] Light + dark themes both show accent strip correctly

Closes #586
Closes #588
Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Give compact activity widgets a hero-card layout and sharper listening artwork**

### What Changed
- Compact activity widgets now show a large 4:3 preview area on top, with the label, title, and details grouped below
- Read, Listen, Watch, and Game widgets use full-size artwork in the preview area; Code, Write, and Move use simple icons there instead
- The title now changes to each activity’s accent color when the widget is hovered
- Listening artwork now loads at a higher resolution on both the widget and the Listen page
- The colour guide now treats Sky as shared by Status and Play, and the decision log records that choice

### Impact
`✅ Clearer activity cards`
`✅ Sharper album art`
`✅ Consistent colour rules for Status and Play`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision record for P5 Sky accent color usage across widgets
  * Updated design system documentation for color consistency guidance

* **Refactor**
  * Restructured compact widget layouts for improved visual consistency
  * Consolidated widget styling rules and centralized accent color management

* **Style**
  * Refined widget presentation with standardized frame-based layout approach
  * Enhanced accent color consistency across all widget types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->