### PR TITLE
feat: truncate featured-card article to a ~160-word teaser (#720)

### DIFF
--- a/src/components/FeaturedPostCard.astro
+++ b/src/components/FeaturedPostCard.astro
@@ -1,7 +1,8 @@
 ---
-import { render, type CollectionEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import { Image } from 'astro:assets';
 import { getReadingTime } from '@utils/reading-time';
+import { getExcerpt } from '@utils/excerpt';
 import { getPostSlug } from '@utils/content';
 
 interface Props {
@@ -9,8 +10,8 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
 const { heroImage, heroImageAlt, heroFocus } = post.data;
+const excerpt = getExcerpt(post.body ?? '');
 
 const primaryTag = post.data.tags[0] ?? null;
 const isoDate = new Date(post.data.pubDate).toISOString().slice(0, 10);
@@ -49,8 +50,8 @@ const href = `/posts/${slug}/`;
       <a href={href}>{post.data.title}</a>
     </h2>
 
-    <div class="gvns-featured__body prose">
-      <Content />
+    <div class="gvns-featured__body">
+      <p class="gvns-featured__excerpt">{excerpt}</p>
     </div>
 
     <footer class="gvns-featured__footer">
@@ -145,7 +146,14 @@ const href = `/posts/${slug}/`;
   }
 
   .gvns-featured__body {
-    /* prose typography inherits from global .prose rules */
+    /* Plain-text teaser (first ~160 words), not the full rendered post. */
+  }
+
+  .gvns-featured__excerpt {
+    margin: 0;
+    color: var(--colour-text-secondary);
+    font-size: 1rem;
+    line-height: 1.7;
   }
 
   .gvns-featured__footer {

--- a/src/utils/excerpt.ts
+++ b/src/utils/excerpt.ts
@@ -14,12 +14,20 @@ const ELLIPSIS = '…';
  * text wholesale — fine for counting, wrong for readable prose).
  */
 export function getExcerpt(content: string, maxWords: number = DEFAULT_MAX_WORDS): string {
-  // Strip HTML tags iteratively to handle nested/crafted tags like <scr<script>ipt>.
+  // Clamp to a sane positive integer so a stray 0/negative/float caller can't
+  // break the "first N words" contract.
+  const limit = Number.isFinite(maxWords) ? Math.max(1, Math.floor(maxWords)) : DEFAULT_MAX_WORDS;
+
+  // Strip HTML comments and tags iteratively (handles nested/crafted tags like
+  // <scr<script>ipt>). Only real tags (<tag>, </tag>) are removed, so prose
+  // like "x < y > z" survives.
   let text = content;
   let previous: string;
   do {
     previous = text;
-    text = text.replace(/<[^>]*>/g, '');
+    text = text
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/<\/?[A-Za-z][^>]*>/g, '');
   } while (text !== previous);
 
   text = text
@@ -36,6 +44,6 @@ export function getExcerpt(content: string, maxWords: number = DEFAULT_MAX_WORDS
     .trim();
 
   const words = text.split(' ').filter(Boolean);
-  if (words.length <= maxWords) return words.join(' ');
-  return words.slice(0, maxWords).join(' ') + ELLIPSIS;
+  if (words.length <= limit) return words.join(' ');
+  return words.slice(0, limit).join(' ') + ELLIPSIS;
 }

--- a/src/utils/excerpt.ts
+++ b/src/utils/excerpt.ts
@@ -1,0 +1,41 @@
+const DEFAULT_MAX_WORDS = 160;
+const ELLIPSIS = '…';
+
+/**
+ * Build a plain-text teaser from raw markdown/MDX body content.
+ *
+ * Strips HTML and markdown syntax (keeping link/anchor text, dropping URLs,
+ * code, and images), collapses whitespace, and returns the first `maxWords`
+ * words. Appends an ellipsis only when the source was longer, so short posts
+ * render in full with no dangling "…".
+ *
+ * Used by the homepage featured card so it shows a teaser rather than the
+ * full post inline. Kept separate from `getReadingTime` (which drops link
+ * text wholesale — fine for counting, wrong for readable prose).
+ */
+export function getExcerpt(content: string, maxWords: number = DEFAULT_MAX_WORDS): string {
+  // Strip HTML tags iteratively to handle nested/crafted tags like <scr<script>ipt>.
+  let text = content;
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, '');
+  } while (text !== previous);
+
+  text = text
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images → drop entirely
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links → keep text, drop URL
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '') // ATX heading markers
+    .replace(/^\s*>\s?/gm, '') // blockquote markers
+    .replace(/^\s*[-+*]\s+/gm, '') // bullet list markers
+    .replace(/^\s*\d+\.\s+/gm, '') // ordered list markers
+    .replace(/[*_~]/g, '') // emphasis / strikethrough
+    .replace(/\s+/g, ' ') // collapse whitespace
+    .trim();
+
+  const words = text.split(' ').filter(Boolean);
+  if (words.length <= maxWords) return words.join(' ');
+  return words.slice(0, maxWords).join(' ') + ELLIPSIS;
+}

--- a/src/utils/excerpt.ts
+++ b/src/utils/excerpt.ts
@@ -26,8 +26,11 @@ export function getExcerpt(content: string, maxWords: number = DEFAULT_MAX_WORDS
   do {
     previous = text;
     text = text
-      .replace(/<!--[\s\S]*?-->/g, '')
-      .replace(/<\/?[A-Za-z][^>]*>/g, '');
+      // Comments — consume through `-->` OR end-of-string so an unterminated
+      // `<!--` can't survive (complete sanitization; clears CodeQL
+      // js/incomplete-multi-character-sanitization).
+      .replace(/<!--[\s\S]*?(?:-->|$)/g, ' ')
+      .replace(/<\/?[A-Za-z][^>]*>/g, ' ');
   } while (text !== previous);
 
   text = text


### PR DESCRIPTION
## **User description**
## Summary
- The homepage featured card rendered the **entire** post inline via `<Content />` (the current featured post is 319 words). Now it shows a **~160-word plain-text teaser** + the existing "Read full post →" link.
- New `src/utils/excerpt.ts` → `getExcerpt(body, maxWords=160)`: strips HTML/markdown, **keeps link text** (drops URLs), drops code/images, and only appends "…" when the post exceeds the limit. Kept separate from `getReadingTime` (which drops link text wholesale — fine for counting, wrong for readable prose).
- Builds on #716 (hero banner) — the hero, eyebrow, title, reading-time, and footer are untouched.

## Verification
- `npm run build` clean; rendered homepage teaser is **exactly 160 words + "…"**, "Read full post →" and the hero figure present.
- Unit-checked `getExcerpt`: short input → returned verbatim (no ellipsis); markdown link → text kept / URL dropped; code blocks & images stripped; 300-word input → 160 words + ellipsis.

## Test Plan
- [ ] Featured card shows ≤ ~160 words with a clean cut + read-more (preview / prod).
- [ ] A post shorter than 160 words renders fully with no dangling ellipsis.

Closes #720


___

## **CodeAnt-AI Description**
**Show a short teaser instead of the full featured post on the homepage**

### What Changed
- The featured article card now shows a plain-text teaser of about 160 words instead of rendering the full post inline
- Teasers keep readable link text, remove URLs and code, and end with an ellipsis only when the post is longer than the limit
- Short posts display in full without a trailing ellipsis, while the existing “Read full post →” link remains available

### Impact
`✅ Shorter homepage featured posts`
`✅ Cleaner article previews`
`✅ Less scrolling on the homepage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Featured posts now display a plain-text excerpt instead of the full article body.
  * Excerpts are automatically generated from the post content, omitting non-text elements like code and images, and truncating to a readable word limit with an ellipsis when needed.
* **Style**
  * Updated featured post card markup and CSS to present the excerpt in a dedicated paragraph with improved spacing, color, font sizing, and line-height.
  * Featured typography no longer depends on global prose styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->