### PR TITLE
chore(ci): standardize all workflows on Node 24

### DIFF
--- a/.github/actions/fetch-github/action.yml
+++ b/.github/actions/fetch-github/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '25'
+        node-version: '24'
 
     - name: Install action dependencies
       shell: bash

--- a/.github/actions/fetch-steam/action.yml
+++ b/.github/actions/fetch-steam/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '25'
+        node-version: '24'
 
     - name: Install action dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "25.8.1"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/fetch-comments.yml
+++ b/.github/workflows/fetch-comments.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "25.8.1"
+          node-version: "24"
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/refresh-threads-token.yml
+++ b/.github/workflows/refresh-threads-token.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "25.8.1"
+          node-version: "24"
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/syndicate.yml
+++ b/.github/workflows/syndicate.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "25.8.1"
+          node-version: "24"
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## **User description**
Standardizes every Node-using workflow and composite action on **Node 24** (current LTS), down from the non-LTS Node 25 line. Companion to #613, which pins `fetch-threads-feed` to 24.

## Changes

| File | Before | After |
|------|--------|-------|
| `ci.yml` | `25.8.1` | `24` |
| `syndicate.yml` | `25.8.1` | `24` |
| `fetch-comments.yml` | `25.8.1` | `24` |
| `refresh-threads-token.yml` | `25.8.1` | `24` |
| `actions/fetch-github/action.yml` | `25` | `24` |
| `actions/fetch-steam/action.yml` | `25` | `24` |

`fetch-threads-feed.yml` is intentionally untouched here — it's bumped to 24 in #613 to avoid a merge conflict.

## Notes

- This is a deliberate downgrade from the odd-numbered Node 25 line to the 24 LTS line, plus a loosening from exact-patch (`25.8.1`) to major (`24`, latest patch). If you'd rather keep exact-patch pinning, say the word and I'll set a specific `24.x.y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use Node 24 across CI workflows and shared actions

### What Changed
- Build, comment fetching, syndication, and token refresh workflows now run on Node 24 instead of Node 25
- The shared GitHub and Steam fetch actions now also use Node 24
- All Node-based automation is now aligned on the same LTS version

### Impact
`✅ Fewer CI version mismatches`
`✅ More reliable workflow runs`
`✅ Consistent Node setup across automation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version from 25.x to version 24 across all GitHub Actions and CI/CD workflows, including build pipelines, automated deployment scripts, and action configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->