### PR TITLE
chore: render images on preview deploys via passthrough on non-main builds (#717)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,9 +29,10 @@ try {
 // production `gvns.ca` zone, so the unpic service's transform URLs 404 on preview hosts
 // and optimised images appear broken there (issue #717).
 //
-// `WORKERS_CI_BRANCH` is injected by Workers Builds. Treat a missing/unknown value as
-// production so prod can never silently lose Image Transformations — only a positively
-// identified non-`main` branch is treated as a preview.
+// `WORKERS_CI_BRANCH` is injected by Workers Builds. A missing value (local builds, or
+// if Workers Builds ever stops injecting it) falls back to production so prod can never
+// silently lose Image Transformations; only a positively identified non-`main` branch is
+// treated as a preview.
 const ciBranch = process.env.WORKERS_CI_BRANCH;
 const isProduction = !ciBranch || ciBranch === "main";
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,26 +23,45 @@ try {
   console.warn("Failed to load shiki-gvns.json, falling back to default theme:", error);
 }
 
+// Production deploys run only on the `main` branch via Cloudflare Workers Builds;
+// every other branch produces a versioned `*.workers.dev` preview (docs/INFRASTRUCTURE.md).
+// Cloudflare Image Transformations (`/cdn-cgi/image/...`) are only served on the
+// production `gvns.ca` zone, so the unpic service's transform URLs 404 on preview hosts
+// and optimised images appear broken there (issue #717).
+//
+// `WORKERS_CI_BRANCH` is injected by Workers Builds. Treat a missing/unknown value as
+// production so prod can never silently lose Image Transformations — only a positively
+// identified non-`main` branch is treated as a preview.
+const ciBranch = process.env.WORKERS_CI_BRANCH;
+const isProduction = !ciBranch || ciBranch === "main";
+
 export default defineConfig({
   site: "https://gvns.ca",
   output: "server",
   adapter: cloudflare({
-    // "custom" tells the Cloudflare adapter to leave `image.service` alone
-    // so the unpic service configured below stays in place (the adapter
-    // would otherwise override it with one of its built-in services).
-    imageService: "custom",
+    // Production keeps the unpic service (configured under `image` below) via "custom".
+    // Previews use "passthrough": Astro emits `/_image?href=/_astro/<asset>` URLs served
+    // by the adapter's passthrough endpoint, which streams the original asset from the
+    // ASSETS binding (HTTP 200) on `*.workers.dev` — no `/cdn-cgi/` zone dependency, where
+    // `/cdn-cgi/image/` transforms would 404 (issue #717).
+    imageService: isProduction ? "custom" : "passthrough",
   }),
-  // Render-time image optimisation:
-  // - Bundled post heroes (Astro `image()` ESM imports) get URL-based transforms via
-  //   Cloudflare Image Transformations (`/cdn-cgi/image/...`) at the edge.
+  // Render-time image optimisation (production only):
+  // - Bundled post heroes (Astro `image()` ESM imports) and markdown images get URL-based
+  //   transforms via Cloudflare Image Transformations (`/cdn-cgi/image/...`) at the edge.
   // - Local/static srcs fall back to Cloudflare.
+  // On previews this block is omitted, leaving the adapter's `passthrough` service in place.
   // See docs/CMS-SETUP.md and docs/DECISIONS.md (ADR-018) for context.
-  image: {
-    service: imageService({
-      fallbackService: "cloudflare",
-      layout: "constrained",
-    }),
-  },
+  ...(isProduction
+    ? {
+        image: {
+          service: imageService({
+            fallbackService: "cloudflare",
+            layout: "constrained",
+          }),
+        },
+      }
+    : {}),
   markdown: {
     shikiConfig: {
       theme: shikiTheme,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -569,6 +569,15 @@ Wire `@unpic/astro` as Astro's image service with `fallbackService: "cloudflare"
 - Installed with `--legacy-peer-deps` because `@unpic/astro@1.0.2` declares `astro@^2 || ^3 || ^4 || ^5.0.0-beta` as its peer range; Astro 6 isn't listed yet but the runtime API used (`getURL`/`getHTMLAttributes`) is unchanged. Track upstream and drop the flag once 6 lands in the peer range.
 - Absolute-fill `<Image>` consumers (e.g. `class="size-full object-cover"` inside an aspect-ratio container) need `layout="fullWidth"` to skip unpic's inline `aspect-ratio` injection — otherwise the image renders at its intrinsic ratio and fights the parent. Current state: `src/components/HorizontalPostCard.astro` (homepage post cards) sets `layout="fullWidth"` for this reason. `src/components/starwind-pro/feature-13/Feature13.astro` would also be affected but is vendor reference material that the project doesn't import. When adding new `<Image>` usages, grep `rg 'size-full|inset-0' src/**/*.astro` against `astro:assets` imports to catch absolute-fill cases.
 
+### Update (#717): preview deploys fall back to `passthrough`
+
+`/cdn-cgi/image/` transforms are only served on the production `gvns.ca` zone, so on `*.workers.dev` PR/branch previews every unpic transform URL returns **404** and optimised images appear broken — image work can't be visually QA'd on the preview URL. As of #717, `astro.config.mjs` gates the image service on the build branch:
+
+- **Production** (`WORKERS_CI_BRANCH === "main"`, or the var absent — fail-safe so prod never silently loses transforms): unchanged — adapter `imageService: "custom"` + the unpic service. Markup still emits `/cdn-cgi/image/...`.
+- **Previews** (any other branch on Workers Builds): adapter `imageService: "passthrough"` and the `image.service` block is omitted. Astro emits `/_image?href=/_astro/<asset>` URLs served by the adapter's passthrough endpoint (`@astrojs/cloudflare/image-passthrough-endpoint`), which streams the original asset from the `ASSETS` binding with HTTP 200 — no `/cdn-cgi/` zone dependency. Images render unoptimised but visible.
+
+Production output/markup is untouched; only non-`main` builds diverge.
+
 ---
 
 ## ADR-019: Swap Footer 9 → Starwind Pro Footer 1 (Socials)


### PR DESCRIPTION
## Summary

Optimised images (post heroes, markdown images) 404 on `*.workers.dev` PR/branch previews because Cloudflare Image Transformations (`/cdn-cgi/image/...`) are only served on the production `gvns.ca` zone. This gates the image service on the Workers Builds branch so previews render images while production is untouched.

- **Production** (`WORKERS_CI_BRANCH === "main"`, or the var absent — fail-safe so prod can never silently lose transforms): unchanged — adapter `imageService: "custom"` + the unpic service; markup still emits `/cdn-cgi/image/...`.
- **Previews** (any other branch): adapter `imageService: "passthrough"` and the `image.service` block is omitted. Astro emits `/_image?href=/_astro/<asset>` URLs served by `@astrojs/cloudflare`'s passthrough endpoint, which streams the original asset from the `ASSETS` binding (HTTP 200) — **no `/cdn-cgi/` zone dependency**. Images render unoptimised but visible.

`docs/DECISIONS.md` (ADR-018) updated with the preview fallback.

### Why `passthrough` and not `compile`

Goal is "can I *see* the image on preview" for QA, not byte-optimisation. Passthrough has no sharp dependency and the smallest diff; the issue already confirmed raw `/_astro/*` returns 200.

## Verification (local)

- **main-mode build** (`npm run build`): **41** `/cdn-cgi/image/` transform URLs across post pages + homepage — production output unchanged.
- **branch-mode build** (`WORKERS_CI_BRANCH=… npm run build`): **0** `/cdn-cgi/image/`; the post hero routes through `/_image?href=/_astro/…` (served by the worker passthrough endpoint, present in `dist/server/`).

## Test Plan

- [ ] Open this PR → confirm a post-hero image loads (HTTP 200) on the Workers Builds preview URL.
- [ ] Confirm production (gvns.ca) still serves `/cdn-cgi/image/` transforms after merge.

## Acceptance Criteria

- [x] Hero/optimized images render (HTTP 200) on `*.workers.dev` previews — via `/_image` passthrough (verify on preview URL).
- [x] Production continues to use Cloudflare Image Transformations (`/cdn-cgi/image/`) — verified: 41 URLs retained in main-mode build.
- [x] No change to production image output/markup — production branch of the conditional is behaviourally identical to the prior config.

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling for preview deployments by adjusting image transformation behavior in non-production environments, preventing preview image errors and ensuring images display correctly.
  * Production deployments continue to use the optimized Cloudflare image transformation behavior as before, with environment-aware configuration.

* **Documentation**
  * Updated architectural decision notes to clarify the preview-vs-production behavior for Cloudflare image transformation URLs and why non-production builds render unoptimized but visible images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->