### PR TITLE
chore: drop hashtags + in-body URL from Threads syndication

### DIFF
--- a/scripts/syndicate.mjs
+++ b/scripts/syndicate.mjs
@@ -92,6 +92,13 @@ function formatPostText({ title, description, url, tags }) {
   return `📝 ${title}\n\n${description}\n\n${url}\n\n${hashtags}`;
 }
 
+/** Format post text for Threads. Threads omits hashtags (not idiomatic there)
+ *  and the in-body URL — Threads renders a native link-preview card from the
+ *  linkAttachment instead, so the URL would otherwise appear twice. */
+function formatThreadsText({ title, description }) {
+  return `📝 ${title}\n\n${description}`;
+}
+
 /** Check which platforms still need syndication for a post. */
 function getMissingSyndications(frontmatter, targetPlatforms) {
   const existing = (frontmatter.syndication || []).map((s) => s.platform);
@@ -153,8 +160,8 @@ async function postToMastodon({ title, description, url, tags }) {
   return status.url;
 }
 
-async function postToThreads({ title, description, url, tags }) {
-  const text = formatPostText({ title, description, url, tags });
+async function postToThreads({ title, description, url }) {
+  const text = formatThreadsText({ title, description });
 
   const containerId = await createThreadsContainer({
     userId: process.env.THREADS_USER_ID,
@@ -244,12 +251,17 @@ async function main() {
       try {
         if (DRY_RUN) {
           console.log(`   ✅ [DRY RUN] Would post to ${platform}`);
-          const previewText = formatPostText({
-            title: frontmatter.title,
-            description: frontmatter.description || '',
-            url,
-            tags,
-          });
+          const previewText = platform === 'threads'
+            ? formatThreadsText({
+                title: frontmatter.title,
+                description: frontmatter.description || '',
+              })
+            : formatPostText({
+                title: frontmatter.title,
+                description: frontmatter.description || '',
+                url,
+                tags,
+              });
           console.log(`   Preview:\n${previewText.split('\n').map((l) => `      ${l}`).join('\n')}`);
           continue;
         }
@@ -309,7 +321,6 @@ async function main() {
             title: frontmatter.title,
             description: frontmatter.description || '',
             url,
-            tags,
           });
           console.log(`   ✅ Threads: ${result.url}`);
           try {


### PR DESCRIPTION
## **User description**
## What

Threads syndication posts no longer include hashtags or the in-body URL.

- **Hashtags** aren't idiomatic on Threads — they just looked like noise.
- The **in-body URL was redundant**: Threads renders a native link-preview card from `linkAttachment`, so the link appeared twice.

## How

- Added a Threads-specific `formatThreadsText({ title, description })` that emits only the `📝 title` + description.
- `postToThreads` now uses it (the `linkAttachment` is untouched, so the link card still renders).
- `--dry-run` preview is now per-platform, so it accurately reflects each platform's output.
- **Bluesky and Mastodon are completely unchanged** — they keep hashtags and the URL (functional/clickable there).

## Verification

Ran `node scripts/syndicate.mjs --dry-run` against a throwaway scratch post:

- **Bluesky / Mastodon** preview: `📝 title` + description + URL + `#hashtags` ✓ (unchanged)
- **Threads** preview: `📝 title` + description only — no URL, no hashtags ✓

Scratch post deleted after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make Threads posts cleaner and match what users actually see**

### What Changed
- Threads posts now show only the title and description, without hashtags or the URL repeated in the message body
- The link still appears as a native preview card on Threads, so the post no longer shows the same link twice
- Dry-run previews now match each platform’s actual post format, so Threads preview output is different from Bluesky and Mastodon

### Impact
`✅ Cleaner Threads posts`
`✅ No duplicate link text on Threads`
`✅ More accurate dry-run previews`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Threads post formatting to optimize content display on the platform, focusing on core message delivery without additional metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->