### PR TITLE
chore: exclude src/data from CodeRabbit + CodeAnt review

### DIFF
--- a/.codeant/configuration.json
+++ b/.codeant/configuration.json
@@ -1,0 +1,7 @@
+{
+  "file_filters": {
+    "config": {
+      "exclude_files": ["src/data/*"]
+    }
+  }
+}

--- a/.codeant/configuration.json
+++ b/.codeant/configuration.json
@@ -1,7 +1,7 @@
 {
   "file_filters": {
     "config": {
-      "exclude_files": ["src/data/*"]
+      "exclude_files": "src/data/*"
     }
   }
 }

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,8 @@
 reviews:
+  # Skip generated data files. Automated auto/* fetch PRs only ever touch
+  # src/data/*.json, so excluding this path keeps CodeRabbit silent on them.
+  path_filters:
+    - "!src/data/**"
   auto_review:
     ignore_usernames:
       - "github-actions[bot]"


### PR DESCRIPTION
## **User description**
## Summary

Automated `auto/*` data-fetch PRs (daily/threads) only ever change `src/data/*.json`. The two review bots were treating them as real PRs to review:

- **CodeAnt** (`codeant-ai`) commented on **every** auto PR — the actual noise.
- **CodeRabbit** was already silent (existing `ignore_usernames: github-actions[bot]`).

Neither bot supports filtering by **head/source branch** (`auto/*`) — only base-branch, author, title, label, or **file path**. Since auto PRs are 100% `src/data/` changes, excluding that path from review delivers the same outcome with a pure in-repo config (no dashboard changes).

## Changes

- **`.codeant/configuration.json`** (new): `file_filters.config.exclude_files: ["src/data/*"]` — CodeAnt now skips generated data files.
- **`.coderabbit.yaml`**: add `reviews.path_filters: ["!src/data/**"]` — makes CodeRabbit's exclusion explicit/path-based (kept the username ignore as belt-and-suspenders).

## Trade-off

`src/data/` changes in a *human* PR also won't be reviewed — acceptable, they're machine-generated fetch output.

## Test Plan

- [ ] Next `auto/update-*` PR receives **no** `codeant-ai` review comment
- [ ] CodeRabbit remains silent on auto PRs
- [ ] A normal PR touching non-data files still gets reviewed by both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated tooling configuration to exclude specific generated data files from file filtering.
  * Updated review configuration to ignore those same generated data files during review processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Stop review bots from commenting on generated data-only PRs**

### What Changed
- Generated `src/data` changes are now skipped by both review bots, so automated data fetch PRs no longer get review comments.
- The silence applies to the usual `auto/*` data update PRs without needing dashboard changes.
- Human PRs that touch these generated data files are also skipped by the bots.

### Impact
`✅ Fewer noisy review comments on automated data PRs`
`✅ Less manual cleanup for routine data updates`
`✅ Quieter PR inbox for generated-file changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
