### PR TITLE
chore: refine Now bar — blur-backdrop cards + matched activity chips

### DIFF
--- a/src/components/widgets/GameWidget.astro
+++ b/src/components/widgets/GameWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { relativeTime, safeUrl } from '@utils/format';
+import { relativeTime, safeUrl, cssUrl } from '@utils/format';
 
 interface Props { compact?: boolean; }
 const { compact = false } = Astro.props;
@@ -58,7 +58,7 @@ const totalHours = Math.round(rawMinutes / 60);
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--game">
-    <div class="gvns-widget-compact__frame">
+    <div class="gvns-widget-compact__frame" style={coverSrc ? `--frame-img: ${cssUrl(coverSrc)}` : undefined}>
       {coverSrc ? (
         <img
           src={coverSrc}

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { relativeTime, isValidMbid } from '@utils/format';
+import { relativeTime, isValidMbid, cssUrl } from '@utils/format';
 
 interface Props { compact?: boolean; }
 const { compact = false } = Astro.props;
@@ -59,7 +59,7 @@ const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--listen">
-    <div class="gvns-widget-compact__frame">
+    <div class="gvns-widget-compact__frame" style={artUrl ? `--frame-img: ${cssUrl(artUrl)}` : undefined}>
       {artUrl && (
         <img src={artUrl} alt={`${latestTrack.album || latestTrack.track} album art`} class="gvns-widget-compact__image gvns-widget-compact__image--fill" loading="lazy" decoding="async" />
       )}

--- a/src/components/widgets/ListenWidget.astro
+++ b/src/components/widgets/ListenWidget.astro
@@ -61,7 +61,7 @@ const artUrl = isValidMbid(latestTrack?.caaReleaseMbid)
   <article class="gvns-widget-compact gvns-widget-compact--listen">
     <div class="gvns-widget-compact__frame" style={artUrl ? `--frame-img: ${cssUrl(artUrl)}` : undefined}>
       {artUrl && (
-        <img src={artUrl} alt={`${latestTrack.album || latestTrack.track} album art`} class="gvns-widget-compact__image gvns-widget-compact__image--fill" loading="lazy" decoding="async" />
+        <img src={artUrl} alt={`${latestTrack.album || latestTrack.track} album art`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
       )}
     </div>
     <div class="gvns-widget-compact__body">

--- a/src/components/widgets/ReadWidget.astro
+++ b/src/components/widgets/ReadWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { safeUrl } from '@utils/format';
+import { safeUrl, cssUrl } from '@utils/format';
 
 interface Props { compact?: boolean; }
 const { compact = false } = Astro.props;
@@ -41,7 +41,7 @@ const progress = typeof rawProgress === 'number' && !Number.isNaN(rawProgress)
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--read">
-    <div class="gvns-widget-compact__frame">
+    <div class="gvns-widget-compact__frame" style={coverSrc ? `--frame-img: ${cssUrl(coverSrc)}` : undefined}>
       {coverSrc && (
         <img src={coverSrc} alt={`Cover of ${currentBook.title}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
       )}

--- a/src/components/widgets/WatchWidget.astro
+++ b/src/components/widgets/WatchWidget.astro
@@ -1,5 +1,5 @@
 ---
-import { relativeTime, safeUrl } from '@utils/format';
+import { relativeTime, safeUrl, cssUrl } from '@utils/format';
 
 interface Props { compact?: boolean; }
 const { compact = false } = Astro.props;
@@ -40,7 +40,7 @@ const watchedDate = latestWatch?.watchedDate && !Number.isNaN(new Date(latestWat
 
 {compact ? (
   <article class="gvns-widget-compact gvns-widget-compact--watch">
-    <div class="gvns-widget-compact__frame">
+    <div class="gvns-widget-compact__frame" style={posterSrc ? `--frame-img: ${cssUrl(posterSrc)}` : undefined}>
       {posterSrc ? (
         <img src={posterSrc} alt={`Poster for ${latestWatch.title}`} class="gvns-widget-compact__image" loading="lazy" decoding="async" />
       ) : (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import WatchWidget from '@components/widgets/WatchWidget.astro';
 import GameWidget from '@components/widgets/GameWidget.astro';
 import ThreadsWidget from '@components/widgets/ThreadsWidget.astro';
 import IconBrandGithub from '@tabler/icons/outline/brand-github.svg';
+import IconActivityHeartbeat from '@tabler/icons/outline/activity-heartbeat.svg';
 import { websiteSchema, normalizeSiteUrl, toJsonLd } from '@utils/json-ld';
 import { SITE_BIO } from '@utils/site';
 import '@styles/widgets.css';
@@ -53,11 +54,18 @@ const codeDays = ((githubData?.calendar as { weeks?: Array<{ days?: Array<{ leve
 const codeHasSignal = codeStreak > 0 || codeDays.some((l) => l > 0);
 
 // Move chip: latest workout summary + recent-strain sparkline (newest right).
+// Padded to a fixed slot count so its bar widths match the coding chip's 7-day
+// spark — missing slots render as faint ghost bars rather than a few fat bars.
+const SPARK_SLOTS = 7;
 interface Workout { sport?: string; durationMinutes?: number; strain?: number }
 const recentWorkouts = ((whoopData?.recentWorkouts as Workout[]) ?? []);
 const moveLatest = recentWorkouts[0] ?? null;
-const moveStrain = recentWorkouts.slice(0, 7).reverse().map((w) => Number(w?.strain) || 0);
-const moveStrainMax = Math.max(...moveStrain, 1);
+const moveStrainRaw = recentWorkouts.slice(0, SPARK_SLOTS).reverse().map((w) => Number(w?.strain) || 0);
+const moveStrainMax = Math.max(...moveStrainRaw, 1);
+const moveSpark: (number | null)[] = [
+  ...Array(Math.max(0, SPARK_SLOTS - moveStrainRaw.length)).fill(null),
+  ...moveStrainRaw,
+];
 const moveHasSignal = !!moveLatest;
 
 const siteUrl = normalizeSiteUrl(Astro.site);
@@ -125,9 +133,12 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
             )}
             {moveHasSignal && (
               <a href="/move" class="gvns-now__chip gvns-now__chip--move">
+                <IconActivityHeartbeat class="gvns-now__chip-icon" aria-hidden="true" />
                 <span class="gvns-now__chip-spark" aria-hidden="true">
-                  {moveStrain.map((s) => (
-                    <i style={`height: ${Math.max((s / moveStrainMax) * 100, 12)}%; opacity: ${0.4 + (s / moveStrainMax) * 0.6}`}></i>
+                  {moveSpark.map((s) => (
+                    s === null
+                      ? <i class="gvns-now__chip-bar--ghost"></i>
+                      : <i style={`height: ${Math.max((s / moveStrainMax) * 100, 12)}%; opacity: ${0.4 + (s / moveStrainMax) * 0.6}`}></i>
                   ))}
                 </span>
                 <span class="gvns-now__chip-text">
@@ -343,6 +354,12 @@ const jsonLd = toJsonLd(websiteSchema(siteUrl));
     background: var(--chip-accent);
     border-radius: 1px;
     min-height: 3px;
+  }
+  /* Ghost bars pad the move spark to a fixed slot count so its bar widths match
+     the coding chip; faint and short to read as "no data for this slot". */
+  .gvns-now__chip-spark > i.gvns-now__chip-bar--ghost {
+    height: 12%;
+    opacity: 0.18;
   }
   .gvns-now__chip-text {
     display: inline-flex;

--- a/src/styles/widgets.css
+++ b/src/styles/widgets.css
@@ -36,6 +36,33 @@
   object-fit: cover;
 }
 
+/* Home Now-bar cards: a shorter 4:3 frame whose letterbox space is filled by a
+   blurred, darkened copy of the same artwork — so differently-shaped covers
+   share one edge-to-edge rhythm without cropping titles. Scoped to the activity
+   grid; other compact-widget usages keep the square frame above.
+   Each widget sets `--frame-img: url(<cover>)` on the frame; when unset the
+   ::before paints nothing and the flat bg-tertiary frame (icon fallback) shows. */
+.gvns-activity-grid .gvns-widget-compact__frame {
+  aspect-ratio: 4 / 3;
+  position: relative;
+}
+.gvns-activity-grid .gvns-widget-compact__frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: var(--frame-img, none);
+  background-size: cover;
+  background-position: center;
+  filter: blur(18px) brightness(0.45);
+  transform: scale(1.15);
+  z-index: 0;
+}
+/* Sharp artwork / icon sits above the blurred backdrop. */
+.gvns-activity-grid .gvns-widget-compact__frame > * {
+  position: relative;
+  z-index: 1;
+}
+
 /* Slot icons for text-only widgets (Code, Move) and missing-image fallbacks (Watch, Game) —
    inherit the widget's accent colour so the bento reads as a cohesive palette, not muted greys. */
 .gvns-widget-compact__icon {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -50,6 +50,12 @@ export function safeUrl(url: string | undefined | null): string | undefined {
   return undefined;
 }
 
+/** Build a CSS `url("...")` value with the URL escaped for the quoted-string
+ *  context (backslashes and double quotes), safe to embed in inline styles. */
+export function cssUrl(url: string): string {
+  return `url("${url.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}")`;
+}
+
 /** Format an ISO date string to a long human-readable timestamp. */
 export function formatTimestamp(dateString: string): string {
   const d = new Date(dateString);


### PR DESCRIPTION
## **User description**
## Summary

Fixes the three things that made the homepage Now bar feel "odd" (confirmed in a design brainstorm):

1. **Cards too big** → frame aspect `1/1 → 4/3` (scoped to `.gvns-activity-grid` only), dropping each card from ~300px to ~225px tall.
2. **No consistent rhythm** → each card's letterbox space is now filled by a **blurred, darkened copy of its own artwork** (a `::before` backdrop fed by a `--frame-img` custom property), with the sharp art kept **uncropped** (`object-fit: contain`) on top. Every card fills edge-to-edge; book/poster titles stay legible. Icon fallbacks keep the flat frame.
3. **Mismatched chips** → the move sparkline is padded to a fixed **7 slots** (faint ghost bars for empty slots) so its bar widths match the coding chip, and the move chip gains a **leading activity icon** mirroring the GitHub icon — a matched pair.

Adds a small `cssUrl()` helper (`src/utils/format.ts`) that escapes URLs for the `url("...")` context, used by all four widgets (addresses a CodeRabbit robustness note).

## Files
- `src/styles/widgets.css` — 4:3 frame + `::before` blur backdrop, scoped to the activity grid; children lifted above it.
- `src/components/widgets/{Read,Listen,Watch,Game}Widget.astro` — set `--frame-img: cssUrl(<cover>)` on the compact frame.
- `src/pages/index.astro` — pad move spark to 7 slots + ghost-bar style + move chip icon.
- `src/utils/format.ts` — `cssUrl()` helper.

## Test plan
- [x] `npm run build` passes; all four cards render the backdrop var; move chip shows 5 ghost + 2 data bars.
- [x] CodeRabbit: 0 findings (after the `cssUrl` escaping fix).
- [ ] Visual: cards shorter & edge-to-edge with blurred backdrops, covers uncropped; both chips 7 equal-width slots with matched icons.


___

## **CodeAnt-AI Description**
Make the homepage Now bar look tighter and more consistent

### What Changed
- The media cards in the Now bar are shorter and now use a blurred copy of their own artwork behind the main image, so covers fill the card edge-to-edge without cropping the visible art
- The reading, listening, watching, and gaming cards now keep their artwork aligned with the new card layout, and icon-only fallbacks still show a plain frame when no image is available
- The move activity chip now uses the same 7-slot rhythm as the coding chip and shows a leading activity icon, with faint ghost bars filling empty slots

### Impact
`✅ Cleaner homepage Now bar`
`✅ More consistent card sizing`
`✅ Matched activity chips`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact activity cards now support using item artwork as a blurred/dimmed backdrop for richer visuals.
  * Compact widgets set background images when covers/posters are available.
  * Move chip visualization updated with fixed-width sparkline and placeholder slots for consistent display.

* **Style**
  * Compact card aspect ratio changed to 4:3 and layering adjusted so content sits above the backdrop.

* **Chores**
  * Added a utility to safely embed image URLs into inline CSS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ggfevans/gvns.ca/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->