### PR TITLE
fix: update syndicate workflow paths and fix slug extraction

### DIFF
--- a/.github/workflows/syndicate.yml
+++ b/.github/workflows/syndicate.yml
@@ -8,7 +8,7 @@
 #   THREADS_USER_ID       — Threads user ID (from developer portal)
 #   THREADS_ACCESS_TOKEN  — Long-lived Threads access token (refreshed by refresh-threads-token.yml)
 
-name: Syndicate Writing
+name: Syndicate Posts
 
 on:
   push:

--- a/.github/workflows/syndicate.yml
+++ b/.github/workflows/syndicate.yml
@@ -1,4 +1,4 @@
-# POSSE syndication workflow — cross-posts new writing to Bluesky, Mastodon, and Threads.
+# POSSE syndication workflow — cross-posts new posts to Bluesky, Mastodon, and Threads.
 #
 # Required repository secrets:
 #   BLUESKY_HANDLE        — Bluesky handle (e.g. gvns.ca)
@@ -14,7 +14,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "src/content/writing/**"
+      - "src/content/posts/**"
   workflow_dispatch:
 
 permissions:
@@ -53,7 +53,7 @@ jobs:
 
       - uses: ./.github/actions/commit-via-pr
         with:
-          paths: src/content/writing/
+          paths: src/content/posts/
           commit-message: "chore: update syndication data"
           branch-prefix: update-syndication
           github-token: ${{ secrets.GH_PAT }}

--- a/scripts/syndicate.mjs
+++ b/scripts/syndicate.mjs
@@ -59,9 +59,8 @@ function getTargetPlatforms(tags) {
   return ['bluesky', 'mastodon', 'threads'];
 }
 
-/** Get the slug from a markdown file path.
- *  Handles co-located index.md patterns: posts/2026/05/hello-world/index.md → "hello-world"
- *  Mirrors the logic in src/utils/content.ts getPostSlug(). */
+/** Get the slug from a filesystem path (conceptually mirrors getPostSlug in
+ *  src/utils/content.ts, but operates on file paths rather than Astro content IDs). */
 function getSlug(filePath) {
   const rel = relative(POSTS_DIR, filePath);
   const parts = rel.split(sep).filter(Boolean);

--- a/scripts/syndicate.mjs
+++ b/scripts/syndicate.mjs
@@ -17,7 +17,7 @@
  */
 
 import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
-import { join, basename, extname } from 'node:path';
+import { join, basename, extname, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
 import { BskyAgent, RichText } from '@atproto/api';
@@ -59,9 +59,14 @@ function getTargetPlatforms(tags) {
   return ['bluesky', 'mastodon', 'threads'];
 }
 
-/** Get the slug from a markdown file path. */
+/** Get the slug from a markdown file path.
+ *  Handles co-located index.md patterns: posts/2026/05/hello-world/index.md → "hello-world"
+ *  Mirrors the logic in src/utils/content.ts getPostSlug(). */
 function getSlug(filePath) {
-  return basename(filePath, '.md');
+  const rel = relative(POSTS_DIR, filePath);
+  const parts = rel.split(sep).filter(Boolean);
+  if (parts[parts.length - 1] === 'index.md') parts.pop();
+  return parts[parts.length - 1]?.replace(/\.md$/, '') ?? rel;
 }
 
 /** Prefer canonicalUrl from frontmatter when available and safe. */


### PR DESCRIPTION
## **User description**
## Summary

The `writing` → `posts` content collection rename (ad9a49c) updated the content directory, content config, page routes, and components — but missed the syndication workflow and script. This left three broken references:

- **Workflow never triggers**: `on.push.paths` watched `src/content/writing/**` (empty) instead of `src/content/posts/**`, so the workflow never fired on post pushes.
- **Syndication data never committed**: `commit-via-pr` staged `src/content/writing/` (empty), so frontmatter updates written to `src/content/posts/` were never committed.
- **Wrong URLs in syndicated posts**: `getSlug()` used `basename(filePath, ".md")` which returns `"index"` for co-located `index.md` files instead of the actual post slug (e.g. `"hello-world"`).

### Changes

| File | Change |
|------|--------|
| `scripts/syndicate.mjs` | Fixed `getSlug()` to handle co-located `index.md` pattern; added `relative`/`sep` imports |
| `.github/workflows/syndicate.yml:1` | Comment: `writing` → `posts` for clarity |
| `.github/workflows/syndicate.yml:17` | Trigger path: `src/content/writing/**` → `src/content/posts/**` |
| `.github/workflows/syndicate.yml:56` | commit-via-pr paths: `src/content/writing/` → `src/content/posts/` |
| `src/content/writing/` | Deleted (untracked, empty leftover from rename) |

### Secure-coding assessment

No security vulnerabilities found — the issues are functional bugs from the rename, not attack surface. Secrets are properly injected via `${{ secrets.* }}` env vars, permissions are minimal (`contents: write` + `pull-requests: write`), and the recursive-trigger guard checks `head_commit.message` prefix.

### Test plan

- [x] `npm run build` succeeds
- [x] `getSlug()` returns `hello-world`, `my-post`, `introducing-nfs-swiftbar` (not `index`) for co-located patterns
- [x] YAML syntax validated
- [ ] Manual `workflow_dispatch` run to verify the workflow triggers and commits correctly (requires secrets)


___

## **CodeAnt-AI Description**
Fix syndication for new posts and use the correct post slug

### What Changed
- Syndication now watches and commits changes in `src/content/posts/**`, so new post updates trigger the workflow and get saved
- Post links now use the actual article slug for nested `index.md` posts instead of showing `index`
- Updated the workflow comment to match the current `posts` content path

### Impact
`✅ New posts are syndicated automatically`
`✅ Fewer missed syndication updates`
`✅ Correct shared links for nested posts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * POSSE syndication now watches the posts content directory for changes.
* **Bug Fixes**
  * Improved post slug generation to correctly handle nested directory structures (e.g., year/month/post-slug and index-based posts), ensuring accurate syndicated URLs and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->