### PR TITLE
feat: relocate & restyle Threads widget to homepage sidebar (#649)

### DIFF
--- a/src/components/widgets/ThreadsWidget.astro
+++ b/src/components/widgets/ThreadsWidget.astro
@@ -1,5 +1,6 @@
 ---
 import { relativeTime, truncate } from '@utils/format';
+import IconBrandThreads from '@tabler/icons/outline/brand-threads.svg';
 
 interface Props {
   compact?: boolean;
@@ -66,7 +67,18 @@ const latestPost = posts[0] ?? null;
   </article>
 ) : (
   <article class="gvns-widget-compact gvns-widget-compact--threads gvns-widget-compact--threads-full">
-    <div class="gvns-widget-compact__label">Recent Threads</div>
+    <header class="gvns-threads__header">
+      <IconBrandThreads class="gvns-threads__logo" aria-hidden="true" />
+      <span class="gvns-threads__id">
+        <span class="gvns-threads__name">Threads</span>
+        <a
+          class="gvns-threads__handle"
+          href="https://www.threads.net/@ggfevans"
+          target="_blank"
+          rel="noopener noreferrer"
+        >@ggfevans</a>
+      </span>
+    </header>
     {posts.length === 0 ? (
       <div class="gvns-widget-compact__empty">Quiet on Threads.</div>
     ) : (
@@ -96,20 +108,92 @@ const latestPost = posts[0] ?? null;
 )}
 
 <style>
-  /* Full (non-compact) variant retains the multi-post stack styling used on /now etc. */
+  /* Full (non-compact) variant — brand-forward 3-post stack used in the home
+     sidebar. The sky accent strip comes from --widget-accent (set by the
+     .gvns-widget-compact--threads class); the crimson fallback is defensive. */
   .gvns-widget-compact--threads-full {
     padding: var(--space-4);
     border-top: 2px solid var(--widget-accent, var(--colour-p6-crimson));
+  }
+
+  /* Brand header: Threads logo + stacked name/handle, sits above the post stack. */
+  .gvns-threads__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding-bottom: var(--space-3);
+    margin-bottom: var(--space-3);
+    border-bottom: 1px solid var(--colour-border);
+  }
+  .gvns-threads__logo {
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--colour-p5-sky);
+    flex-shrink: 0;
+  }
+  .gvns-threads__id {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.15;
+  }
+  .gvns-threads__name {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: var(--text-sm);
+    color: var(--colour-text-primary);
+  }
+  .gvns-threads__handle {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--colour-text-muted);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+  .gvns-threads__handle:hover,
+  .gvns-threads__handle:focus-visible {
+    color: var(--colour-p5-sky-hover);
+  }
+
+  /* Post stack — each post separated by a hairline divider. */
+  .gvns-widget-compact--threads-full .gvns-widget-compact__content {
+    display: flex;
+    flex-direction: column;
+  }
+  .gvns-widget-compact--threads-full .gvns-widget-compact__link {
+    display: block;
+    padding-block: var(--space-3);
+    border-top: 1px solid var(--colour-border);
+  }
+  .gvns-widget-compact--threads-full .gvns-widget-compact__link:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  /* Override the shared single-line title — full-variant posts wrap to ~3 lines. */
+  .gvns-widget-compact--threads-full .gvns-widget-compact__title {
+    white-space: normal;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    font-weight: 500;
+    line-height: 1.4;
+    margin-bottom: var(--space-2);
   }
 
   .gvns-widget-compact--threads-full .gvns-widget-compact__meta {
     display: flex;
     gap: 0.5rem;
     align-items: center;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     opacity: 0.7;
   }
-
+  .gvns-widget-compact--threads-full .gvns-widget-compact__timestamp {
+    font-family: var(--font-mono);
+    color: var(--colour-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
   .gvns-widget-compact--threads-full .gvns-widget-compact__badge {
     font-family: var(--font-mono);
     font-size: 0.65rem;
@@ -117,5 +201,26 @@ const latestPost = posts[0] ?? null;
     border-radius: 0.125rem;
     background: var(--colour-bg-tertiary);
     color: var(--colour-text-secondary);
+  }
+
+  /* Footer CTA — divider above, mono link with nudging arrow on hover. */
+  .gvns-widget-compact--threads-full .gvns-widget-compact__footer {
+    display: inline-block;
+    margin-top: var(--space-3);
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--colour-border);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--colour-text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+  .gvns-widget-compact--threads-full .gvns-widget-compact__footer:hover,
+  .gvns-widget-compact--threads-full .gvns-widget-compact__footer:focus-visible {
+    color: var(--colour-p5-sky-hover);
+  }
+
+  .gvns-widget-compact--threads-full .gvns-widget-compact__empty {
+    padding: 0;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,6 +78,7 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         </div>
         <div class="gvns-home__sidebar">
           <RecentPostsList posts={posts.slice(1, 5)} />
+          <ThreadsWidget />
         </div>
       </section>
     ) : posts.length === 1 ? (
@@ -143,7 +144,6 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
         <ListenWidget compact />
         <WatchWidget compact />
         <GameWidget compact />
-        <ThreadsWidget compact />
       </div>
     </section>
   </main>
@@ -202,14 +202,14 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
   .gvns-activity-widgets {
     padding-block: var(--space-2);
   }
-  /* Bento: six column units. Four single tiles (Read P1 → Listen P2 → Watch P3
-     → Play P4) plus the double-width Shitposting tile (P5 sky, spans 2 cols).
-     Move (P6 crimson) lives in the heading-meta chip row. Activity-to-token
-     mapping is canonical left-to-right and shared with the masthead/footer
-     gradients. The threads span-2 + frame aspect rule lives in widgets.css. */
+  /* Bento: four equal tiles (Read P1 → Listen P2 → Watch P3 → Play P4).
+     Threads (P5 sky) now lives in the upper-right sidebar beside the featured
+     post, not in this row. Move (P6 crimson) lives in the heading-meta chip
+     row. Activity-to-token mapping is canonical left-to-right and shared with
+     the masthead/footer gradients. */
   .gvns-activity-grid {
     display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--space-4);
   }
   @media (max-width: 1023px) {

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -116,28 +116,4 @@
 .gvns-widget-compact--write   { --widget-accent: var(--colour-p4-amber); }
 .gvns-widget-compact--threads { --widget-accent: var(--colour-p5-sky); }
 .gvns-widget-compact--code    { --widget-accent: var(--colour-p1-violet); }
-
-/* When the Threads tile sits in the home-page activity grid, it spans two
-   columns (text-heavy content earns the wider tile). Frame aspect tuned so
-   double-tile-frame-height === single-tile-frame-height — colour line
-   stays at the same y-position as the single-width media tiles.
-
-   Math: double_tile_width = 2*col + gap; we want frame_height = col,
-   so aspect = (2*col + gap) / col = 2 + gap/col.
-   At desktop (6 cols, container 1248px, gap 16px): col ≈ 194.67,
-   gap/col ≈ 0.0822, aspect ≈ 2.083. */
-.gvns-activity-grid > .gvns-widget-compact--threads {
-  grid-column: span 2;
-}
-.gvns-activity-grid > .gvns-widget-compact--threads .gvns-widget-compact__frame {
-  aspect-ratio: 2.083 / 1;
-}
-@media (max-width: 1023px) {
-  .gvns-activity-grid > .gvns-widget-compact--threads {
-    grid-column: auto;
-  }
-  .gvns-activity-grid > .gvns-widget-compact--threads .gvns-widget-compact__frame {
-    aspect-ratio: 1 / 1;
-  }
-}
 .gvns-widget-compact--move   { --widget-accent: var(--colour-p6-crimson); }


### PR DESCRIPTION
## **User description**
## Summary

Relocates the Threads (Meta) feed from the bottom *Now* activity bar into the dead space in the upper-right homepage sidebar (below the recent-posts list, beside the featured post), and rebalances the freed-up Now bar.

- **Threads → sidebar:** uses the existing full 3-post variant of `ThreadsWidget` with a new **brand-forward header** — Tabler `brand-threads` logo (sky-tinted) + "Threads" + `@ggfevans` handle, above the P5 sky accent strip. Posts wrap to ~3 lines with hairline dividers and a "See more on Threads →" footer.
- **Now bar:** activity grid `repeat(6, …)` → `repeat(4, …)` so Read/Listen/Watch/Play become equal wider tiles; square media frames retained.
- **Cleanup:** removed the obsolete `.gvns-activity-grid > .gvns-widget-compact--threads` span-2 + `aspect-ratio: 2.083` rules (and their mobile override) from `widgets.css`.

The full variant was previously unrendered anywhere, so this PR also adds the scoped styles it needs (multi-line title override, post dividers, footer, timestamp) to match the approved design. The `compact` branch of `ThreadsWidget` is now unused on the homepage but kept intact for possible future reuse.

## Files changed
- `src/pages/index.astro` — move `<ThreadsWidget />` into sidebar; drop compact tile from grid; 6→4 col; refresh bento comment.
- `src/components/widgets/ThreadsWidget.astro` — brand header + scoped full-variant styles.
- `src/styles/widgets.css` — delete obsolete threads grid rules.

## Test plan
- [x] `npm run build` passes (`brand-threads.svg` import resolves; no orphaned CSS).
- [x] CodeRabbit review: 0 findings.
- [x] Rendered homepage contains the threads header (logo + `@ggfevans`) and a 4-column activity grid.
- [ ] Visual check desktop `>=1024px`: card fills sidebar dead space; 4 equal Now-bar tiles.
- [ ] Visual check mobile `<=1023px`: single-column stack; card full-width; tiles reflow.

Closes #649


___

## **CodeAnt-AI Description**
**Move Threads to the homepage sidebar and simplify the activity row**

### What Changed
- Threads now appears in the upper-right homepage sidebar beside the featured post instead of inside the activity grid
- The Threads card now shows a branded header with the Threads logo, account name, and handle, plus a clearer post list and footer link
- Threads posts can now take up more vertical space, with visible dividers between posts and a cleaner empty state
- The homepage activity row now uses four equal tiles instead of making room for Threads

### Impact
`✅ Clearer homepage layout`
`✅ Easier access to Threads updates`
`✅ More balanced activity tiles`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Threads brand icon and enhanced full widget layout with dedicated header and refined post display
  * Relocated Threads widget from activity grid to sidebar for improved organization

* **Style**
  * Updated activity grid to use consistent four-column layout
  * Enhanced footer styling and post dividers for better visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->