### PR TITLE
fix: scope Threads stack hover accent to the hovered post

### DIFF
--- a/src/components/widgets/ThreadsWidget.astro
+++ b/src/components/widgets/ThreadsWidget.astro
@@ -182,6 +182,19 @@ const latestPost = posts[0] ?? null;
     margin-bottom: var(--space-2);
   }
 
+  /* The shared `.gvns-widget-compact:hover .gvns-widget-compact__title` rule
+     lights up every title on card-hover — fine for single-post tiles, but this
+     stack has three. Neutralise the card-wide trigger and re-scope the accent
+     to the post link actually being hovered/focused. */
+  .gvns-widget-compact--threads-full:hover .gvns-widget-compact__title,
+  .gvns-widget-compact--threads-full:focus-within .gvns-widget-compact__title {
+    color: var(--colour-text-primary);
+  }
+  .gvns-widget-compact--threads-full .gvns-widget-compact__link:hover .gvns-widget-compact__title,
+  .gvns-widget-compact--threads-full .gvns-widget-compact__link:focus-visible .gvns-widget-compact__title {
+    color: var(--widget-accent, var(--colour-p5-sky));
+  }
+
   .gvns-widget-compact--threads-full .gvns-widget-compact__meta {
     display: flex;
     gap: 0.5rem;


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #650. In the new sidebar Threads stack, hovering anywhere on the card recoloured **all three** post titles to the sky accent instead of just the one under the cursor.

**Cause:** the shared rule `.gvns-widget-compact:hover .gvns-widget-compact__title` applies the accent to every `__title` descendant on card-hover. Fine for the single-post media tiles, but the full variant renders three titles.

**Fix:** for `.gvns-widget-compact--threads-full`, neutralise the card-wide hover/focus-within title trigger and re-scope the accent to the individual `__link:hover` / `:focus-visible`.

## Test plan
- [x] `npm run build` passes.
- [x] CodeRabbit: 0 findings.
- [x] Built CSS contains the per-link scoped hover rule.
- [ ] Visual: hovering one post highlights only that title; keyboard focus does the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined hover styling in the threaded posts widget to apply accent colors only to the specific post being hovered, improving visual clarity when interacting with posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Hovering one Threads post now highlights only that post**

### What Changed
- In the full Threads stack, hovering the card no longer turns every post title blue at once
- The highlight now stays on the specific post link being hovered or focused
- Keyboard focus follows the same behavior, so only the active post is emphasized

### Impact
`✅ Clearer post selection`
`✅ Less visual confusion in the Threads stack`
`✅ Consistent hover and keyboard focus feedback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
