### PR TITLE
fix(security): pin ws>=8.20.1 in sveltia-auth — clear moderate advisory

### DIFF
--- a/workers/sveltia-auth/package-lock.json
+++ b/workers/sveltia-auth/package-lock.json
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/workers/sveltia-auth/package.json
+++ b/workers/sveltia-auth/package.json
@@ -14,6 +14,7 @@
     "wrangler": "^4.0.0"
   },
   "overrides": {
+    "ws": "8.20.1",
     "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
## **User description**
## What
Mirror the existing root `ws: 8.20.1` override into the `workers/sveltia-auth` worker. `ws` was pulled transitively (`miniflare → wrangler`) at a vulnerable version (`8.0.0 – 8.20.0`); the root manifest already pins `8.20.1` but this worker's manifest did not.

## Why
Resolves **GHSA-58qx-3vcg-4xpx** (moderate) — `ws` uninitialized memory disclosure. Surfaced by `npm audit` in `workers/sveltia-auth` (follow-up to #710's esbuild burndown; not a Dependabot alert as it's dev-scoped).

## Verification
- `ws` now resolves to a single deduped **8.20.1** node in the lockfile
- `npm audit` → **0 vulnerabilities** (was 3 moderate)
- Diff scoped to 2 files; dev-tooling only — no worker runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Pin a vulnerable websocket dependency in the sveltia-auth worker

### What Changed
- The sveltia-auth worker now uses the fixed ws 8.20.1 release instead of a vulnerable 8.18.0 version
- This removes a moderate security advisory from the worker’s development dependencies and clears the audit finding

### Impact
`✅ Fewer security advisories in worker installs`
`✅ Safer local and build-time dependency resolution`
`✅ Clearer npm audit results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraint to ensure consistent version pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->