### PR TITLE
feat: Threads reply counts on post cards + fix bundle-post comment slug

### DIFF
--- a/scripts/fetch-comments.mjs
+++ b/scripts/fetch-comments.mjs
@@ -19,7 +19,7 @@
  */
 
 import { readdir, readFile, writeFile, mkdir, access } from 'node:fs/promises';
-import { join, basename, extname } from 'node:path';
+import { join, basename, dirname, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
 import { getReplies } from '@codybrom/denim';
@@ -50,9 +50,15 @@ async function collectMarkdownFiles(dir) {
   return files;
 }
 
-/** Get the slug from a markdown file path. */
+/**
+ * Get the canonical slug from a markdown file path.
+ * Bundle posts live in `<slug>/index.md`, so fall back to the parent directory
+ * name — mirrors getPostSlug() in src/utils/content.ts and keeps comment files
+ * keyed by the same slug the post is routed and rendered under.
+ */
 function getSlug(filePath) {
-  return basename(filePath, '.md');
+  const name = basename(filePath, '.md');
+  return name === 'index' ? basename(dirname(filePath)) : name;
 }
 
 /** Check whether a file exists. */

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import { parseCommentsData, EMPTY_COMMENTS } from '@utils/comments';
 import { relativeTime } from '@utils/format';
 import { formatDate } from '@utils/date';
+import { getPostSlug } from '@utils/content';
 
 interface Props {
   post: CollectionEntry<'posts'>;
@@ -16,8 +17,9 @@ let data = EMPTY_COMMENTS;
 if (threadsEntry) {
   try {
     const modules = import.meta.glob('../data/comments/*.json', { eager: true });
-    // post.id is always at least the filename, so .pop() is guaranteed to return a string
-    const slug = post.id.split('/').pop()!;
+    // Bundle posts (`<slug>/index.md`) have ids ending in `/index`; getPostSlug
+    // resolves those to the canonical slug the fetcher keys comment files by.
+    const slug = getPostSlug(post.id);
     const key = `../data/comments/${slug}.json`;
     if (modules[key]) {
       data = parseCommentsData((modules[key] as { default: unknown }).default);

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -4,6 +4,7 @@ import { formatDate } from '@utils/date';
 import { getReadingTime } from '@utils/reading-time';
 import TagList from './TagList.astro';
 import { getPostSlug } from '@utils/content';
+import { getReplyCount } from '@utils/comments';
 
 interface Props {
   post: CollectionEntry<'posts'>;
@@ -12,11 +13,15 @@ interface Props {
 }
 
 const { post, showReadingTime = true, headingLevel = 'h3' } = Astro.props;
-const { title, description, pubDate, tags } = post.data;
+const { title, description, pubDate, tags, syndication } = post.data;
 const readingTime = getReadingTime(post.body ?? '');
 const HeadingTag = headingLevel;
 
 const filename = getPostSlug(post.id);
+
+// Reply count surfaces on any post syndicated to Threads (0 until replies land).
+const isSyndicatedToThreads = syndication?.some((s) => s.platform === 'threads') ?? false;
+const replyCount = isSyndicatedToThreads ? getReplyCount(filename) : 0;
 ---
 
 <article class="post-card">
@@ -26,6 +31,11 @@ const filename = getPostSlug(post.id);
   <div class="post-meta">
     <time datetime={pubDate.toISOString()}>{formatDate(pubDate)}</time>
     {showReadingTime && <span class="reading-time">{readingTime} min read</span>}
+    {isSyndicatedToThreads && (
+      <span class="comment-count" aria-label={`${replyCount} ${replyCount === 1 ? 'reply' : 'replies'} on Threads`}>
+        {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+      </span>
+    )}
   </div>
   <p class="post-description">{description}</p>
   <TagList tags={tags} />
@@ -69,7 +79,8 @@ const filename = getPostSlug(post.id);
     margin-bottom: 0.75rem;
   }
 
-  .reading-time::before {
+  .reading-time::before,
+  .comment-count::before {
     content: "·";
     margin-right: 1rem;
   }

--- a/src/utils/comments.ts
+++ b/src/utils/comments.ts
@@ -34,8 +34,8 @@ export const EMPTY_COMMENTS: CommentsData = {
  */
 export function getReplyCount(slug: string): number {
   const posts = (commentsIndex as { posts?: Record<string, { count?: unknown }> }).posts ?? {};
-  const entry = posts[slug];
-  return entry && typeof entry.count === 'number' ? entry.count : 0;
+  const count = posts[slug]?.count;
+  return typeof count === 'number' && Number.isFinite(count) && count >= 0 ? count : 0;
 }
 
 export function parseCommentsData(raw: unknown): CommentsData {

--- a/src/utils/comments.ts
+++ b/src/utils/comments.ts
@@ -1,3 +1,5 @@
+import commentsIndex from '../data/comments/_index.json';
+
 export interface ThreadsReply {
   id: string;
   username: string;
@@ -24,6 +26,17 @@ export const EMPTY_COMMENTS: CommentsData = {
   fetchedAt: new Date(0).toISOString(),
   lastError: null,
 };
+
+/**
+ * Reply count for a post slug, read from the build-time comments index
+ * (`src/data/comments/_index.json`). Returns 0 when the post has no entry
+ * (never syndicated, no replies fetched yet, or the index is empty).
+ */
+export function getReplyCount(slug: string): number {
+  const posts = (commentsIndex as { posts?: Record<string, { count?: unknown }> }).posts ?? {};
+  const entry = posts[slug];
+  return entry && typeof entry.count === 'number' ? entry.count : 0;
+}
 
 export function parseCommentsData(raw: unknown): CommentsData {
   if (!raw || typeof raw !== 'object') return EMPTY_COMMENTS;


### PR DESCRIPTION
## **User description**
## Summary

Closes out the last buildable item on the **Threads comments epic (#238)** and fixes a latent slug bug the feature depends on.

The comments pipeline (`fetch-comments.mjs`, `fetch-comments.yml`, `Comments.astro`, `SyndicationLinks.astro`, post-layout wiring) was already shipped. Per the owner's status notes on #238, the only remaining code item was the **reply-count badge on `PostCard`** ("punt or do?") — this builds it, and while in the code adds a small hardening fix.

## What changed

**Reply-count badge (decision: show for all Threads-syndicated posts, 0 until replies land)**
- `PostCard.astro` — renders `"<n> replies"` in the post meta row for any post with a `threads` syndication entry, with an `aria-label`. Singular/plural handled.
- `comments.ts` — new `getReplyCount(slug)` helper reading the build-time `src/data/comments/_index.json`.

**Hardening — bundle-post slug collision (latent bug)**
All posts are bundle-style (`<slug>/index.md`), so `post.id` ends in `/index`. Both the fetcher (`basename(filePath, '.md')`) and `Comments.astro` (`post.id.split('/').pop()`) resolved to `"index"` — meaning every post would collide on `index.json` and never match its routed slug (`getPostSlug` → `hello-world`). This was masked only because no real reply data has landed yet (`_index.json` is `posts: {}`).
- `fetch-comments.mjs` — `getSlug()` now falls back to the parent directory name for `index.md`, mirroring `getPostSlug()`.
- `Comments.astro` — now uses `getPostSlug(post.id)` for the lookup key.

Verified in isolation: fetcher and renderer now both yield `hello-world` (was `index`); flat-layout posts still resolve correctly; `getReplyCount` returns 0 against the current empty index.

## What's still open on #238 (not code)

- **End-to-end verification** is blocked on real-world data: it needs a syndicated post to collect an actual Threads reply before `_index.json` / per-post JSON populate. Once that lands, the badge and renderer can be eyeballed against live data.

## Test notes

- `npm run build` could not be run in this environment: the JSR registry hosting `@codybrom/denim` (used only by `scripts/fetch-comments.mjs`, not the Astro build) is blocked by the network policy, so `npm ci` fails. CI (`ci.yml`) will run the authoritative build on this PR.
- Logic for `getSlug`, `getPostSlug` parity, and `getReplyCount` was unit-verified against real paths and the live `_index.json`.
- `node --check scripts/fetch-comments.mjs` passes.

Refs #238

https://claude.ai/code/session_015SnNuXv2TfvATe663dPD95

---
_Generated by [Claude Code](https://claude.ai/code/session_015SnNuXv2TfvATe663dPD95)_


___

## **CodeAnt-AI Description**
**Show Threads reply counts on post cards and keep comment slugs aligned**

### What Changed
- Post cards now show a reply count for posts syndicated to Threads, including singular and plural labels.
- Posts without Threads syndication do not show the reply count.
- Comment lookup now uses the same slug for bundled posts and generated comment files, so comments load for posts under `<slug>/index.md` instead of falling back to the wrong path.
- The comment fetcher now writes comment data under the correct slug for bundled posts, preventing posts from being mixed up under `index`.

### Impact
`✅ Clearer Threads engagement on post listings`
`✅ Replies shown for the correct post`
`✅ Fewer missing comment matches on bundled posts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show reply counts for posts syndicated to Threads in the post metadata area.

* **Bug Fixes**
  * Normalize bundled-post slugs to ensure comment counts and per-post comment files are found and associated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->