### PR TITLE
fix(widgets): hero-card visuals — Watch fallback, Game URL chain, Code sparkline

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "gvns-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 4322
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ pnpm-debug.log*
 
 # wrangler local state
 .wrangler/
+.superpowers/

--- a/src/components/widgets/CodeWidget.astro
+++ b/src/components/widgets/CodeWidget.astro
@@ -17,12 +17,37 @@ try {
 
 const latestActivity = data.recentActivity[0] ?? null;
 const streak = data.streak;
+
+// Mini contribution chart — last 14 days from the calendar.
+// Replaces the bare `</>` chevron with actual activity data, matching MoveWidget's data-as-visual pattern.
+const allDays = data.calendar.weeks.flatMap((w) => w.days);
+const last14 = allDays.slice(-14);
+// Level (0-4) drives bar height. Level 0 still shows a baseline tick so empty days are legible.
+const LEVEL_HEIGHTS: Record<number, number> = { 0: 6, 1: 20, 2: 36, 3: 50, 4: 64 };
 ---
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--code">
-    <div class="gvns-widget-compact__frame">
-      <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+    <div class="gvns-widget-compact__frame gvns-widget-compact__frame--chart">
+      {last14.length > 0 ? (
+        <svg class="gvns-code-chart" viewBox="0 0 140 80" preserveAspectRatio="none" aria-hidden="true">
+          {last14.map((day, i) => {
+            const h = LEVEL_HEIGHTS[day.level] ?? 6;
+            return (
+              <rect
+                x={i * 9.5 + 4}
+                y={72 - h}
+                width="7"
+                height={h}
+                rx="0.5"
+                class:list={['gvns-code-chart__bar', `gvns-code-chart__bar--l${day.level}`, i === last14.length - 1 && 'gvns-code-chart__bar--today']}
+              />
+            );
+          })}
+        </svg>
+      ) : (
+        <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+      )}
     </div>
     <div class="gvns-widget-compact__body">
       <div class="gvns-widget-compact__label">Now Coding</div>
@@ -97,5 +122,31 @@ const streak = data.streak;
 
   .gvns-widget-compact__title--mono {
     font-family: var(--font-mono);
+  }
+
+  /* 14-day contribution sparkline — fills the 4:3 hero frame */
+  .gvns-code-chart {
+    width: 100%;
+    height: 100%;
+    display: block;
+    padding: var(--space-2);
+    box-sizing: border-box;
+  }
+
+  .gvns-code-chart__bar {
+    fill: var(--colour-p1-violet);
+    transition: fill-opacity var(--transition-fast);
+  }
+
+  .gvns-code-chart__bar--l0 { fill-opacity: 0.16; }
+  .gvns-code-chart__bar--l1 { fill-opacity: 0.42; }
+  .gvns-code-chart__bar--l2 { fill-opacity: 0.62; }
+  .gvns-code-chart__bar--l3 { fill-opacity: 0.82; }
+  .gvns-code-chart__bar--l4 { fill-opacity: 1; }
+
+  /* Today's bar gets a subtle stroke so the most-recent day reads as the "now" anchor */
+  .gvns-code-chart__bar--today {
+    stroke: var(--colour-p1-violet);
+    stroke-width: 0.5;
   }
 </style>

--- a/src/components/widgets/GameWidget.astro
+++ b/src/components/widgets/GameWidget.astro
@@ -36,7 +36,18 @@ try {
 }
 
 const latestGame = data.recentlyPlayed[0] ?? null;
-const coverSrc = safeUrl(latestGame?.portraitUrl);
+const portraitSrc = safeUrl(latestGame?.portraitUrl);
+const headerSrc = safeUrl(latestGame?.headerUrl);
+const capsuleSrc = safeUrl(latestGame?.capsuleUrl);
+// Steam's library_600x900.jpg is missing for many newer titles (e.g. DEATH STRANDING 2, appId 3280350 → 404).
+// Prefer portrait, fall back to header → capsule. Runtime onerror swaps to the next candidate if portrait 404s.
+const coverCandidates = [portraitSrc, headerSrc, capsuleSrc].filter((u): u is string => Boolean(u));
+const coverSrc = coverCandidates[0];
+const coverIsPortrait = coverSrc !== undefined && coverSrc === portraitSrc;
+const coverFallbacks = coverCandidates.slice(1);
+const onCoverError = coverFallbacks.length > 0
+  ? `var i=parseInt(this.dataset.fbi||'0',10);var f=${JSON.stringify(coverFallbacks)};if(i<f.length){this.dataset.fbi=String(i+1);this.src=f[i];}else{this.onerror=null;}`
+  : undefined;
 const profileUrl = safeUrl(data.profile?.profileUrl) ?? 'https://store.steampowered.com/';
 const lastPlayedDate = latestGame?.lastPlayed && !Number.isNaN(new Date(latestGame.lastPlayed).getTime())
   ? latestGame.lastPlayed
@@ -48,8 +59,17 @@ const totalHours = Math.round(rawMinutes / 60);
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--game">
     <div class="gvns-widget-compact__frame">
-      {coverSrc && (
-        <img src={coverSrc} alt={`Cover art for ${latestGame.name}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
+      {coverSrc ? (
+        <img
+          src={coverSrc}
+          alt={`Cover art for ${latestGame.name}`}
+          class:list={['gvns-widget-compact__image', !coverIsPortrait && 'gvns-widget-compact__image--fill']}
+          loading="lazy"
+          decoding="async"
+          onerror={onCoverError}
+        />
+      ) : (
+        <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="6" y1="11" x2="10" y2="11"></line><line x1="8" y1="9" x2="8" y2="13"></line><line x1="15" y1="12" x2="15.01" y2="12"></line><line x1="18" y1="10" x2="18.01" y2="10"></line><path d="M17.32 5H6.68a4 4 0 0 0-3.978 3.59c-.006.052-.01.101-.017.152C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258A4 4 0 0 0 17.32 5z"></path></svg>
       )}
     </div>
     <div class="gvns-widget-compact__body">
@@ -78,6 +98,7 @@ const totalHours = Math.round(rawMinutes / 60);
             height="72"
             loading="lazy"
             decoding="async"
+            onerror={onCoverError}
           />
         )}
         <div>

--- a/src/components/widgets/WatchWidget.astro
+++ b/src/components/widgets/WatchWidget.astro
@@ -41,8 +41,10 @@ const watchedDate = latestWatch?.watchedDate && !Number.isNaN(new Date(latestWat
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--watch">
     <div class="gvns-widget-compact__frame">
-      {posterSrc && (
+      {posterSrc ? (
         <img src={posterSrc} alt={`Poster for ${latestWatch.title}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
+      ) : (
+        <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18"></rect><line x1="7" y1="2" x2="7" y2="22"></line><line x1="17" y1="2" x2="17" y2="22"></line><line x1="2" y1="12" x2="22" y2="12"></line><line x1="2" y1="7" x2="7" y2="7"></line><line x1="2" y1="17" x2="7" y2="17"></line><line x1="17" y1="17" x2="22" y2="17"></line><line x1="17" y1="7" x2="22" y2="7"></line></svg>
       )}
     </div>
     <div class="gvns-widget-compact__body">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,9 +62,9 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
       <div class="gvns-activity-grid">
         <ReadWidget compact />
         <ListenWidget compact />
+        <GameWidget compact />
         <WatchWidget compact />
         <CodeWidget compact />
-        <GameWidget compact />
         <MoveWidget compact />
       </div>
     </section>
@@ -73,6 +73,11 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
 
 <style>
   .gvns-home {
+    /* width:100% is load-bearing — without it, BaseLayout's `body{display:flex;flex-direction:column}`
+       combined with `margin:0 auto` cross-axis-auto-margins suppresses flex stretch and main collapses
+       to intrinsic content width. With width:100% the element claims body width, max-width then caps it,
+       and margin:auto centers normally. */
+    width: 100%;
     max-width: var(--width-wide);
     margin: 0 auto;
     padding-inline: var(--space-4);
@@ -119,24 +124,12 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   .gvns-activity-widgets {
     padding-block: var(--space-2);
   }
+  /* Auto-fit with a card-width floor — no jarring breakpoint snap.
+     At any viewport, columns scale smoothly between 1 and 6 cards-per-row
+     while every card stays ≥ ~190px so frame imagery never shrinks below readable. */
   .gvns-activity-grid {
     display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
     gap: var(--space-4);
-  }
-  @media (max-width: 1279px) {
-    .gvns-activity-grid {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-  }
-  @media (max-width: 1023px) {
-    .gvns-activity-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-  }
-  @media (max-width: 640px) {
-    .gvns-activity-grid {
-      grid-template-columns: minmax(0, 1fr);
-    }
   }
 </style>

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -10,9 +10,9 @@
   transition: border-color var(--transition-fast);
 }
 
-/* Hero-card frame — 4:3 cover area at top of card */
+/* Hero-card frame — square crop for a uniform visual rhythm across the bento */
 .gvns-widget-compact__frame {
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,13 +20,18 @@
   overflow: hidden;
 }
 
+/* Images fit fully inside the square (no crop) — portraits letterbox left/right,
+   landscape headers letterbox top/bottom, square art fills. Preserves titles and
+   key composition that cover-crop would shave off. */
 .gvns-widget-compact__image {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  object-position: center;
 }
 
-/* Album art fills the 4:3 frame; portraits letterbox by default */
+/* Opt-in to cover-fill for sources that look better filling the frame edge-to-edge.
+   Currently no caller sets this; retained as an escape hatch. */
 .gvns-widget-compact__image--fill {
   object-fit: cover;
 }

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -31,11 +31,13 @@
   object-fit: cover;
 }
 
-/* Slot icons for text-only widgets (Code) — 33% of frame width, capped at 120px */
+/* Slot icons for text-only widgets (Code, Move) and missing-image fallbacks (Watch, Game) —
+   inherit the widget's accent colour so the bento reads as a cohesive palette, not muted greys. */
 .gvns-widget-compact__icon {
   width: 33%;
   max-width: 120px;
-  color: var(--colour-text-muted);
+  color: var(--widget-accent, var(--colour-text-muted));
+  opacity: 0.7;
 }
 
 /* Hero-card body — text section below frame with accent strip */


### PR DESCRIPTION
## **User description**
## Summary

The home-page bento read as half-broken — three of six hero cards had no working imagery. Root causes were independent but the user-visible effect was a single ugly bento.

- **WatchWidget** — `posterUrl` is `null` for every Trakt entry. Root cause is the empty `TMDB_API_KEY` secret (per fetcher investigation); this PR makes the widget degrade to an amber film-strip icon instead of an empty grey 4:3 frame.
- **GameWidget** — `portraitUrl` for DEATH STRANDING 2 (appId 3280350) returns HTTP 404; Steam doesn't expose `library_600x900.jpg` for many newer titles. The widget already had a valid `headerUrl` in the data but never reached for it. Adds SSR fallback chain (`portrait → header → capsule`) plus a runtime `onerror` hop so the browser swaps on 404 without a flash of broken image.
- **CodeWidget** — bare `</>` chevron at 33% width looked accidental next to the content-rich neighbours. Replaced with a 14-day contribution sparkline rendered from `calendar.weeks` data, level-graded P1 violet opacity, today's bar gets a stroke accent. Mirrors MoveWidget's "data-as-visual" pattern.
- **widgets.css** — slot icon colour now inherits from `--widget-accent` (set per variant) so fallback icons read as part of the P1–P6 palette instead of muted grey.

### Before / After

User flagged the live homepage with The Punisher poster missing, gvns.ca card showing the bare chevron, and DEATH STRANDING 2 cover broken with alt text leaking through. After this PR the same six cards each carry their accent colour and either real content imagery or an intentional fallback.

### Data-layer follow-ups (separate)

- TMDB_API_KEY secret needs to be regenerated and added under Settings → Secrets → Actions (Quick).
- `fetch-steam/src/index.js artworkUrls()` should HEAD-check the legacy `library_600x900.jpg` URL and fall back to `headerUrl` at fetch time so newer titles store a valid `portraitUrl` (Short, ~10 lines).

Both are tracked as work I noted while diagnosing — UI now degrades gracefully whether or not those land.

## Test plan

- [x] `npm run build` clean (20 routes prerender)
- [x] Dev-server verification — inspected rendered HTML for all six compact widgets; Watch shows icon SVG, Game has `onerror` attribute pointing at headerUrl, Code emits 14 sparkline bars + today-bar stroke
- [x] Screenshot of widget row at 1600×900 dark mode confirms cohesive palette
- [ ] Reviewer eyeballs the Game card after Cloudflare preview deploys (browser will exercise the onerror swap that curl can't trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code widget now shows a 14-day contribution sparkline chart
  * Game and Watch widgets add intelligent image fallback handling for missing covers/posters

* **Improvements**
  * Compact widget frame changed to a square crop; icon styling now supports accent color and opacity
  * Homepage activity grid updated to a responsive auto-fit layout and explicit full-width container

* **Chores**
  * Added a VS Code launch configuration; updated ignore rules to exclude a superpowers directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Make homepage activity cards more consistent and resilient**

### What Changed
- Home activity cards now use square image frames and a smoother grid so the bento stays balanced across screen sizes.
- The homepage wrapper now fills the page width correctly, fixing the card row collapsing to a narrower column.
- Watch cards now show a film-strip fallback when poster art is missing instead of leaving an empty frame.
- Game cards now try multiple cover images and switch to the next one if the first image fails to load.
- Code cards now show a 14-day contribution sparkline instead of a plain symbol, with a clear highlight for today.

### Impact
`✅ Fewer broken-looking homepage cards`
`✅ More consistent card layout across screen sizes`
`✅ Clearer visual fallback when artwork is missing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
