### PR TITLE
fix(deps): patch ws, undici, vite, js-yaml security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3732,9 +3732,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4163,9 +4163,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6713,9 +6723,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -7073,12 +7083,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -7362,16 +7372,6 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/wrangler/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/wrangler/node_modules/workerd": {
       "version": "1.20260623.1",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260623.1.tgz",
@@ -7394,9 +7394,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "ws": "8.20.1",
+    "ws": "8.21.0",
+    "undici": "^7.28.0",
     "esbuild": "^0.28.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## **User description**
## What

Bumps four vulnerable root dependencies to patched versions to clear the open **Dependabot + Trivy** advisories on the root `package-lock.json`. Only `package.json` and `package-lock.json` are touched; the existing `esbuild` override is left intact. `astro` stays on `^6` (no major upgrade).

| Package | Before | After | Mechanism | Advisory range cleared |
|---|---|---|---|---|
| **ws** | 8.20.1 | **8.21.0** | bump existing override | `>= 8.0.0, < 8.21.0` (HIGH) |
| **undici** | 7.24.8 | **7.28.0** | new `^7.28.0` override | `>= 7.0.0, < 7.28.0` (HIGH/MOD/LOW ×7) |
| **vite** | 7.3.2 | **7.3.6** | `npm update` (within `^7.3.2`) | `>= 7.0.0, <= 7.3.4` (HIGH + MOD) |
| **js-yaml** (direct) | 4.1.1 | **4.3.0** | `npm update` (within `^4.1.1`) | `<= 4.1.1` — GHSA-h67p-54hq-rp68 (MOD) |

The previous `ws` override was actively **pinning** a vulnerable version. The `undici` override is required because `@astrojs/cloudflare`'s `miniflare` pins undici exactly (`7.24.8`); the override forces the patched version and dedupes both miniflare instances onto a single `undici@7.28.0`.

## Alerts this clears (root `package-lock.json` manifest)

- ws `< 8.21.0` (1 alert)
- vite `<= 7.3.4` (2 alerts: HIGH + MODERATE)
- undici `< 7.28.0` (7 alerts on the root manifest)
- js-yaml `<= 4.1.1` — **direct** dependency (astro / @astrojs/internal-helpers) upgraded to 4.3.0

> The `undici < 6.27.0` alerts under `.github/actions/fetch-*/package-lock.json` are **separate manifests** and intentionally out of scope for this PR.

## ⚠️ Known residual (js-yaml via gray-matter)

`gray-matter@4.0.3` (the latest release) transitively pins `js-yaml ^3.13.1` and is **incompatible with js-yaml 4.x** — it calls the `safeLoad`/`safeDump` API that was removed in js-yaml 4.0. GHSA-h67p-54hq-rp68 has **no patched 3.x release** (only `4.2.0`+), so the gray-matter-transitive js-yaml (now `3.15.0`, the newest available 3.x) remains within the vulnerable range. Forcing js-yaml 4.x onto gray-matter crashes `scripts/validate-image-refs.mjs` (the `prebuild` step), so it cannot be cleared here without breaking the build or replacing gray-matter — both out of scope. **Recommend a follow-up** to migrate off / patch gray-matter. The single js-yaml Dependabot alert may therefore stay open until that follow-up lands.

## Verification

```
$ npm why ws       -> ws@8.21.0 overridden
$ npm why undici   -> undici@7.28.0
$ npm why vite     -> vite@7.3.6
$ npm why js-yaml  -> js-yaml@4.3.0 (direct)
                      js-yaml@3.15.0 (gray-matter, residual — see above)

$ npm run build
> gvns-ca@0.0.1 prebuild
> node scripts/validate-image-refs.mjs
validate-image-refs: 5 files scanned, all refs resolved
...
[build] Server built in 6.48s
[build] Complete!
# exit code 0
```

Lockfile diff is minimal (26 insertions / 26 deletions): only the four target packages + an undici dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgfdqxHNqEFHur25Q1J5dw


___

## **CodeAnt-AI Description**
Patch vulnerable root dependencies to remove known security alerts

### What Changed
- Updated root dependency overrides so the app uses patched versions of `ws`, `undici`, `vite`, and `js-yaml`
- Kept the existing build setup intact while replacing versions that were flagged by security scans
- Left the `gray-matter` transitive `js-yaml` dependency unchanged because it cannot move to the fixed 4.x line without breaking the build

### Impact
`✅ Fewer security alerts`
`✅ Safer dependency updates`
`✅ Lower exposure to known package vulnerabilities`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled network library dependency to a newer version.
  * Added a dependency override to keep a related HTTP client package on a compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->