### PR TITLE
feat(home): Now-section refactor (closes #585) + Option C hero/chip layout

### DIFF
--- a/.github/actions/fetch-trakt/scripts/http.sh
+++ b/.github/actions/fetch-trakt/scripts/http.sh
@@ -6,7 +6,11 @@
 fetch_url() {
   local url="$1" output="$2" max_attempts=3 attempt=0 status
   while [ $attempt -lt $max_attempts ]; do
-    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+    # --compressed: TMDB (and many CDN-fronted APIs) return gzip-encoded bodies to HTTP/2
+    # clients by default. Without this flag curl writes the raw compressed bytes to $output,
+    # downstream jq silently fails to parse, and callers see "HTTP 200 but no fields" —
+    # which broke poster enrichment without surfacing as a failure (0/N fetched, 0 failed).
+    status=$(curl -sL --compressed --max-redirs 3 -w "%{http_code}" -o "$output" \
       --max-time 30 --connect-timeout 10 "$url") || status="000"
     if [ "$status" -eq 429 ]; then
       local wait=$((2 ** attempt))
@@ -30,7 +34,7 @@ fetch_url_with_headers() {
   shift 2
   local max_attempts=3 attempt=0 status
   while [ $attempt -lt $max_attempts ]; do
-    status=$(curl -sL --max-redirs 3 -w "%{http_code}" -o "$output" \
+    status=$(curl -sL --compressed --max-redirs 3 -w "%{http_code}" -o "$output" \
       --max-time 30 --connect-timeout 10 "$@" "$url") || status="000"
     if [ "$status" -eq 429 ]; then
       local wait=$((2 ** attempt))

--- a/src/components/widgets/CodeWidget.astro
+++ b/src/components/widgets/CodeWidget.astro
@@ -50,7 +50,7 @@ const LEVEL_HEIGHTS: Record<number, number> = { 0: 6, 1: 20, 2: 36, 3: 50, 4: 64
       )}
     </div>
     <div class="gvns-widget-compact__body">
-      <div class="gvns-widget-compact__label">Now Coding</div>
+      <div class="gvns-widget-compact__label">Coding</div>
       {latestActivity ? (
         <a href="/code" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title gvns-widget-compact__title--mono">{latestActivity.repo}</p>

--- a/src/components/widgets/GameWidget.astro
+++ b/src/components/widgets/GameWidget.astro
@@ -73,7 +73,7 @@ const totalHours = Math.round(rawMinutes / 60);
       )}
     </div>
     <div class="gvns-widget-compact__body">
-      <div class="gvns-widget-compact__label">Now Playing</div>
+      <div class="gvns-widget-compact__label">Playing</div>
       {latestGame ? (
         <a href={profileUrl} class="gvns-widget-compact__link" target="_blank" rel="noopener noreferrer">
           <p class="gvns-widget-compact__title">{latestGame.name}</p>

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -65,7 +65,7 @@ const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
       )}
     </div>
     <div class="gvns-widget-compact__body">
-      <div class="gvns-widget-compact__label">Now Listening</div>
+      <div class="gvns-widget-compact__label">Listening</div>
       {latestTrack ? (
         <a href="/listen" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{latestTrack.track}</p>

--- a/src/components/widgets/ReadWidget.astro
+++ b/src/components/widgets/ReadWidget.astro
@@ -47,7 +47,7 @@ const progress = typeof rawProgress === 'number' && !Number.isNaN(rawProgress)
       )}
     </div>
     <div class="gvns-widget-compact__body">
-      <div class="gvns-widget-compact__label">Now Reading</div>
+      <div class="gvns-widget-compact__label">Reading</div>
       {currentBook ? (
         <a href="/read" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{currentBook.title}</p>

--- a/src/components/widgets/ThreadsWidget.astro
+++ b/src/components/widgets/ThreadsWidget.astro
@@ -74,7 +74,7 @@ const latestPost = posts[0] ?? null;
         {posts.map((p) => (
           <a href={p.permalink} target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__link">
             <div class="gvns-widget-compact__info">
-              <p class="gvns-widget-compact__title">{truncate(p.text || '', 140)}</p>
+              <p class="gvns-widget-compact__title">{truncate(p.text || '(media)', 140)}</p>
               <div class="gvns-widget-compact__meta">
                 {mediaBadge[p.mediaType] && <span class="gvns-widget-compact__badge">{mediaBadge[p.mediaType]}</span>}
                 <span class="gvns-widget-compact__timestamp">{relativeTime(p.timestamp)}</span>

--- a/src/components/widgets/ThreadsWidget.astro
+++ b/src/components/widgets/ThreadsWidget.astro
@@ -41,46 +41,68 @@ const mediaBadge: Record<string, string> = {
   CAROUSEL_ALBUM: '[album]',
   AUDIO: '[audio]',
 };
+const latestPost = posts[0] ?? null;
 ---
 
-<article class={`gvns-widget-compact gvns-widget-compact--threads ${!compact ? 'gvns-widget-full' : ''}`}>
-  <div class="gvns-widget-compact__label">Recent Threads</div>
-  
-  {posts.length === 0 ? (
-    <div class="gvns-widget-compact__empty">Quiet on Threads.</div>
-  ) : (
-    <div class="gvns-widget-compact__content">
-      {posts.map((p) => (
-        <a href={p.permalink} target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__link">
-          <div class="gvns-widget-compact__info">
-            <p class="gvns-widget-compact__title">{truncate(p.text || '', 140)}</p>
-            <div class="gvns-widget-compact__meta">
-              {mediaBadge[p.mediaType] && <span class="gvns-widget-compact__badge">{mediaBadge[p.mediaType]}</span>}
-              <span class="gvns-widget-compact__timestamp">{relativeTime(p.timestamp)}</span>
-            </div>
-          </div>
-        </a>
-      ))}
+{compact ? (
+  <article class="gvns-widget-compact gvns-widget-compact--threads">
+    <div class="gvns-widget-compact__frame">
+      <svg class="gvns-widget-compact__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
     </div>
-  )}
-  
-  <a 
-    class="gvns-widget-compact__footer" 
-    href="https://www.threads.net/@ggfevans" 
-    target="_blank" 
-    rel="noopener noreferrer"
-  >
-    See more on Threads &rarr;
-  </a>
-</article>
+    <div class="gvns-widget-compact__body">
+      <div class="gvns-widget-compact__label">Shitposting</div>
+      {latestPost ? (
+        <a href={latestPost.permalink} target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__link">
+          <p class="gvns-widget-compact__title">{truncate(latestPost.text || '(media)', 60)}</p>
+          <p class="gvns-widget-compact__subtitle">{relativeTime(latestPost.timestamp)}</p>
+        </a>
+      ) : (
+        <a href="https://www.threads.net/@ggfevans" target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__link">
+          <p class="gvns-widget-compact__title">Quiet on Threads</p>
+          <p class="gvns-widget-compact__subtitle">@ggfevans &rarr;</p>
+        </a>
+      )}
+    </div>
+  </article>
+) : (
+  <article class="gvns-widget-compact gvns-widget-compact--threads gvns-widget-compact--threads-full">
+    <div class="gvns-widget-compact__label">Recent Threads</div>
+    {posts.length === 0 ? (
+      <div class="gvns-widget-compact__empty">Quiet on Threads.</div>
+    ) : (
+      <div class="gvns-widget-compact__content">
+        {posts.map((p) => (
+          <a href={p.permalink} target="_blank" rel="noopener noreferrer" class="gvns-widget-compact__link">
+            <div class="gvns-widget-compact__info">
+              <p class="gvns-widget-compact__title">{truncate(p.text || '', 140)}</p>
+              <div class="gvns-widget-compact__meta">
+                {mediaBadge[p.mediaType] && <span class="gvns-widget-compact__badge">{mediaBadge[p.mediaType]}</span>}
+                <span class="gvns-widget-compact__timestamp">{relativeTime(p.timestamp)}</span>
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+    )}
+    <a
+      class="gvns-widget-compact__footer"
+      href="https://www.threads.net/@ggfevans"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      See more on Threads &rarr;
+    </a>
+  </article>
+)}
 
 <style>
-  .gvns-widget-compact--threads {
+  /* Full (non-compact) variant retains the multi-post stack styling used on /now etc. */
+  .gvns-widget-compact--threads-full {
     padding: var(--space-4);
-    border-top: 2px solid var(--widget-accent);
+    border-top: 2px solid var(--widget-accent, var(--colour-p6-crimson));
   }
 
-  .gvns-widget-compact__meta {
+  .gvns-widget-compact--threads-full .gvns-widget-compact__meta {
     display: flex;
     gap: 0.5rem;
     align-items: center;
@@ -88,7 +110,7 @@ const mediaBadge: Record<string, string> = {
     opacity: 0.7;
   }
 
-  .gvns-widget-compact__badge {
+  .gvns-widget-compact--threads-full .gvns-widget-compact__badge {
     font-family: var(--font-mono);
     font-size: 0.65rem;
     padding: 0 0.25rem;

--- a/src/components/widgets/WatchWidget.astro
+++ b/src/components/widgets/WatchWidget.astro
@@ -48,7 +48,7 @@ const watchedDate = latestWatch?.watchedDate && !Number.isNaN(new Date(latestWat
       )}
     </div>
     <div class="gvns-widget-compact__body">
-      <div class="gvns-widget-compact__label">Now Watching</div>
+      <div class="gvns-widget-compact__label">Watching</div>
       {latestWatch ? (
         <a href="/watch" class="gvns-widget-compact__link">
           <p class="gvns-widget-compact__title">{latestWatch.title}</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,9 +8,7 @@ import RecentPostsList from '@components/RecentPostsList.astro';
 import ReadWidget from '@components/widgets/ReadWidget.astro';
 import ListenWidget from '@components/widgets/ListenWidget.astro';
 import WatchWidget from '@components/widgets/WatchWidget.astro';
-import CodeWidget from '@components/widgets/CodeWidget.astro';
 import GameWidget from '@components/widgets/GameWidget.astro';
-import MoveWidget from '@components/widgets/MoveWidget.astro';
 import ThreadsWidget from '@components/widgets/ThreadsWidget.astro';
 import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 import { SITE_BIO } from '@utils/site';
@@ -20,6 +18,46 @@ const posts = (await getCollection('posts'))
   .filter((post) => (import.meta.env.PROD ? !post.data.draft : true))
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 5);
+
+// All six activity data sources, loaded once and used to derive both the
+// `last fetched` timestamp under the Now heading and the inline Code/Move chips.
+const dataModules = await Promise.all([
+  import('../data/reading.json'),
+  import('../data/listening.json'),
+  import('../data/watching.json'),
+  import('../data/gaming.json'),
+  import('../data/github.json'),
+  import('../data/whoop.json'),
+]);
+const [, , , , githubData, whoopData] = dataModules.map((m) => m.default as Record<string, unknown>);
+
+const lastFetchMs = dataModules
+  .map((m) => (m.default as { lastUpdated?: string | null }).lastUpdated)
+  .filter((s): s is string => Boolean(s))
+  .map((s) => new Date(s).getTime())
+  .filter((t) => !Number.isNaN(t))
+  .reduce((max, t) => (t > max ? t : max), 0);
+const lastFetch = lastFetchMs > 0 ? new Date(lastFetchMs) : null;
+const lastFetchDisplay = lastFetch
+  ? `${lastFetch.toISOString().slice(0, 10)} · ${lastFetch.toISOString().slice(11, 16)} UTC`
+  : null;
+const lastFetchIso = lastFetch?.toISOString() ?? '';
+
+// Coding chip: current streak + last-7-day contribution sparkline (level 0-4).
+const codeStreak = Number((githubData?.streak as { current?: number })?.current ?? 0);
+const codeDays = ((githubData?.calendar as { weeks?: Array<{ days?: Array<{ level?: number }> }> })?.weeks ?? [])
+  .flatMap((w) => w.days ?? [])
+  .slice(-7)
+  .map((d) => Number(d?.level ?? 0));
+const codeHasSignal = codeStreak > 0 || codeDays.some((l) => l > 0);
+
+// Move chip: latest workout summary + recent-strain sparkline (newest right).
+interface Workout { sport?: string; durationMinutes?: number; strain?: number }
+const recentWorkouts = ((whoopData?.recentWorkouts as Workout[]) ?? []);
+const moveLatest = recentWorkouts[0] ?? null;
+const moveStrain = recentWorkouts.slice(0, 7).reverse().map((w) => Number(w?.strain) || 0);
+const moveStrainMax = Math.max(...moveStrain, 1);
+const moveHasSignal = !!moveLatest;
 
 const siteUrl = normalizeSiteUrl(Astro.site);
 const jsonLd = toJsonLd(websiteSchema(siteUrl));
@@ -39,7 +77,6 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         </div>
         <div class="gvns-home__sidebar">
           <RecentPostsList posts={posts.slice(1, 5)} />
-          <ThreadsWidget compact />
         </div>
       </section>
     ) : posts.length === 1 ? (
@@ -53,19 +90,55 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         </p>
       </section>
     )}
-    {posts.length <= 1 && (
-      <section class="gvns-home__threads-solo" aria-label="Recent Threads">
-        <ThreadsWidget compact />
-      </section>
-    )}
     <section class="gvns-activity-widgets" aria-label="Current activity">
+      <header class="gvns-now">
+        <div class="gvns-now__row">
+          <h2 class="gvns-now__title">Now</h2>
+          <span class="gvns-now__cursor" aria-hidden="true"></span>
+        </div>
+        <div class="gvns-now__meta">
+          {lastFetch && (
+            <p class="gvns-now__date">
+              <span class="gvns-now__branch" aria-hidden="true">&#x2514;</span>
+              <time datetime={lastFetchIso}>{lastFetchDisplay}</time>
+            </p>
+          )}
+          <div class="gvns-now__stats">
+            {codeHasSignal && (
+              <a href="/code" class="gvns-now__chip gvns-now__chip--code">
+                <span class="gvns-now__chip-spark" aria-hidden="true">
+                  {codeDays.map((level) => (
+                    <i style={`height: ${Math.max((level / 4) * 100, 12)}%; opacity: ${0.3 + (level / 4) * 0.7}`}></i>
+                  ))}
+                </span>
+                <span class="gvns-now__chip-text">
+                  <span class="gvns-now__chip-label">coding</span>
+                  <span class="gvns-now__chip-value">{codeStreak}-day streak</span>
+                </span>
+              </a>
+            )}
+            {moveHasSignal && (
+              <a href="/move" class="gvns-now__chip gvns-now__chip--move">
+                <span class="gvns-now__chip-spark" aria-hidden="true">
+                  {moveStrain.map((s) => (
+                    <i style={`height: ${Math.max((s / moveStrainMax) * 100, 12)}%; opacity: ${0.4 + (s / moveStrainMax) * 0.6}`}></i>
+                  ))}
+                </span>
+                <span class="gvns-now__chip-text">
+                  <span class="gvns-now__chip-label">move</span>
+                  <span class="gvns-now__chip-value">{moveLatest!.sport} &middot; {moveLatest!.durationMinutes}m</span>
+                </span>
+              </a>
+            )}
+          </div>
+        </div>
+      </header>
       <div class="gvns-activity-grid">
         <ReadWidget compact />
         <ListenWidget compact />
-        <GameWidget compact />
         <WatchWidget compact />
-        <CodeWidget compact />
-        <MoveWidget compact />
+        <GameWidget compact />
+        <ThreadsWidget compact />
       </div>
     </section>
   </main>
@@ -124,12 +197,140 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   .gvns-activity-widgets {
     padding-block: var(--space-2);
   }
-  /* Auto-fit with a card-width floor — no jarring breakpoint snap.
-     At any viewport, columns scale smoothly between 1 and 6 cards-per-row
-     while every card stays ≥ ~190px so frame imagery never shrinks below readable. */
+  /* Bento: six column units. Four single tiles (Read P1 → Listen P2 → Watch P3
+     → Play P4) plus the double-width Shitposting tile (P5 sky, spans 2 cols).
+     Move (P6 crimson) lives in the heading-meta chip row. Activity-to-token
+     mapping is canonical left-to-right and shared with the masthead/footer
+     gradients. The threads span-2 + frame aspect rule lives in widgets.css. */
   .gvns-activity-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: var(--space-4);
+  }
+  @media (max-width: 1023px) {
+    .gvns-activity-grid {
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+  }
+
+  /* "Now" heading layout:
+       title row   — "Now" + blinking cursor (left-aligned)
+       meta row    — branch-glyph date (left) + status chips (right, margin-left:auto)
+     Chips wrap below the date row at narrow widths via flex-wrap. */
+  .gvns-now {
+    margin-block-end: var(--space-4);
+  }
+  .gvns-now__row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+  }
+  .gvns-now__meta {
+    margin-top: var(--space-2);
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
+  }
+  .gvns-now__title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1.25rem;
+    line-height: 1;
+    color: var(--colour-text-primary);
+    margin: 0;
+    letter-spacing: -0.02em;
+  }
+  .gvns-now__cursor {
+    display: inline-block;
+    background: var(--colour-p5-sky);
+    width: 5px;
+    height: 15px;
+    transform: translateY(1px);
+    animation: gvns-now-cursor-blink 1.1s steps(1) infinite;
+  }
+  @keyframes gvns-now-cursor-blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .gvns-now__cursor { animation: none; }
+  }
+
+  /* Inline status chips — Coding (P1 violet) + Move (P6 crimson). Each is a
+     link to the relevant /code or /move detail page; the sparkline is decorative. */
+  .gvns-now__stats {
+    display: flex;
+    gap: var(--space-6);
+    margin-left: auto;
+    align-items: center;
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
+  }
+  .gvns-now__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
+    text-decoration: none;
+    color: inherit;
+    transition: color var(--transition-fast);
+  }
+  .gvns-now__chip:hover .gvns-now__chip-value,
+  .gvns-now__chip:focus-visible .gvns-now__chip-value {
+    color: var(--chip-accent);
+  }
+  .gvns-now__chip-spark {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 22px;
+    width: 72px;
+  }
+  .gvns-now__chip-spark > i {
+    display: block;
+    flex: 1;
+    background: var(--chip-accent);
+    border-radius: 1px;
+    min-height: 3px;
+  }
+  .gvns-now__chip-text {
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: 1;
+  }
+  .gvns-now__chip-label {
+    color: var(--colour-text-muted);
+    text-transform: lowercase;
+    letter-spacing: 0.04em;
+  }
+  .gvns-now__chip-value {
+    color: var(--colour-text-secondary);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    transition: color var(--transition-fast);
+  }
+  .gvns-now__chip--code { --chip-accent: var(--colour-p1-violet); }
+  .gvns-now__chip--move { --chip-accent: var(--colour-p6-crimson); }
+
+  .gvns-now__date {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--colour-text-muted);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .gvns-now__branch {
+    color: var(--colour-p5-sky);
+    opacity: 0.55;
+  }
+  .gvns-now__date time {
+    color: inherit;
+    font-variant-numeric: tabular-nums;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,8 +93,11 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     <section class="gvns-activity-widgets" aria-label="Current activity">
       <header class="gvns-now">
         <div class="gvns-now__row">
-          <h2 class="gvns-now__title">Now</h2>
+          <h2 class="gvns-now__title">
+            <a class="gvns-now__link" href="/now">Now</a>
+          </h2>
           <span class="gvns-now__cursor" aria-hidden="true"></span>
+          <span class="gvns-now__arrow" aria-hidden="true">&rarr;</span>
         </div>
         <div class="gvns-now__meta">
           {lastFetch && (
@@ -254,8 +257,44 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     0%, 50% { opacity: 1; }
     51%, 100% { opacity: 0; }
   }
+
+  /* The heading word itself links to /now. P5 Sky is the design system's
+     status/now accent — hover/focus pick up sky-hover (sky-400) and the
+     decorative trailing arrow nudges 2px right via :has(). */
+  .gvns-now__link {
+    color: inherit;
+    text-decoration: none;
+    border-radius: 2px;
+    transition: color var(--transition-fast);
+  }
+  .gvns-now__link:hover,
+  .gvns-now__link:focus-visible {
+    color: var(--colour-p5-sky-hover);
+  }
+  .gvns-now__link:focus-visible {
+    outline: 2px solid var(--colour-p5-sky-hover);
+    outline-offset: 3px;
+  }
+  .gvns-now__arrow {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    line-height: 1;
+    color: var(--colour-text-muted);
+    transition: color var(--transition-fast), transform var(--transition-fast);
+  }
+  .gvns-now__row:has(.gvns-now__link:hover) .gvns-now__arrow,
+  .gvns-now__row:has(.gvns-now__link:focus-visible) .gvns-now__arrow {
+    color: var(--colour-p5-sky-hover);
+    transform: translateX(2px);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .gvns-now__cursor { animation: none; }
+    .gvns-now__arrow { transition: color var(--transition-fast); }
+    .gvns-now__row:has(.gvns-now__link:hover) .gvns-now__arrow,
+    .gvns-now__row:has(.gvns-now__link:focus-visible) .gvns-now__arrow {
+      transform: none;
+    }
   }
 
   /* Inline status chips — Coding (P1 violet) + Move (P6 crimson). Each is a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import ListenWidget from '@components/widgets/ListenWidget.astro';
 import WatchWidget from '@components/widgets/WatchWidget.astro';
 import GameWidget from '@components/widgets/GameWidget.astro';
 import ThreadsWidget from '@components/widgets/ThreadsWidget.astro';
+import IconBrandGithub from '@tabler/icons/outline/brand-github.svg';
 import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 import { SITE_BIO } from '@utils/site';
 import '@styles/widgets.css';
@@ -109,6 +110,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
           <div class="gvns-now__stats">
             {codeHasSignal && (
               <a href="/code" class="gvns-now__chip gvns-now__chip--code">
+                <IconBrandGithub class="gvns-now__chip-icon" aria-hidden="true" />
                 <span class="gvns-now__chip-spark" aria-hidden="true">
                   {codeDays.map((level) => (
                     <i style={`height: ${Math.max((level / 4) * 100, 12)}%; opacity: ${0.3 + (level / 4) * 0.7}`}></i>
@@ -318,6 +320,15 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   .gvns-now__chip:hover .gvns-now__chip-value,
   .gvns-now__chip:focus-visible .gvns-now__chip-value {
     color: var(--chip-accent);
+  }
+  /* GitHub source attribution mark on the coding chip — kept small so the
+     sparkline stays the chip's primary visual. Picks up --chip-accent so the
+     icon, sparkline, and value share the P1 Violet column on hover/focus. */
+  .gvns-now__chip-icon {
+    width: 14px;
+    height: 14px;
+    color: var(--chip-accent);
+    flex-shrink: 0;
   }
   .gvns-now__chip-spark {
     display: inline-flex;

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -100,12 +100,44 @@
   padding: var(--space-4);
 }
 
-/* Per-variant accent colours — single source of truth for border + hover */
-.gvns-widget-compact--read    { --widget-accent: var(--colour-p2-rose); }
-.gvns-widget-compact--listen  { --widget-accent: var(--colour-p3-emerald); }
-.gvns-widget-compact--watch   { --widget-accent: var(--colour-p4-amber); }
-.gvns-widget-compact--code    { --widget-accent: var(--colour-p1-violet); }
-.gvns-widget-compact--game    { --widget-accent: var(--colour-p5-sky); }
+/* Per-variant accent colours — single source of truth for border + hover.
+   Mapping is aligned with the masthead/footer canonical gradient (P1→P6):
+     P1 violet  = read       (was P2 rose)
+     P2 rose    = listen     (was P3 emerald)
+     P3 emerald = watch      (was P4 amber)
+     P4 amber   = play/write (was P5 sky for play)
+     P5 sky     = threads    (was P6 crimson)
+     P6 crimson = move       (unchanged)
+   Code keeps violet for chip use (shared with read tile). */
+.gvns-widget-compact--read    { --widget-accent: var(--colour-p1-violet); }
+.gvns-widget-compact--listen  { --widget-accent: var(--colour-p2-rose); }
+.gvns-widget-compact--watch   { --widget-accent: var(--colour-p3-emerald); }
+.gvns-widget-compact--game    { --widget-accent: var(--colour-p4-amber); }
 .gvns-widget-compact--write   { --widget-accent: var(--colour-p4-amber); }
 .gvns-widget-compact--threads { --widget-accent: var(--colour-p5-sky); }
+.gvns-widget-compact--code    { --widget-accent: var(--colour-p1-violet); }
+
+/* When the Threads tile sits in the home-page activity grid, it spans two
+   columns (text-heavy content earns the wider tile). Frame aspect tuned so
+   double-tile-frame-height === single-tile-frame-height — colour line
+   stays at the same y-position as the single-width media tiles.
+
+   Math: double_tile_width = 2*col + gap; we want frame_height = col,
+   so aspect = (2*col + gap) / col = 2 + gap/col.
+   At desktop (6 cols, container 1248px, gap 16px): col ≈ 194.67,
+   gap/col ≈ 0.0822, aspect ≈ 2.083. */
+.gvns-activity-grid > .gvns-widget-compact--threads {
+  grid-column: span 2;
+}
+.gvns-activity-grid > .gvns-widget-compact--threads .gvns-widget-compact__frame {
+  aspect-ratio: 2.083 / 1;
+}
+@media (max-width: 1023px) {
+  .gvns-activity-grid > .gvns-widget-compact--threads {
+    grid-column: auto;
+  }
+  .gvns-activity-grid > .gvns-widget-compact--threads .gvns-widget-compact__frame {
+    aspect-ratio: 1 / 1;
+  }
+}
 .gvns-widget-compact--move   { --widget-accent: var(--colour-p6-crimson); }


### PR DESCRIPTION
## **User description**
## Summary

Two layered changes on the home page:

1. **Closes #585** (Stage 1 — Now section): heading `<h2><a href="/now">Now …</a></h2>` with P5 Sky hover/focus, single-word widget labels (Reading / Listening / Watching / Coding / Playing), and a tabler `brand-github` mark inside the new coding chip as the tracking-source attribution.
2. **Option C hero-card / bento refactor** (separately scoped in #585's "Out of Scope"): explicit 6-col bento with `ThreadsWidget` spanning 2 cols and a new compact hero variant, `CodeWidget` + `MoveWidget` demoted to sparkline chips in a new heading row, last-fetched timestamp under the heading, and a left-to-right widget accent recanonicalisation (P1 violet → P6 crimson) aligned with the masthead/footer gradient.

The #585 ACs are explicitly satisfied:

| AC | Status |
|----|--------|
| 1. `<h2><a href="/now">Now …</a></h2>` above grid | ✅ `ac4297f` |
| 2. P5 Sky hover/focus + focus-visible ring, both themes | ✅ `ac4297f` |
| 3. Five widget labels single-word | ✅ `93c857b` |
| 4. CodeWidget shows GitHub mark in P1 Violet | ✅ `cdfbfee` (on the live home Code surface — the coding chip; `<CodeWidget compact />` has no current callers, so its fallback-icon swap is a follow-up if/when that mode re-mounts) |
| 5. No regressions on full-mode rendering | ✅ `/now` (full mode) unchanged |

### Notable design choices
- **CodeRabbit Design Choice 1**: used `@tabler/icons/outline/brand-github.svg` rather than introducing Lucide — repo already standardises on tabler (Footer, About, etc.).
- **Cursor + arrow**: the heading's terminal-prompt cursor (added in `93c857b`) stays as decorative chrome between the link and the arrow; the arrow nudges 2px right on hover/focus via `:has()`.
- **Widget accent shift**: read=P1, listen=P2, watch=P3, game=P4, threads=P5, move=P6. Code/chip retain violet. Aligned with the canonical masthead/footer gradient.

## Test plan

- [ ] Visual check on `/` at sm / md / xl breakpoints — heading row, chip row, bento grid
- [ ] Keyboard tab through the heading: focus-visible ring on `Now`, arrow + colour both react
- [ ] Hover the `Now` link: text turns sky, decorative arrow nudges right + matches colour
- [ ] Toggle dark/light themes — P5 Sky hover/focus still legible in both
- [ ] `prefers-reduced-motion`: cursor stops blinking, arrow doesn't translate
- [ ] `/now` page renders unchanged (`CodeWidget` full mode)
- [ ] Lighthouse a11y on `/` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Refresh the home page activity section and fix poster fetching for watched items**

### What Changed
- Reworked the home page “Now” area so it shows the latest update time, a linked heading, and two inline status chips for coding and movement activity.
- Shortened the compact labels on the reading, listening, watching, coding, and gaming tiles, and moved Threads into the main activity grid with a wider layout.
- Updated the activity tile colors so they follow one consistent order across the home page.
- Fixed poster lookups so watched items can fetch their artwork reliably again instead of appearing as missing data.

### Impact
`✅ Clearer home page activity overview`
`✅ Fewer empty watched-item posters`
`✅ Easier access to coding and workout status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Now" section to the homepage showcasing current GitHub coding activity and latest WHOOP workout data.

* **Style**
  * Simplified activity widget labels for a cleaner appearance.
  * Redesigned activity grid layout with updated visual styling and color accents.
  * Enhanced Threads widget layout for improved visibility on desktop displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->