### PR TITLE
fix: enlarge navbar avatar (26px → 40px)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -32,8 +32,8 @@ const statusOpen = status === 'open';
           <img
             src="/avatar.jpg"
             alt=""
-            width="26"
-            height="26"
+            width="40"
+            height="40"
             loading="eager"
             decoding="async"
             class="gvns-navbar__avatar"
@@ -101,8 +101,8 @@ const statusOpen = status === 'open';
         <img
           src="/avatar.jpg"
           alt=""
-          width="26"
-          height="26"
+          width="40"
+          height="40"
           loading="eager"
           decoding="async"
           class="gvns-navbar__avatar"
@@ -128,7 +128,9 @@ const statusOpen = status === 'open';
 <style>
   .gvns-navbar {
     position: relative;
-    padding: var(--space-4) var(--space-6);
+    /* Vertical padding trimmed (space-4 → space-3) so the enlarged avatar grows
+       without ballooning the bar height — the avatar now sets the row rhythm. */
+    padding: var(--space-3) var(--space-6);
     border-bottom: 1px solid var(--colour-border);
   }
 
@@ -169,8 +171,8 @@ const statusOpen = status === 'open';
   }
 
   .gvns-navbar__avatar {
-    width: 26px;
-    height: 26px;
+    width: 40px;
+    height: 40px;
     border-radius: 9999px;
     object-fit: cover;
     display: block;


### PR DESCRIPTION
## **User description**
## Summary

The top-bar avatar was **26px** — barely visible. This bumps it to **40px**, the largest size that still reads as a slim nav bar (not a profile header).

To keep the bar from ballooning, the navbar vertical padding is trimmed `space-4 → space-3` (16px → 12px), so the bar height only grows ~6px (≈58px → ≈64px) while the avatar grows 54%. The source asset is 256×256, so it stays crisp; intrinsic `width`/`height` attrs updated to `40` on both the desktop and mobile lockups to avoid layout shift.

## Test plan
- [x] `npm run build` passes; `40px` present in built CSS.
- [x] CodeRabbit: 0 findings.
- [ ] Visual: avatar clearly visible; bar still slim; nothing wraps/overflows at desktop, tablet (768px), and mobile.


___

## **CodeAnt-AI Description**
**Make the navbar avatar clearly visible without making the header bulky**

### What Changed
- The avatar in both desktop and mobile navigation is enlarged from 26px to 40px
- The navbar’s vertical padding is reduced so the header stays slim while the avatar stands out
- The avatar’s displayed size is updated to prevent layout shift when the page loads

### Impact
`✅ Easier-to-see profile branding in the header`
`✅ Slimmer navigation bar with a larger avatar`
`✅ Less layout shift on page load`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
