### PR TITLE
fix(fetch-trakt): pass --compressed so TMDB poster lookups don't silently no-op

### DIFF
--- a/.github/actions/fetch-trakt/scripts/http.sh
+++ b/.github/actions/fetch-trakt/scripts/http.sh
@@ -6,7 +6,11 @@
 fetch_url() {
   local url="$1" output="$2" max_attempts=3 attempt=0 status
   while [ $attempt -lt $max_attempts ]; do
-    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+    # --compressed: TMDB (and many CDN-fronted APIs) return gzip-encoded bodies to HTTP/2
+    # clients by default. Without this flag curl writes the raw compressed bytes to $output,
+    # downstream jq silently fails to parse, and callers see "HTTP 200 but no fields" —
+    # which broke poster enrichment without surfacing as a failure (0/N fetched, 0 failed).
+    status=$(curl -sL --compressed --max-redirs 3 -w "%{http_code}" -o "$output" \
       --max-time 30 --connect-timeout 10 "$url") || status="000"
     if [ "$status" -eq 429 ]; then
       local wait=$((2 ** attempt))
@@ -30,7 +34,7 @@ fetch_url_with_headers() {
   shift 2
   local max_attempts=3 attempt=0 status
   while [ $attempt -lt $max_attempts ]; do
-    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+    status=$(curl -sL --compressed --max-redirs 3 -w "%{http_code}" -o "$output" \
       --max-time 30 --connect-timeout 10 "$@" "$url") || status="000"
     if [ "$status" -eq 429 ]; then
       local wait=$((2 ** attempt))


### PR DESCRIPTION
## **User description**
## Summary

Every Trakt fetch since the migration to local composite actions has been silently dropping TMDB poster enrichment with the exact same log line: `Fetched 0/18 posters (0 failed)`. The data file lands but every `posterUrl` is `null` — so the home-page WatchWidget has had nothing to render even when the API key is valid.

## Root cause

TMDB's API (CloudFront-fronted) returns gzip-encoded bodies to HTTP/2 clients regardless of whether the client sent `Accept-Encoding`. `curl` only adds that header and decodes the response when called with `--compressed`. Without the flag, the raw gzip bytes get written to the temp file; the script then runs `jq -r '.poster_path // empty'` against compressed binary, gets empty back, and accounts the response as "HTTP 200, no poster_path" — neither the FETCHED nor FAILED counter increments. Silent fail.

## Verification

```bash
curl -s             "https://api.themoviedb.org/3/movie/550?api_key=XXX" | head -c 80
# (binary)

curl -s --compressed "https://api.themoviedb.org/3/movie/550?api_key=XXX" | jq '{title, poster_path}'
# {"title": "Fight Club", "poster_path": "/jSziioSwPVrOy9Yow3XhWIBDjq1.jpg"}
```

## Scope

Trakt's `http.sh` only. I probed listenbrainz and hardcover endpoints — neither sends `content-encoding: gzip` to clients that didn't ask for it, so they're not affected. Adding `--compressed` everywhere defensively would be cheap, but I'd rather land this fix first and leave that as a follow-up if anyone wants it.

## Test plan

- [x] Local verify with real key — uncompressed response is binary, compressed response has `poster_path`
- [ ] After merge: dispatch `fetch-daily.yml` and confirm `src/data/watching.json` has non-null `posterUrl` values
- [ ] Home-page WatchWidget shows the real Punisher poster instead of the amber film-strip fallback (paired with #606)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved HTTP request handling for better support of compressed data transfers, enhancing performance and reliability across platform interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix Trakt poster lookups so image data is decoded correctly

### What Changed
- TMDB poster fetches now return readable data instead of compressed bytes, so poster URLs can be extracted again
- Trakt fetch runs will now populate poster images instead of reporting successful fetches with no posters found
- The same fix is applied to shared HTTP fetches used by the Trakt flow, while keeping the existing retry behavior

### Impact
`✅ Restored poster images on the home page`
`✅ Fewer silent missing-data fetches`
`✅ More reliable Trakt poster enrichment`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
