### PR TITLE
chore(ci): disable Whoop daily fetch (device retired)

### DIFF
--- a/.github/workflows/fetch-daily.yml
+++ b/.github/workflows/fetch-daily.yml
@@ -73,20 +73,6 @@ jobs:
           tmdb_api_key: ${{ secrets.TMDB_API_KEY }}
           output_path: src/data/watching.json
 
-      - id: whoop
-        name: Fetch Whoop data
-        continue-on-error: true
-        env:
-          WHOOP_CLIENT_ID: ${{ secrets.WHOOP_CLIENT_ID }}
-          WHOOP_CLIENT_SECRET: ${{ secrets.WHOOP_CLIENT_SECRET }}
-          WHOOP_REFRESH_TOKEN: ${{ secrets.WHOOP_REFRESH_TOKEN }}
-          # GH_PAT (fine-grained, repo Secrets: read/write) is required so
-          # the script can persist rotated refresh + access tokens back to
-          # secrets — see scripts/fetch-whoop.mjs preamble (§4.4 of the spec).
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: node scripts/fetch-whoop.mjs
-
       - name: Commit and open PR
         if: always()
         uses: ./.github/actions/commit-via-pr
@@ -105,7 +91,6 @@ jobs:
             [listening]="${{ steps.listening.outcome }}"
             [reading]="${{ steps.reading.outcome }}"
             [watching]="${{ steps.watching.outcome }}"
-            [whoop]="${{ steps.whoop.outcome }}"
           )
           {
             echo "### Fetch outcomes"


### PR DESCRIPTION
## **User description**
## What

Disables only the Whoop fetch in the `Fetch Daily` workflow.

## Why

The owner retired their Whoop device. The Whoop fetch therefore failed on every scheduled run, which marked the entire `Fetch Daily` workflow red even though all other fetchers (Steam, GitHub, ListenBrainz, Hardcover, Trakt) succeeded.

## Changes

- Removed the `whoop` fetch step (`node scripts/fetch-whoop.mjs`, including its `env` block and token-persistence comments).
- Removed the `[whoop]` entry from the `outcomes` associative array in the "Fail run if any fetcher failed" gate.

## Scope

Intentionally minimal. The fetch script (`scripts/fetch-whoop.mjs`), bootstrap script, data file (`src/data/whoop.json`), site widgets, docs, and the PAT-verification workflow are all left in place so the integration can be revived easily if the device returns.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML valid
- `grep -i whoop .github/workflows/fetch-daily.yml` → no matches
- `actionlint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgfdqxHNqEFHur25Q1J5dw


___

## **CodeAnt-AI Description**
**Stop the daily fetch workflow from failing because of the retired Whoop device**

### What Changed
- Removed the Whoop fetch from the daily data workflow, so the run no longer depends on a device that is no longer in use
- The workflow still checks the remaining fetches and reports failures for those jobs as before
- The Whoop integration files and data remain in place for possible future reuse

### Impact
`✅ Fewer false CI failures`
`✅ Cleaner daily workflow runs`
`✅ No lost Whoop integration data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
