### PR TITLE
fix(threads): trim access token and pin fetch workflow to Node 24

### DIFF
--- a/.github/workflows/fetch-threads-feed.yml
+++ b/.github/workflows/fetch-threads-feed.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Fetch threads feed (smart short-circuit inside script)
         env:

--- a/scripts/fetch-threads-feed.mjs
+++ b/scripts/fetch-threads-feed.mjs
@@ -1,7 +1,7 @@
 import { writeFile, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-const TOKEN = process.env.THREADS_ACCESS_TOKEN;
+const TOKEN = process.env.THREADS_ACCESS_TOKEN?.trim();
 const OUT = resolve('src/data/threads.json');
 const BASE = 'https://graph.threads.net/v1.0/me/threads';
 const FIELDS = 'id,text,media_type,permalink,timestamp,is_quote_post';


### PR DESCRIPTION
## **User description**
## Problem

`fetch-threads-feed` was failing every run with:

```
Threads API 400: {"error":{"message":"Invalid OAuth access token - Cannot parse access token","type":"OAuthException","code":190}}
```

## Root cause

"Cannot parse access token" (vs. an expiry/permission error) means Threads received a malformed token string. The `THREADS_ACCESS_TOKEN` secret carried a trailing newline/whitespace, and the script interpolated it raw and unencoded into the request URL (`&access_token=${TOKEN}`), so the stray character was sent to the API.

Confirmed by bisect: the same fresh token fetched successfully when run locally (bypassing the secret layer).

## Changes

- `scripts/fetch-threads-feed.mjs` — `process.env.THREADS_ACCESS_TOKEN?.trim()` so a stray newline/whitespace can never reach the API. The `if (!TOKEN)` guard still holds (whitespace-only → `''`, falsy).
- `.github/workflows/fetch-threads-feed.yml` — pin `node-version` 20 → 24.

## Verification

- Local run with the fresh token wrote 2 posts successfully.
- Secret being re-set cleanly via `printf %s | gh secret set` (no trailing newline). After merge, `gh workflow run fetch-threads-feed.yml` confirms CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent Threads feed runs from failing on a malformed access token**

### What Changed
- The Threads feed job now ignores stray whitespace around the saved access token, so a trailing newline no longer breaks API requests
- The workflow now runs on Node 24 instead of Node 20

### Impact
`✅ Fewer Threads feed failures`
`✅ More reliable scheduled feed updates`
`✅ Consistent workflow runs on the current Node version`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication token validation to properly handle leading and trailing whitespace in tokens.

* **Chores**
  * Updated build environment to Node.js version 24.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->